### PR TITLE
Update to 1.90.0 with out-of-tree retagging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
 name = "bsan-driver"
 version = "0.1.0"
 dependencies = [
+ "bsan-shared",
  "env_logger",
  "log",
  "rustc_version",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 name = "cargo-bsan"
 version = "0.1.0"
 dependencies = [
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.21.0",
  "directories",
  "env_logger",
  "log",
@@ -230,13 +230,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dc1a6f7b5651af85774ae5a34b4e8be397d9cf4bc063b7e6dbd99a841837830"
+dependencies = [
+ "semver",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 2.0.12",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver",
  "serde",
  "serde_json",
@@ -245,12 +270,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "5cfca2aaa699835ba88faf58a06342a314a950d2b9686165e038286c30316868"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.2.0",
+ "cargo-util-schemas",
  "semver",
  "serde",
  "serde_json",
@@ -259,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "shlex",
 ]
@@ -420,6 +446,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +510,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -517,6 +564,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -559,6 +615,113 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indenter"
@@ -664,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags",
  "libc",
@@ -678,6 +841,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -722,6 +891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +933,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6e819bbd49d5939f682638fa54826bf1650abddcd65d000923de8ad63cc7d15"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -844,9 +1046,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
 dependencies = [
  "bitflags",
 ]
@@ -945,22 +1147,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -1002,6 +1198,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -1074,6 +1291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1081,20 +1304,19 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn 2.0.104",
 ]
 
@@ -1118,6 +1340,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1214,6 +1447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1540,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "ui_test"
 version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,7 +1554,7 @@ dependencies = [
  "annotate-snippets",
  "anyhow",
  "bstr",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "cargo_metadata 0.18.1",
  "color-eyre",
  "colored",
@@ -1339,6 +1588,29 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1613,9 +1885,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -1634,6 +1906,12 @@ checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xattr"
@@ -1667,4 +1945,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = ["bsan-driver", "bsan-rt", "bsan-script", "bsan-shared", "cargo-bsan"]
 default-members = ["bsan-driver", "bsan-script", "cargo-bsan"]
+exclude = [".toolchain"]
 resolver = "3"
 
 [package]
@@ -12,7 +13,7 @@ edition = "2024"
 colored = "2"
 ui_test = "0.26.5"
 rustc_version = "0.4"
-regex = "1.5.5"
+regex = "1.11.1"
 tempfile = "3"
 
 [[test]]

--- a/bsan-driver/Cargo.toml
+++ b/bsan-driver/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-env_logger = "0.11.6"
-log = "0.4.22"
+env_logger = "0.11.8"
+log = "0.4.27"
 rustc_version = "0.4.1"
 
 [lib]

--- a/bsan-driver/Cargo.toml
+++ b/bsan-driver/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 env_logger = "0.11.8"
 log = "0.4.27"
 rustc_version = "0.4.1"
+bsan-shared = { path = "../bsan-shared" }
 
 [lib]
 test = true     # we have unit tests

--- a/bsan-driver/src/callbacks.rs
+++ b/bsan-driver/src/callbacks.rs
@@ -1,6 +1,7 @@
+use bsan_shared::{AccessKind, Permission, PermissionInfo, ProtectorKind};
 use rustc_interface::Config;
-use rustc_middle::mir::RetagParams;
-use rustc_middle::ty::{Ty, TyCtxt, TypingEnv};
+use rustc_middle::mir::{RetagKind, RetagParams};
+use rustc_middle::ty::{self, Mutability, Ty, TyCtxt, TypingEnv};
 use rustc_middle::util::Providers;
 use rustc_session::Session;
 
@@ -16,8 +17,42 @@ fn override_queries(_sess: &Session, providers: &mut Providers) {
 }
 
 fn retag_perm<'tcx>(
-    _tcx: TyCtxt<'tcx>,
-    _key: (TypingEnv<'tcx>, Ty<'tcx>, RetagParams),
+    tcx: TyCtxt<'tcx>,
+    key: (TypingEnv<'tcx>, Ty<'tcx>, RetagParams),
 ) -> Option<u64> {
-    Some(0)
+    let (env, ty, params) = key;
+    let ty_is_freeze = ty.is_freeze(tcx, env);
+    let ty_is_unpin = ty.is_unpin(tcx, env);
+    let is_protected = params.kind == RetagKind::FnEntry;
+
+    let info = if let ty::Ref(_, _, mutability) = ty.kind() {
+        let (perm_kind, access_kind) = match mutability {
+            Mutability::Not if ty_is_unpin => (
+                Permission::new_reserved(ty_is_freeze && !params.in_unsafe_cell, is_protected),
+                Some(AccessKind::Read),
+            ),
+            Mutability::Mut if ty_is_freeze => {
+                if params.in_unsafe_cell {
+                    (Permission::new_cell(), None)
+                } else {
+                    (Permission::new_frozen(), Some(AccessKind::Read))
+                }
+            }
+            // Raw pointers never enter this function so they are not handled.
+            // However raw pointers are not the only pointers that take the parent
+            // tag, this also happens for `!Unpin` `&mut`s and interior mutable
+            // `&`s, which are excluded above.
+            _ => return None,
+        };
+
+        let protector_kind = is_protected.then_some(ProtectorKind::StrongProtector);
+        PermissionInfo { perm_kind, protector_kind, access_kind }
+    } else {
+        assert!(params.is_unique);
+        let protector_kind = is_protected.then_some(ProtectorKind::WeakProtector);
+        let perm_kind =
+            Permission::new_reserved(ty_is_freeze && !params.in_unsafe_cell, is_protected);
+        PermissionInfo { perm_kind, protector_kind, access_kind: None }
+    };
+    Some(PermissionInfo::into_raw(info))
 }

--- a/bsan-driver/src/callbacks.rs
+++ b/bsan-driver/src/callbacks.rs
@@ -1,0 +1,23 @@
+use rustc_interface::Config;
+use rustc_middle::mir::RetagParams;
+use rustc_middle::ty::{Ty, TyCtxt, TypingEnv};
+use rustc_middle::util::Providers;
+use rustc_session::Session;
+
+pub struct BSanCallBacks {}
+impl rustc_driver::Callbacks for BSanCallBacks {
+    fn config(&mut self, config: &mut Config) {
+        config.override_queries = Some(override_queries);
+    }
+}
+
+fn override_queries(_sess: &Session, providers: &mut Providers) {
+    providers.retag_perm = retag_perm;
+}
+
+fn retag_perm<'tcx>(
+    _tcx: TyCtxt<'tcx>,
+    _key: (TypingEnv<'tcx>, Ty<'tcx>, RetagParams),
+) -> Option<u64> {
+    Some(0)
+}

