### PR TITLE
Allow dead code to prevent warnings when using within rustc.

### DIFF
--- a/bsan-shared/src/lib.rs
+++ b/bsan-shared/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), no_std)]
+#![allow(dead_code)]
 mod foreign_access_skipping;
 mod helpers;
 mod perms;


### PR DESCRIPTION
When we use `bsan-shared` as a dependency in [`rustc`](https://github.com/BorrowSanitizer/rust), we want to allow temporarily unused features until our port of Tree Borrows is stable.