### PR TITLE
Updated Rust fork to fix pointee size in retags.

### DIFF
--- a/bsan-driver/src/callbacks.rs
+++ b/bsan-driver/src/callbacks.rs
@@ -18,41 +18,44 @@ fn override_queries(_sess: &Session, providers: &mut Providers) {
 
 fn retag_perm<'tcx>(
     tcx: TyCtxt<'tcx>,
-    key: (TypingEnv<'tcx>, Ty<'tcx>, RetagParams),
+    key: (TypingEnv<'tcx>, Ty<'tcx>, Ty<'tcx>, RetagParams),
 ) -> Option<u64> {
-    let (env, ty, params) = key;
-    let ty_is_freeze = ty.is_freeze(tcx, env);
-    let ty_is_unpin = ty.is_unpin(tcx, env);
+    let (env, pointer_ty, pointee_ty, params) = key;
+    let ty_is_freeze = pointee_ty.is_freeze(tcx, env);
+    let ty_is_unpin = pointee_ty.is_unpin(tcx, env);
     let is_protected = params.kind == RetagKind::FnEntry;
-
-    let info = if let ty::Ref(_, _, mutability) = ty.kind() {
-        let (perm_kind, access_kind) = match mutability {
-            Mutability::Not if ty_is_unpin => (
-                Permission::new_reserved(ty_is_freeze && !params.in_unsafe_cell, is_protected),
-                Some(AccessKind::Read),
-            ),
-            Mutability::Mut if ty_is_freeze => {
-                if params.in_unsafe_cell {
-                    (Permission::new_cell(), None)
-                } else {
-                    (Permission::new_frozen(), Some(AccessKind::Read))
+    let info = match pointer_ty.kind() {
+        ty::Ref(_, _, mutability) => {
+            let (perm_kind, access_kind) = match mutability {
+                Mutability::Not if ty_is_unpin => (
+                    Permission::new_reserved(ty_is_freeze && !params.in_unsafe_cell, is_protected),
+                    Some(AccessKind::Read),
+                ),
+                Mutability::Mut if ty_is_freeze => {
+                    if params.in_unsafe_cell {
+                        (Permission::new_cell(), None)
+                    } else {
+                        (Permission::new_frozen(), Some(AccessKind::Read))
+                    }
                 }
-            }
-            // Raw pointers never enter this function so they are not handled.
-            // However raw pointers are not the only pointers that take the parent
-            // tag, this also happens for `!Unpin` `&mut`s and interior mutable
-            // `&`s, which are excluded above.
-            _ => return None,
-        };
+                // Raw pointers never enter this function so they are not handled.
+                // However raw pointers are not the only pointers that take the parent
+                // tag, this also happens for `!Unpin` `&mut`s and interior mutable
+                // `&`s, which are excluded above.
+                _ => return None,
+            };
 
-        let protector_kind = is_protected.then_some(ProtectorKind::StrongProtector);
-        PermissionInfo { perm_kind, protector_kind, access_kind }
-    } else {
-        assert!(params.is_unique);
-        let protector_kind = is_protected.then_some(ProtectorKind::WeakProtector);
-        let perm_kind =
-            Permission::new_reserved(ty_is_freeze && !params.in_unsafe_cell, is_protected);
-        PermissionInfo { perm_kind, protector_kind, access_kind: None }
+            let protector_kind = is_protected.then_some(ProtectorKind::StrongProtector);
+            PermissionInfo { perm_kind, protector_kind, access_kind }
+        }
+
+        ty::Adt(def, ..) if def.is_box() => {
+            let protector_kind = is_protected.then_some(ProtectorKind::WeakProtector);
+            let perm_kind =
+                Permission::new_reserved(ty_is_freeze && !params.in_unsafe_cell, is_protected);
+            PermissionInfo { perm_kind, protector_kind, access_kind: None }
+        }
+        _ => return None,
     };
     Some(PermissionInfo::into_raw(info))
 }

--- a/bsan-driver/src/lib.rs
+++ b/bsan-driver/src/lib.rs
@@ -11,7 +11,7 @@ pub use callbacks::BSanCallBacks;
 pub const BSAN_BUG_REPORT_URL: &str = "https://github.com/BorrowSanitizer/rust/issues/new";
 
 pub const BSAN_DEFAULT_ARGS: &[&str] =
-    &["--cfg=bsan", "-Copt-level=0", "-Zmir-opt-level=0", "-Cpasses=bsan", "-Zmir-emit-retag"];
+    &["--cfg=bsan", "-Copt-level=0", "-Zmir-opt-level=0", "-Cpasses=bsan", "-Zmir-emit-retag=full"];
 
 /// Execute a compiler with the given CLI arguments and callbacks.
 pub fn run_compiler(mut args: Vec<String>, target_crate: bool, callbacks: &mut BSanCallBacks) -> ! {

--- a/bsan-script/src/env.rs
+++ b/bsan-script/src/env.rs
@@ -122,7 +122,6 @@ impl BsanEnv {
                 show_error!("Please specify an installation directory for our toolchain using `xb --toolchain-dir=[dir]`.")
             }
         };
-        fs::create_dir_all(&deps_dir)?;
 
         let config_path = path!(root_dir / "config.toml");
         let mut config = BsanConfig::from_file(&config_path)?;

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -59,6 +59,7 @@ pub fn setup(
     // If we've passed these checks, then let's do the expensive step of
     // downloading and installing our custom toolchain.
     if let Some(PromptResult::Yes) = prompt_user_unless(skip_prompt, prompt_text)? {
+        fs::create_dir_all(toolchain_dir)?;
         toolchain(sh, host, config, toolchain_dir)
     } else {
         std::process::exit(0)

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.90.0-dev-07c76d1"
-sha = "07c76d1b7418e5cadad523e973f8f4e49122780e"
+tag = "rolling-1.90.0-dev-e27d0c1"
+sha = "e27d0c149394221eb1550c078e4cf2ccb0914bd3"
 version = "1.90.0-dev"
 dependencies = ["cmake", "ninja", "curl"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.90.0-dev-df8c54e"
-sha = "df8c54e8a6cf571b7e60156e9f5a19ab78eb022b"
+tag = "rolling-1.90.0-dev-07c76d1"
+sha = "07c76d1b7418e5cadad523e973f8f4e49122780e"
 version = "1.90.0-dev"
 dependencies = ["cmake", "ninja", "curl"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
Retags were incorrectly configured to use the size and type of the pointer being retagged, instead of the pointee.