### PR TITLE
task(#16): Modified `xb` to add testing for bsan-shared

### DIFF
--- a/bsan-rt/src/borrow_tracker/unimap.rs
+++ b/bsan-rt/src/borrow_tracker/unimap.rs
@@ -248,6 +248,7 @@ impl<'a, V> UniEntry<'a, V> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use core::fmt::Debug;
 

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -107,6 +107,7 @@ pub enum Component {
     CargoBsan,
     BsanRuntime,
     BsanLLVMPass,
+    BsanShared,
 }
 
 #[macro_export]
@@ -117,6 +118,7 @@ macro_rules! all_components {
             Component::CargoBsan,
             Component::BsanRuntime,
             Component::BsanLLVMPass,
+            Component::BsanShared,
         ]
     };
 }
@@ -130,6 +132,7 @@ impl Deref for Component {
             Component::CargoBsan => &CargoBsan,
             Component::BsanRuntime => &BsanRuntime,
             Component::BsanLLVMPass => &BsanLLVMPlugin,
+            Component::BsanShared => &BsanShared,
         }
     }
 }
@@ -191,6 +194,7 @@ macro_rules! impl_component {
 
 impl_component!(BsanDriver, "bsan-driver");
 impl_component!(CargoBsan, "cargo-bsan");
+impl_component!(BsanShared, "bsan-shared");
 
 static RT_FLAGS: &[&str] =
     &["-Cpanic=abort", "-Zpanic_abort_tests", "-Cembed-bitcode=yes", "-Clto"];


### PR DESCRIPTION
## Notes

Added `bsan-shared` as a component and added functionality to run tests via macro `impl_component!`

Added testing decorator to `unimap.rs` (in `bsan-rt`)

Closes #16 