### PR TITLE
Removes allocation instrumentation from the LLVM pass.

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -193,10 +193,6 @@ namespace
             return getProvenance(I->getOperand(i));
         }
 
-        CallInst *createAllocationMetadata(Value *AllocAddr, APInt &AllocSize)
-        {
-        }
-
         void instrumentLoad(LoadInst &I) {}
 
         void instrumentVectorLoad(LoadInst &I) {}


### PR DESCRIPTION
Temporarily removes insertion of `__bsan_alloc` from the LLVM pass, since provenance and shadow memory handling has not yet been implemented. 