--- a/bsan-driver/src/lib.rs
+++ b/bsan-driver/src/lib.rs
@@ -1,21 +1,17 @@
 #![feature(rustc_private)]
 
 extern crate rustc_driver;
-
+extern crate rustc_interface;
+extern crate rustc_middle;
+extern crate rustc_session;
+mod callbacks;
 use std::env;
+
+pub use callbacks::BSanCallBacks;
 pub const BSAN_BUG_REPORT_URL: &str = "https://github.com/BorrowSanitizer/rust/issues/new";
 
-pub const BSAN_DEFAULT_ARGS: &[&str] = &[
-    "--cfg=bsan",
-    "-Copt-level=0",
-    "-Zmir-opt-level=0",
-    "-Cpasses=bsan",
-    "-Zmir-emit-retag",
-    "-Zllvm-emit-retag",
-];
-
-pub struct BSanCallBacks {}
-impl rustc_driver::Callbacks for BSanCallBacks {}
+pub const BSAN_DEFAULT_ARGS: &[&str] =
+    &["--cfg=bsan", "-Copt-level=0", "-Zmir-opt-level=0", "-Cpasses=bsan", "-Zmir-emit-retag"];
 
 /// Execute a compiler with the given CLI arguments and callbacks.
 pub fn run_compiler(mut args: Vec<String>, target_crate: bool, callbacks: &mut BSanCallBacks) -> ! {

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -93,6 +93,7 @@ namespace
             LongSize = M.getDataLayout().getPointerSizeInBits();
             TargetTriple = Triple(M.getTargetTriple());
             Int8Ty = Type::getInt8Ty(*C);
+            Int64Ty = Type::getInt64Ty(*C);
             PtrTy = PointerType::getUnqual(*C);
             IntptrTy = Type::getIntNTy(*C, LongSize);
             ProvenanceTy = StructType::get(IntptrTy, IntptrTy, PtrTy);
@@ -122,6 +123,7 @@ namespace
         int LongSize;
         Triple TargetTriple;
         Type *Int8Ty;
+        Type *Int64Ty;
         PointerType *PtrTy;
         Type *IntptrTy;
         StructType *ProvenanceTy;
@@ -423,8 +425,8 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
     IRBuilder<> IRB(*C);
 
     BsanFuncRetag = M.getOrInsertFunction(kBsanFuncRetagName, IRB.getVoidTy(),
-                                          PtrTy, IntptrTy, Int8Ty, Int8Ty);
-
+                                          PtrTy, IntptrTy, Int64Ty, IntptrTy, IntptrTy, PtrTy);
+                                          
     BsanFuncPushFrame = M.getOrInsertFunction(
         kBsanFuncPushFrameName, FunctionType::get(PtrTy, IntptrTy, /*isVarArg=*/false));
 

