### PR TITLE
porting bsan_malloc from rust repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ dependencies = [
  "hashbrown",
  "libc",
  "libc-print",
+ "log",
  "rustc-hash",
  "smallvec",
 ]

--- a/bsan-rt/Cargo.toml
+++ b/bsan-rt/Cargo.toml
@@ -13,6 +13,7 @@ rustc-hash = { version = "2.1.1", default-features = false }
 smallvec = { version = "1.14.0" }
 libc-print = { version = "0.1.23" }
 bsan-shared = { path = "../bsan-shared" }
+log = "0.4"
 
 [lib]
 name = "bsan_rt"

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -33,6 +33,7 @@ pub struct GlobalCtx {
     hooks: BsanHooks,
     next_alloc_id: AtomicUsize,
     next_thread_id: AtomicUsize,
+    alloc_metadata_map: BlockAllocator<AllocMetadata>,
     shadow_heap: ShadowHeap<Provenance>,
 }
 
@@ -43,10 +44,17 @@ impl GlobalCtx {
     /// Creates a new instance of `GlobalCtx` using the given `BsanHooks`.
     /// This function will also initialize our shadow heap
     fn new(hooks: BsanHooks) -> Self {
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+        let alloc_metadata_size = mem::size_of::<AllocMetadata>();
+        debug_assert!(0 < alloc_metadata_size && alloc_metadata_size <= page_size);
+        //let num_elements = NonZeroUsize::new(page_size / mem::size_of::<AllocMetadata>()).unwrap();
+        let num_elements = NonZeroUsize::new(1024).unwrap();
+        let block = Self::generate_block(hooks.mmap, hooks.munmap, num_elements);
         Self {
             hooks,
             next_alloc_id: AtomicUsize::new(AllocId::min().get()),
             next_thread_id: AtomicUsize::new(0),
+            alloc_metadata_map: BlockAllocator::new(block),
             shadow_heap: ShadowHeap::new(&hooks),
         }
     }
@@ -59,18 +67,23 @@ impl GlobalCtx {
         &self.hooks
     }
 
-    pub fn new_block<T>(&self, num_elements: NonZeroUsize) -> Block<T> {
+    pub(crate) unsafe fn allocate_lock_location(&self) -> NonNull<MaybeUninit<AllocMetadata>> {
+        match self.alloc_metadata_map.alloc() {
+            Some(a) => a,
+            None => {
+                log::error!("Failed to allocate lock location");
+                panic!("Failed to allocate lock location");
+            }
+        }
+    }
+
+    fn generate_block<T>(mmap: MMap, munmap: MUnmap, num_elements: NonZeroUsize) -> Block<T> {
         let layout = Layout::array::<T>(num_elements.into()).unwrap();
-        let size = NonZeroUsize::new(layout.size()).unwrap();
+        let size: NonZero<usize> = NonZeroUsize::new(layout.size()).unwrap();
+
+        debug_assert!(mmap as usize != 0);
         let base = unsafe {
-            (self.hooks.mmap)(
-                ptr::null_mut(),
-                layout.size(),
-                BSAN_MMAP_PROT,
-                BSAN_MMAP_FLAGS,
-                -1,
-                0,
-            )
+            (mmap)(ptr::null_mut(), layout.size(), BSAN_MMAP_PROT, BSAN_MMAP_FLAGS, -1, 0)
         };
 
         if base.is_null() {
@@ -78,11 +91,15 @@ impl GlobalCtx {
         }
         let base = unsafe { mem::transmute::<*mut c_void, *mut T>(base) };
         let base = unsafe { NonNull::new_unchecked(base) };
-        let munmap = self.hooks.munmap;
-        Block { size, base, munmap }
+
+        Block { num_elements, base, munmap }
     }
 
-    fn allocator(&self) -> BsanAllocHooks {
+    pub fn new_block<T>(&self, num_elements: NonZeroUsize) -> Block<T> {
+        Self::generate_block(self.hooks.mmap, self.hooks.munmap, num_elements)
+    }
+
+    pub fn allocator(&self) -> BsanAllocHooks {
         self.hooks.alloc
     }
 

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -347,10 +347,10 @@ extern "C" fn __bsan_pop_frame() {}
 ///  been called to initialize the global context, esp. the allocator and mmap hooks.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn __bsan_alloc(
-    span: Span,
-    prov: *mut MaybeUninit<Provenance>,
     object_address: *const c_void,
     alloc_size: usize,
+    prov: *mut MaybeUninit<Provenance>,
+    span: Span,
 ) {
     debug_assert!(!prov.is_null());
     let ctx = unsafe { global_ctx() };
@@ -442,7 +442,7 @@ mod test {
         let mut prov = MaybeUninit::<Provenance>::uninit();
         let prov_ptr = (&mut prov) as *mut _;
         unsafe {
-            __bsan_alloc(Span::new(), prov_ptr, 0xaaaaaaaa as *const c_void, 10);
+            __bsan_alloc(0xaaaaaaaa as *const c_void, 10, prov_ptr, Span::new());
             prov.assume_init()
         }
     }

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -9,6 +9,7 @@
 
 #[macro_use]
 extern crate alloc;
+use alloc::boxed::Box;
 use core::alloc::{AllocError, Allocator, GlobalAlloc, Layout};
 use core::cell::UnsafeCell;
 use core::ffi::{c_char, c_ulonglong, c_void};
@@ -34,6 +35,14 @@ mod diagnostics;
 mod shadow;
 mod span;
 
+use block::{BlockAllocator, Linkable};
+mod tree_borrows;
+use log::debug;
+use tree_borrows::tree_borrows_wrapper as TreeBorrows;
+
+use crate::span::Span;
+use crate::ui_test;
+
 macro_rules! println {
     ($($arg:tt)*) => {
         libc_print::std_name::println!($($arg)*);
@@ -41,50 +50,50 @@ macro_rules! println {
 }
 pub(crate) use println;
 
-pub type MMap = unsafe extern "C" fn(*mut c_void, usize, i32, i32, i32, off_t) -> *mut c_void;
-pub type MUnmap = unsafe extern "C" fn(*mut c_void, usize) -> i32;
-pub type Malloc = unsafe extern "C" fn(usize) -> *mut c_void;
-pub type Free = unsafe extern "C" fn(*mut c_void);
-pub type Exit = unsafe extern "C" fn() -> !;
+static ALLOC_COUNTER: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct BsanHooks {
-    alloc: BsanAllocHooks,
-    mmap: MMap,
-    munmap: MUnmap,
-    exit: Exit,
+union FreeListAddrUnion {
+    free_list_next: *mut AllocMetadata,
+    base_addr: *const c_void,
 }
 
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-pub struct BsanAllocHooks {
-    malloc: Malloc,
-    free: Free,
+impl core::fmt::Debug for FreeListAddrUnion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        unsafe { write!(f, "{:?}", self.base_addr) }
+    }
 }
 
-unsafe impl Allocator for BsanAllocHooks {
-    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
-        unsafe {
-            match layout.size() {
-                0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
-                size => {
-                    let ptr = (self.malloc)(layout.size());
-                    if ptr.is_null() {
-                        return Err(AllocError);
-                    }
-                    let ptr = NonNull::new_unchecked(ptr as *mut u8);
-                    Ok(NonNull::slice_from_raw_parts(ptr, size))
-                }
-            }
-        }
+/// This is the metadata stored with each allocation
+#[derive(Debug)]
+pub struct AllocMetadata {
+    alloc_id: AllocId,
+    base_addr: FreeListAddrUnion,
+    // TODO(obraunsdorf) making tree_address a Box is benefitial internal memory-safety of our bsanrt library
+    // however, a Box with a non-zero-sized allocator takes up more space than just a raw pointer.
+    // We should consider making this a raw pointer or storing malloc/free pointers in a lazily initialized
+    // global variable (maybe using OnceCell/OnceLock),
+    // such that we can make BsanAllocHooks a zero-sized allocator that just uses the global malloc/free.
+    tree_address: Box<TreeBorrows::Tree, BsanAllocHooks>,
+}
+
+unsafe impl Linkable<AllocMetadata> for AllocMetadata {
+    fn next(&mut self) -> *mut *mut AllocMetadata {
+        // we are re-using the space of base_addr to store the free list pointer
+        // SAFETY: this is safe because both union fields are raw pointers
+        unsafe { core::ptr::addr_of_mut!(self.base_addr.free_list_next) }
+    }
+}
+
+impl AllocMetadata {
+    fn base_addr(&self) -> *const c_void {
+        // SAFETY: this is safe because both union fields are raw pointers
+        unsafe { self.base_addr.base_addr }
     }
 
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
-        unsafe {
-            let ptr = mem::transmute::<*mut u8, *mut libc::c_void>(ptr.as_ptr());
-            (self.free)(ptr);
-        }
+    fn dealloc(&mut self, borrow_tag: TreeBorrows::BorrowTag) {
+        self.alloc_id = AllocId::invalid();
+        self.tree_address.deallocate(self.base_addr(), borrow_tag);
+        //TODO(obraunsdorf) free the allocation of the tree itself
     }
 }
 
@@ -101,7 +110,7 @@ impl AllocId {
         self.0
     }
     /// An invalid allocation
-    pub const fn null() -> Self {
+    pub const fn invalid() -> Self {
         AllocId(0)
     }
 
@@ -168,11 +177,11 @@ impl fmt::Debug for BorTag {
 /// and a borrow tag. We also include a pointer to the "lock" location for the allocation,
 /// which contains all other metadata used to detect undefined behavior.
 #[repr(C)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct Provenance {
     pub alloc_id: AllocId,
-    pub bor_tag: BorTag,
-    pub alloc_info: *mut c_void,
+    pub borrow_tag: TreeBorrows::BorrowTag,
+    pub lock_address: *const AllocMetadata,
 }
 
 impl Default for Provenance {
@@ -185,47 +194,63 @@ impl Provenance {
     /// The default provenance value, which is assigned to dangling or invalid
     /// pointers.
     const fn null() -> Self {
-        Provenance {
-            alloc_id: AllocId::null(),
-            bor_tag: BorTag::new(0),
-            alloc_info: core::ptr::null_mut(),
-        }
+        Provenance { alloc_id: AllocId::invalid(), borrow_tag: 0, lock_address: ptr::null() }
     }
 
     /// Pointers cast from integers receive a "wildcard" provenance value, which permits
     /// any access.
     const fn wildcard() -> Self {
-        Provenance {
-            alloc_id: AllocId::wildcard(),
-            bor_tag: BorTag::new(0),
-            alloc_info: core::ptr::null_mut(),
-        }
+        Provenance { alloc_id: AllocId::wildcard(), borrow_tag: 0, lock_address: ptr::null() }
     }
 }
 
-/// Every allocation is associated with a "lock" object, which is an instance of `AllocInfo`.
-/// Provenance is the "key" to this lock. To validate a memory access, we compare the allocation ID
-/// of a pointer's provenance with the value stored in its corresponding `AllocInfo` object. If the values
-/// do not match, then the access is invalid. If they do match, then we proceed to validate the access against
-/// the tree for the allocation.
+//#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+pub type MMap = unsafe extern "C" fn(*mut c_void, usize, i32, i32, i32, i64) -> *mut c_void;
+//#[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
+//pub type MMap = unsafe extern "C" fn(*mut c_void, usize, i32, i32, i32, c_ulonglong) -> *mut c_void;
+pub type MUnmap = unsafe extern "C" fn(*mut c_void, usize) -> i32;
+pub type Malloc = unsafe extern "C" fn(usize) -> *mut c_void;
+pub type Free = unsafe extern "C" fn(*mut c_void);
+pub type Exit = unsafe extern "C" fn() -> !;
+
 #[repr(C)]
-struct AllocInfo {
-    pub alloc_id: AllocId,
-    pub base_addr: usize,
-    pub size: usize,
-    pub align: usize,
-    pub tree: *mut c_void,
+#[derive(Debug, Copy, Clone)]
+pub struct BsanHooks {
+    alloc: BsanAllocHooks,
+    mmap: MMap,
+    munmap: MUnmap,
+    exit: Exit,
 }
 
-impl AllocInfo {
-    /// When we deallocate an allocation, we need to invalidate its metadata.
-    /// so that any uses-after-free are detectable.
-    fn dealloc(&mut self) {
-        self.alloc_id = AllocId::null();
-        self.base_addr = 0;
-        self.size = 0;
-        self.align = 1;
-        // FIXME: free the tree
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct BsanAllocHooks {
+    malloc: Malloc,
+    free: Free,
+}
+
+unsafe impl Allocator for BsanAllocHooks {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        unsafe {
+            match layout.size() {
+                0 => Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0)),
+                size => {
+                    let ptr = (self.malloc)(layout.size());
+                    if ptr.is_null() {
+                        return Err(AllocError);
+                    }
+                    let ptr = NonNull::new_unchecked(ptr as *mut u8);
+                    Ok(NonNull::slice_from_raw_parts(ptr, size))
+                }
+            }
+        }
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, _layout: Layout) {
+        unsafe {
+            let ptr = mem::transmute::<*mut u8, *mut libc::c_void>(ptr.as_ptr());
+            (self.free)(ptr);
+        }
     }
 }
 
@@ -312,27 +337,80 @@ extern "C" fn __bsan_push_frame() {}
 #[unsafe(no_mangle)]
 extern "C" fn __bsan_pop_frame() {}
 
-// Registers a heap allocation of size `size`
+/// Creates metadata for a heap allocation of the application.
+/// (out:) `prov` is a pointer for returning the provenance (pointer metadata) for this allocation.
+/// `span` is a ID to trace back to the source code location of the allocation
+/// `object_address` is the address of the allocated object
+/// `alloc_size` is the size of the allocated object
+/// # Safety
+///  The caller must ensure that `bsan_aalloc()` is only called after `bsan_init()` has
+///  been called to initialize the global context, esp. the allocator and mmap hooks.
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_alloc(prov: *mut MaybeUninit<Provenance>, addr: usize, size: usize) {
+unsafe extern "C" fn __bsan_alloc(
+    span: Span,
+    prov: *mut MaybeUninit<Provenance>,
+    object_address: *const c_void,
+    alloc_size: usize,
+) {
     debug_assert!(!prov.is_null());
+    let ctx = unsafe { global_ctx() };
+    let alloc_hooks = ctx.allocator();
+
+    let tree = Box::new_in(TreeBorrows::Tree::new(object_address, alloc_size), alloc_hooks);
+    let root_borrow_tag = tree.get_root_borrow_tag();
+    let alloc_id = ctx.new_alloc_id();
+    //global::debug!(ctx, "allocating lock location for alloc_id: {:?}", alloc_id);
     unsafe {
-        (*prov).write(Provenance::null());
+        let mut lock_location = ctx.allocate_lock_location();
+        //global::debug!(ctx, "Allocated lock location: {:?}", lock_location);
+        let alloc_metadata = AllocMetadata {
+            alloc_id,
+            base_addr: FreeListAddrUnion { base_addr: object_address },
+            tree_address: tree,
+        };
+        let lock_address = lock_location.as_mut().write(alloc_metadata) as *const AllocMetadata;
+        (*prov).write(Provenance { alloc_id, borrow_tag: root_borrow_tag, lock_address });
     }
 }
 
-/// Registers a stack allocation of size `size`.
-#[unsafe(no_mangle)]
-extern "C" fn __bsan_alloc_stack(prov: *mut MaybeUninit<Provenance>, size: usize) {
-    debug_assert!(!prov.is_null());
+// FIXME(obraunsdorf) using thiserror for good error handling
+// might be valuable in the future to also catch and report Tree Borrows errors
+struct BsanDeallocError {
+    msg: &'static str,
+}
+unsafe fn __inner_bsan_dealloc(span: Span, prov: *mut Provenance) -> Result<(), BsanDeallocError> {
     unsafe {
-        (*prov).write(Provenance::null());
+        let prov = &mut *prov;
+        let ctx = global_ctx();
+        let alloc_metadata = &mut *(prov.lock_address as *mut AllocMetadata);
+        if (alloc_metadata.alloc_id.get() != prov.alloc_id.get()) {
+            return Err(BsanDeallocError {
+                //TODO(obraunsdorf) format the id's into the error message for better error reporting
+                msg: "Allocation ID in pointer metadata does not match the one in the lock address",
+            });
+        }
+        alloc_metadata.dealloc(prov.borrow_tag);
     }
+    Ok(())
 }
 
 /// Deregisters a heap allocation
+/// # Safety
+/// Mutating alloc_metadata (i.e. deallocating the tree, and invalidating alloc_id) through the provencance
+/// metadata (which is copy) is only thread-safe, if the application itself is thread-safe.
+/// BSAN is not ensuring thread-safety here
+/// if the
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_dealloc(prov: *mut Provenance) {}
+unsafe extern "C" fn __bsan_dealloc(span: Span, prov: *mut Provenance) {
+    let result = unsafe { __inner_bsan_dealloc(span, prov) };
+    match result {
+        Ok(_) => {}
+        Err(e) => {
+            //TODO(obraunsdorf) use error handling routing from the hooks to print the error message and exit
+            panic!("BSAN ERROR: {}", e.msg);
+        }
+    }
+}
 
 /// Marks the borrow tag for `prov` as "exposed," allowing it to be resolved to
 /// validate accesses through "wildcard" pointers.
@@ -343,4 +421,80 @@ extern "C" fn __bsan_expose_tag(prov: *const Provenance) {}
 #[panic_handler]
 fn panic(info: &PanicInfo<'_>) -> ! {
     loop {}
+}
+
+#[cfg(test)]
+mod test {
+    use core::alloc::{GlobalAlloc, Layout};
+    use core::mem::MaybeUninit;
+    use core::ptr::NonNull;
+
+    use super::*;
+    use crate::span::SpanData;
+
+    fn init_bsan_with_test_hooks() {
+        unsafe {
+            __bsan_init();
+        }
+    }
+
+    fn create_metadata() -> Provenance {
+        let mut prov = MaybeUninit::<Provenance>::uninit();
+        let prov_ptr = (&mut prov) as *mut _;
+        unsafe {
+            __bsan_alloc(Span::new(), prov_ptr, 0xaaaaaaaa as *const c_void, 10);
+            prov.assume_init()
+        }
+    }
+
+    #[test]
+    fn bsan_alloc_increasing_alloc_id() {
+        init_bsan_with_test_hooks();
+        unsafe {
+            log::debug!("before bsan_alloc");
+            let prov1 = create_metadata();
+            log::debug!("directly after bsan_alloc");
+            assert_eq!(prov1.alloc_id.get(), 3);
+            assert_eq!(AllocId::min().get(), 3);
+            let prov2 = create_metadata();
+            assert_eq!(prov2.alloc_id.get(), 4);
+        }
+    }
+
+    #[test]
+    fn bsan_alloc_and_dealloc() {
+        init_bsan_with_test_hooks();
+        unsafe {
+            let mut prov = create_metadata();
+            let span = Span::from(SpanData::from(42));
+            __bsan_dealloc(span, &mut prov as *mut _);
+            let alloc_metadata = &*prov.lock_address;
+            assert_eq!(alloc_metadata.alloc_id.get(), AllocId::invalid().get());
+            assert_eq!(alloc_metadata.alloc_id.get(), 0);
+        }
+    }
+
+    #[test]
+    fn bsan_dealloc_detect_double_free() {
+        init_bsan_with_test_hooks();
+        unsafe {
+            let mut prov = create_metadata();
+            let _ = __inner_bsan_dealloc(Span::new(), &mut prov as *mut _);
+            let result = __inner_bsan_dealloc(Span::new(), &mut prov as *mut _);
+            assert!(result.is_err());
+        }
+    }
+
+    #[test]
+    fn bsan_dealloc_detect_invalid_free() {
+        init_bsan_with_test_hooks();
+        unsafe {
+            let span = Span::new();
+            let mut prov = create_metadata();
+            let mut modified_prov = prov;
+            modified_prov.alloc_id = AllocId::new(99);
+            let result = __inner_bsan_dealloc(span, &mut modified_prov as *mut _);
+            assert!(result.is_err());
+        }
+    }
 }

--- a/bsan-rt/src/span.rs
+++ b/bsan-rt/src/span.rs
@@ -7,7 +7,14 @@ impl SpanData {
     }
 }
 
+impl From<usize> for SpanData {
+    fn from(val: usize) -> Self {
+        SpanData(val)
+    }
+}
+
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+#[repr(C)]
 pub struct Span(usize);
 
 impl Span {

--- a/bsan-rt/src/tree_borrows/mod.rs
+++ b/bsan-rt/src/tree_borrows/mod.rs
@@ -1,0 +1,39 @@
+pub(super) mod tree_borrows_wrapper {
+    use core::ffi::c_void;
+    pub type BorrowTag = u64;
+    use alloc::boxed::Box;
+
+    use log::debug;
+
+    #[derive(Debug)]
+    pub enum TreeBorrowsError {
+        InvalidAccess,
+    }
+
+    #[derive(Debug)]
+    pub struct Tree {}
+    impl Tree {
+        pub fn new(object_address: *const c_void, alloc_size: usize) -> Self {
+            Self {}
+        }
+
+        pub fn get_root_borrow_tag(&self) -> BorrowTag {
+            0
+        }
+
+        pub fn deallocate(
+            &mut self,
+            object_address: *const c_void,
+            borrow_tag: BorrowTag,
+        ) -> Result<(), TreeBorrowsError> {
+            debug!( "Invalidating tree for object allocation at {object_address:p} with borrow tag {borrow_tag}");
+            Ok(())
+        }
+    }
+
+    impl Drop for Tree {
+        fn drop(&mut self) {
+            debug!("Dropping Tree");
+        }
+    }
+}


### PR DESCRIPTION
This is porting over the pull request from the Rust repo: https://github.com/BorrowSanitizer/rust/pull/16

There are still things todo

- [ ] How to properly initialize the block allocator
- [ ] adjusting the parameter type of the method `next` in the `Linkable` trait
- [ ] Moving to AtomicU64 (which also means moving to u64 for AllocId)
- [ ] How to properly dealloc the tree (CC @Gitter499) 