### PR TITLE
Added `From<SpanData>` impl for `Span` and ensured that `bsan-shared` is tested in CI.

### DIFF
--- a/bsan-script/src/env.rs
+++ b/bsan-script/src/env.rs
@@ -8,6 +8,7 @@ use rustc_version::VersionMeta;
 use serde::Deserialize;
 use xshell::{cmd, Cmd, Shell};
 
+use crate::commands::Buildable;
 use crate::utils::show_error;
 use crate::{download, utils};
 
@@ -283,6 +284,11 @@ impl BsanEnv {
         }
         cmd.run()?;
         Ok(())
+    }
+
+    pub fn build_artifact(&mut self, b: impl Buildable, args: &[String]) -> Result<PathBuf> {
+        b.build(self, args)?;
+        Ok(self.assert_artifact(b.artifact()))
     }
 
     pub fn cc_cmd(&self) -> Cmd<'_> {


### PR DESCRIPTION
Fixes a failing clippy lint for `Span` and allows for `Buildable` implementations that do not produce artifacts by changing `Buildable::build` to return `Result<()>` instead of `Result<PathBuf>`. To ensure that an artifact is built, you should now use `BsanEnv::build_artifact`. 