--- a/bsan-rt/Cargo.toml
+++ b/bsan-rt/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2024"
 ui_test = []
 
 [dependencies]
-libc = { version = "0.2.169", default-features = false }
-hashbrown = { version = "0.15.2", default-features = false, features = ["default-hasher", "nightly", "inline-more"] }
+libc = { version = "0.2.174", default-features = false }
+hashbrown = { version = "0.15.4", default-features = false, features = ["default-hasher", "nightly", "inline-more"] }
 rustc-hash = { version = "2.1.1", default-features = false }
-smallvec = { version = "1.14.0" }
+smallvec = { version = "1.15.1" }
 libc-print = { version = "0.1.23" }
 bsan-shared = { path = "../bsan-shared" }
 spin = "0.10.0"

--- a/bsan-rt/src/borrow_tracker/mod.rs
+++ b/bsan-rt/src/borrow_tracker/mod.rs
@@ -89,7 +89,7 @@ impl BorrowTracker {
         let parent_tag = self.prov.bor_tag;
         let new_tag = global_ctx.new_borrow_tag();
 
-        if let Some(protect) = retag_info.protector_kind {
+        if let Some(protect) = retag_info.perm.protector_kind {
             // We register the protection in two different places.
             // This makes creating a protector slower, but checking whether a tag
             // is protected faster.
@@ -107,7 +107,7 @@ impl BorrowTracker {
         );
 
         let base_offset = self.range.start;
-        if let Some(access_kind) = retag_info.access_kind {
+        if let Some(access_kind) = retag_info.perm.access_kind {
             for (perm_range, perm) in perms_map.iter_mut_all() {
                 if perm.is_accessed() {
                     // Some reborrows incur a read access to the parent.
@@ -133,8 +133,8 @@ impl BorrowTracker {
             }
         }
 
-        let protected = retag_info.protector_kind.is_some();
-        let default_perm = retag_info.perm_kind;
+        let protected = retag_info.perm.protector_kind.is_some();
+        let default_perm = retag_info.perm.perm_kind;
 
         let child_params = ChildParams {
             base_offset,

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -8,7 +8,6 @@
 #![feature(allocator_api)]
 #![feature(alloc_layout_extra)]
 #![feature(format_args_nl)]
-#![feature(nonnull_provenance)]
 #![feature(core_intrinsics)]
 #![feature(yeet_expr)]
 #![feature(unsafe_cell_access)]
@@ -350,18 +349,15 @@ unsafe extern "C" fn __bsan_deinit() {
 unsafe extern "C" fn __bsan_retag(
     object_addr: *mut c_void,
     access_size: usize,
+    perm: u64,
     alloc_id: AllocId,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
-    perm_kind: u16,
-    protector_kind: u8,
-    access_kind: u8,
 ) {
     let global_ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
-    let retag_info =
-        unsafe { RetagInfo::from_raw(access_size, perm_kind, protector_kind, access_kind) };
+    let retag_info = unsafe { RetagInfo::from_raw(access_size, perm) };
     let bt = BorrowTracker::new(prov, object_addr, Some(access_size));
     let _ = bt.iter().flatten().try_for_each(|bt| bt.retag(global_ctx, local_ctx, retag_info));
 }

--- a/bsan-script/Cargo.toml
+++ b/bsan-script/Cargo.toml
@@ -5,19 +5,19 @@ edition = "2024"
 
 [dependencies]
 anyhow = "1.0.98"
-cc = "1.2.24"
-clap = { version = "4.5.21", features = ["derive"] }
+cc = "1.2.30"
+clap = { version = "4.5.41", features = ["derive"] }
 cmake = "0.1.54"
 dunce = "1.0.5"
 path_macro = "1.0.0"
 rustc_version = "0.4.1"
 semver = "1.0.26"
 serde = { version = "1.0.219", features = ["derive"] }
-strum = "0.27.1"
-strum_macros = "0.27.1"
-serde_json = "1.0.140"
+strum = "0.27.2"
+strum_macros = "0.27.2"
+serde_json = "1.0.141"
 tar = "0.4.44"
-toml = "0.8.22"
+toml = "0.8.23"
 which = "7.0.3"
 xshell = "0.2.7"
 xz2 = "0.1.7"

--- a/bsan-shared/src/lib.rs
+++ b/bsan-shared/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), no_std)]
+#![feature(cfg_select)]
 #![allow(dead_code)]
 #![feature(allocator_api)]
 

--- a/bsan-shared/src/perms.rs
+++ b/bsan-shared/src/perms.rs
@@ -8,18 +8,37 @@ use super::helpers::{AccessKind, AccessRelatedness};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RetagInfo {
     pub size: usize,
+    pub perm: PermissionInfo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PermissionInfo {
     pub perm_kind: Permission,
     pub protector_kind: Option<ProtectorKind>,
     pub access_kind: Option<AccessKind>,
 }
 
-impl RetagInfo {
+impl PermissionInfo {
+    pub fn into_raw(self) -> u64 {
+        let perm_kind: u16 = Permission::into_raw(self.perm_kind);
+        let protector_kind: u8 = ProtectorKind::into_raw(self.protector_kind);
+        let access_kind: u8 = AccessKind::into_raw(self.access_kind);
+        cfg_select! {
+            target_endian = "little" => {
+                perm_kind as u64 & ((protector_kind as u64) << 16) & ((access_kind as u64) << 24)
+            }
+            target_endian = "big" => {
+                perm_kind as u64 & ((protector_kind as u64) >> 16) & ((access_kind as u64) >> 24)
+            }
+        }
+    }
+
     /// # Safety
     /// The first 32 bits of `perm` must contain the `Permission`,
     /// the `ProtectorKind`, and the `AccessKind, in that order.`
     #[inline]
     #[allow(clippy::needless_late_init)]
-    pub unsafe fn from_raw(size: usize, perm: u64) -> Self {
+    unsafe fn from_raw(perm: u64) -> Self {
         let perm_kind: u16;
         let protector_kind: u8;
         let access_kind: u8;
@@ -41,8 +60,18 @@ impl RetagInfo {
             let perm_kind = Permission::from_raw(perm_kind);
             let protector_kind = ProtectorKind::from_raw(protector_kind);
             let access_kind = AccessKind::from_raw(access_kind);
-            Self { size, perm_kind, protector_kind, access_kind }
+            Self { perm_kind, protector_kind, access_kind }
         }
+    }
+}
+
+impl RetagInfo {
+    /// # Safety
+    /// The first 32 bits of `perm` must contain the `Permission`,
+    /// the `ProtectorKind`, and the `AccessKind, in that order.`
+    pub unsafe fn from_raw(size: usize, perm: u64) -> Self {
+        let perm = unsafe { PermissionInfo::from_raw(perm) };
+        Self { size, perm }
     }
 }
 
@@ -736,6 +765,36 @@ impl Permission {
         match self.inner {
             ReservedFrz { conflicted } => conflicted == expected_conflicted,
             _ => false,
+        }
+    }
+}
+
+mod test {
+
+    #[cfg(test)]
+    fn perm_into_raw_roundtrip() {
+        use crate::{AccessKind, Permission, PermissionInfo, ProtectorKind};
+        let initial_perms = [
+            Permission::new_reserved_frz(),
+            Permission::new_reserved_im(),
+            Permission::new_cell(),
+            Permission::new_frozen(),
+        ];
+
+        let access_kinds = [Some(AccessKind::Read), Some(AccessKind::Write), None];
+        let protector_kinds =
+            [Some(ProtectorKind::StrongProtector), Some(ProtectorKind::WeakProtector), None];
+
+        for perm_kind in initial_perms {
+            for access_kind in access_kinds {
+                for protector_kind in protector_kinds {
+                    let perm = PermissionInfo { perm_kind, protector_kind, access_kind };
+                    assert_eq!(
+                        unsafe { PermissionInfo::from_raw(PermissionInfo::into_raw(perm)) },
+                        perm
+                    );
+                }
+            }
         }
     }
 }

--- a/cargo-bsan/Cargo.toml
+++ b/cargo-bsan/Cargo.toml
@@ -4,17 +4,16 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-cargo_metadata = "0.19.1"
+cargo_metadata = "0.21"
 directories = "6.0.0"
-env_logger = "0.11.6"
-log = "0.4.22"
-rustc-build-sysroot = "0.5.4"
-rustc_version = "0.4.1"
-rustc_tools_util = "0.4.0"
+env_logger = "0.11.8"
+log = "0.4.27"
+rustc-build-sysroot = "0.5.8"
+rustc_version = "0.4"
 path_macro = "1.0.0"
 
 [build-dependencies]
-rustc_tools_util = "0.4.0"
+rustc_tools_util = "0.4"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/cargo-bsan/Cargo.toml
+++ b/cargo-bsan/Cargo.toml
@@ -8,7 +8,7 @@ cargo_metadata = "0.21"
 directories = "6.0.0"
 env_logger = "0.11.8"
 log = "0.4.27"
-rustc-build-sysroot = "0.5.8"
+rustc-build-sysroot = "0.5.9"
 rustc_version = "0.4"
 path_macro = "1.0.0"
 

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -88,7 +88,7 @@ pub fn setup_sysroot(
         SysrootConfig::NoStd
     } else {
         SysrootConfig::WithStd {
-            std_features: ["panic_unwind", "backtrace"].into_iter().map(Into::into).collect(),
+            std_features: ["panic-unwind", "backtrace"].into_iter().map(Into::into).collect(),
         }
     };
     let cargo_cmd = {

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.89.0-dev-540ee5b"
-sha = "540ee5b05763fbf34ad4523c7f76e247794e151b"
-version = "1.89.0-dev"
+tag = "rolling-1.90.0-dev-8088c7b"
+sha = "8088c7b1aa874397d631f29be4709edd7dee4f58"
+version = "1.90.0-dev"
 dependencies = ["cmake", "ninja", "curl"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.90.0-dev-8088c7b"
-sha = "8088c7b1aa874397d631f29be4709edd7dee4f58"
+tag = "rolling-1.90.0-dev-df8c54e"
+sha = "df8c54e8a6cf571b7e60156e9f5a19ab78eb022b"
 version = "1.90.0-dev"
 dependencies = ["cmake", "ninja", "curl"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
Updates our toolchain to [`rolling-1.90.0-dev-df8c54e`](https://github.com/BorrowSanitizer/rust/releases/tag/rolling-1.90.0-dev-df8c54e), which adds support for implementing the semantics of a retag by overriding a compiler query, as described in our [project goal proposal](https://github.com/rust-lang/rust-project-goals/pull/350).