### PR TITLE
Support protectors and dynamic allocas.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,21 +145,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bsan-rt"
-version = "0.1.0"
-dependencies = [
- "backtrace",
- "bsan-shared",
- "foldhash",
- "hashbrown",
- "libc",
- "libc-print",
- "rustc-hash",
- "spin",
- "thiserror-no-std",
-]
-
-[[package]]
 name = "bsan-script"
 version = "0.1.0"
 dependencies = [
@@ -185,6 +170,20 @@ dependencies = [
 [[package]]
 name = "bsan-shared"
 version = "0.1.0"
+
+[[package]]
+name = "bsan_rt"
+version = "0.1.0"
+dependencies = [
+ "bsan-shared",
+ "foldhash",
+ "hashbrown",
+ "libc",
+ "libc-print",
+ "rustc-hash",
+ "spin",
+ "thiserror-no-std",
+]
 
 [[package]]
 name = "bstr"
@@ -306,9 +305,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "clap"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -316,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.42"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -731,9 +730,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -2018,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdbb9122ea75b11bf96e7492afb723e8a7fbe12c67417aa95e7e3d18144d37cd"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [ "bsan-debug","bsan-driver", "bsan-rt", "bsan-script", "bsan-shared", "cargo-bsan"]
+members = ["bsan-debug", "bsan-driver", "bsan-rt", "bsan-script", "bsan-shared", "cargo-bsan"]
 default-members = ["bsan-driver", "bsan-script", "cargo-bsan"]
 exclude = [".toolchain"]
 resolver = "3"

--- a/bsan-pass/BorrowSanitizer.h
+++ b/bsan-pass/BorrowSanitizer.h
@@ -16,23 +16,35 @@ const char kBsanPrefix[] = BSAN_FN();
 
 const char kBsanFuncInitName[] = BSAN_FN("init");
 const char kBsanFuncDeinitName[] = BSAN_FN("deinit");
-const char kBsanFuncPushFrameName[] = BSAN_FN("push_frame");
-const char kBsanFuncPopFrameName[] = BSAN_FN("pop_frame");
+
+const char kBsanFuncPushAllocaFrameName[] = BSAN_FN("push_alloca_frame");
+const char kBsanFuncPushRetagFrameName[] = BSAN_FN("push_retag_frame");
+
+const char kBsanFuncPopAllocaFrameName[] = BSAN_FN("pop_alloca_frame");
+const char kBsanFuncPopRetagFrameName[] = BSAN_FN("pop_retag_frame");
+
 const char kBsanFuncShadowCopyName[] = BSAN_FN("shadow_copy");
 const char kBsanFuncShadowClearName[] = BSAN_FN("shadow_clear");
+
 const char kBsanFuncGetShadowDestName[] = BSAN_FN("shadow_dest");
 const char kBsanFuncGetShadowSrcName[] = BSAN_FN("shadow_src");
+
 const char kBsanFuncShadowLoadVectorName[] = BSAN_FN("shadow_load_vector");
 const char kBsanFuncShadowStoreVectorName[] = BSAN_FN("shadow_store_vector");
+
 const char kBsanFuncRetagName[] = BSAN_FN("retag");
 const char kBsanFuncAllocName[] = BSAN_FN("alloc");
-const char kBsanFuncAllocStackName[] = BSAN_FN("alloc_stack");
+
+const char kBsanFuncReserveStackSlotName[] = BSAN_FN("reserve_stack_slot");
+const char kBsanFuncAllocInPlace[] = BSAN_FN("alloc_in_place");
+
 const char kBsanFuncNewBorrowTagName[] = BSAN_FN("new_tag");
 const char kBsanFuncNewAllocIDName[] = BSAN_FN("new_alloc_id");
 const char kBsanFuncDeallocName[] = BSAN_FN("dealloc");
 const char kBsanFuncExposeTagName[] = BSAN_FN("expose_tag");
 const char kBsanFuncReadName[] = BSAN_FN("read");
 const char kBsanFuncWriteName[] = BSAN_FN("write");
+
 
 // Helper functions for debugging and testing.
 #define BSAN_DEBUG_PREFIX BSAN_FN("debug_")

--- a/bsan-rt/Cargo.toml
+++ b/bsan-rt/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "bsan-rt"
+name = "bsan_rt"
 version = "0.1.0"
 edition = "2024"
 
@@ -15,11 +15,8 @@ bsan-shared = { path = "../bsan-shared" }
 spin = "0.10.0"
 thiserror-no-std = "2.0.2"
 foldhash = { version = "0.1.5", default-features = false }
-backtrace = "0.3.75"
 
 [lib]
 name = "bsan_rt"
 crate-type = ["staticlib"] 
-test = true     # we have unit tests
-doctest = false # but no doc tests
 

--- a/bsan-rt/src/borrow_tracker/mod.rs
+++ b/bsan-rt/src/borrow_tracker/mod.rs
@@ -1,6 +1,5 @@
 // Components in this library were ported from Miri and then modified by our team.
 use core::ffi::c_void;
-use core::ptr;
 
 use bsan_shared::{
     AccessKind, IdempotentForeignAccess, Permission, ProtectorKind, RangeMap, RetagInfo, Size,
@@ -10,10 +9,10 @@ use tree::{AllocRange, Tree};
 
 use crate::borrow_tracker::tree::{ChildParams, LocationState};
 use crate::diagnostics::AccessCause;
-use crate::errors::{BorsanResult, ErrorInfo, UBInfo};
+use crate::errors::{BorsanResult, UBInfo};
 use crate::memory::hooks::BsanAllocHooks;
 use crate::span::Span;
-use crate::{throw_ub, AllocId, AllocInfo, BorTag, GlobalCtx, LocalCtx, Provenance};
+use crate::{throw_ub, AllocId, BorTag, GlobalCtx, LocalCtx, Provenance};
 
 pub mod tree;
 pub mod unimap;
@@ -32,6 +31,7 @@ impl BorrowTracker {
     fn lock_mut(&mut self) -> MutexGuard<'_, Option<Tree<BsanAllocHooks>>> {
         unsafe { (*self.prov.alloc_info).tree_lock.lock() }
     }
+
     /// # Safety
     /// Takes in provenance pointer that is checked via debug_asserts
     pub fn new(
@@ -91,8 +91,8 @@ impl BorrowTracker {
             // We register the protection in two different places.
             // This makes creating a protector slower, but checking whether a tag
             // is protected faster.
-            //global_ctx.add_protected_tag(new_tag, protect);
-            local_ctx.add_protected_tag(new_tag);
+            global_ctx.add_protected_tag(new_tag, protect);
+            local_ctx.protected_tags.push(new_tag)?;
         }
 
         if retag_info.size == 0 {
@@ -187,7 +187,7 @@ impl BorrowTracker {
         let range = self.range;
 
         let mut lock = self.lock_mut();
-        let mut tree = unsafe { lock.take().unwrap() };
+        let mut tree = lock.take().unwrap();
         drop(lock);
 
         tree.dealloc(
@@ -203,7 +203,6 @@ impl BorrowTracker {
         let info = unsafe { &mut *self.prov.alloc_info };
         info.alloc_id = AllocId::invalid();
         unsafe { global_ctx.deallocate_lock_location(self.prov.alloc_info) };
-
         Ok(())
     }
 }

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -5,7 +5,6 @@ use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use core::sync::atomic::AtomicUsize;
 
-use backtrace::Backtrace;
 use bsan_shared::ProtectorKind;
 use hashbrown::{DefaultHashBuilder, HashMap};
 
@@ -109,7 +108,6 @@ impl GlobalCtx {
         let mut tag_map = self.protected_tags.lock();
         for tag in bor_tags {
             if *tag != BorTag(0) {
-                crate::eprintln!("Removing tag {:?}", tag);
                 tag_map.remove(tag);
             }
         }
@@ -122,7 +120,6 @@ impl GlobalCtx {
 
     pub fn handle_error(&self, info: ErrorInfo) -> ! {
         crate::eprintln!("An error occurred: {info:?}\n\nExiting...");
-        crate::eprintln!("{:?}", Backtrace::new());
         self.exit(1)
     }
 }

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(test), no_std)]
 #![allow(internal_features)]
-#![allow(unused)]
 #![warn(clippy::transmute_ptr_to_ptr)]
 #![warn(clippy::borrow_as_ptr)]
 #![feature(sync_unsafe_cell)]
@@ -20,12 +19,12 @@ extern crate alloc;
 use core::cell::UnsafeCell;
 use core::ffi::c_void;
 use core::fmt::Debug;
+use core::mem::MaybeUninit;
 #[cfg(not(test))]
 use core::panic::PanicInfo;
 use core::ptr::NonNull;
-use core::{fmt, num, ptr, slice};
+use core::{fmt, ptr};
 
-use backtrace::Backtrace;
 use bsan_shared::{AccessKind, RetagInfo, Size};
 use libc_print::std_name::*;
 use spin::Mutex;
@@ -45,13 +44,12 @@ mod span;
 use span::Span;
 
 mod memory;
-use memory::hooks::BsanAllocHooks;
 
 mod errors;
 
 use crate::borrow_tracker::tree::Tree;
 use crate::errors::BorsanResult;
-use crate::memory::{hooks, Heapable};
+use crate::memory::hooks;
 
 macro_rules! println {
     ($($arg:tt)*) => {
@@ -282,21 +280,22 @@ static __BSAN_NULL_PROVENANCE: Provenance = Provenance::null();
 #[derive(Debug)]
 #[repr(C)]
 pub struct AllocInfo {
+    /// An identifier for this allocation.
     pub alloc_id: AllocId,
     pub base_addr: FreeListAddrUnion,
     pub size: usize,
     pub tree_lock: Mutex<Option<tree::Tree<hooks::BsanAllocHooks>>>,
 }
 
-/// # Safety
-/// Values of type `AllocInfo` can fit within the size of a heap chunk.
-unsafe impl Heapable<AllocInfo> for AllocInfo {
-    fn next(&mut self) -> *mut Option<NonNull<AllocInfo>> {
-        // we are re-using the space of base_addr to store the free list pointer
-        // SAFETY: this is safe because both union fields are raw pointers
-        unsafe { &raw mut self.base_addr.free_list_next }
+impl AllocInfo {
+    unsafe fn force_dealloc(&mut self) {
+        self.alloc_id = AllocId::invalid();
+        self.base_addr = FreeListAddrUnion { base_addr: ptr::null_mut() };
+        self.size = 0;
+        self.tree_lock.lock().take();
     }
 }
+
 /// Initializes the global state of the runtime library.
 /// The safety of this library is entirely dependent on this
 /// function having been executed. We assume the global invariant that
@@ -520,62 +519,92 @@ unsafe extern "C-unwind" fn __bsan_shadow_store_vector(
         .unwrap_or_else(|info| ctx.handle_error(info.into()));
 }
 
-/// Creates metadata for a dynamic stack allocation
+/// Reserves a stack slot for allocation metadata.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_alloc_stack(
+unsafe extern "C" fn __bsan_reserve_stack_slot() -> NonNull<AllocInfo> {
+    let global_ctx = unsafe { global_ctx() };
+    let local_ctx = unsafe { local_ctx_mut() };
+    local_ctx.allocas.reserve_slots(1).unwrap_or_else(|info| global_ctx.handle_error(info.into()))
+}
+
+/// Initializes stack allocation metadata in-place.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __bsan_alloc_in_place(
     base_addr: *mut c_void,
     size: usize,
     alloc_id: AllocId,
     bor_tag: BorTag,
-) -> NonNull<AllocInfo> {
+    alloc_info: NonNull<MaybeUninit<AllocInfo>>,
+) {
     let ctx = unsafe { global_ctx() };
-    let local_ctx = unsafe { local_ctx_mut() };
-    bsan_alloc_stack(ctx, local_ctx, base_addr, size, alloc_id, bor_tag)
+    bsan_alloc_in_place(ctx, base_addr, size, alloc_id, bor_tag, alloc_info)
         .unwrap_or_else(|info| ctx.handle_error(info))
 }
 
 #[inline]
-fn bsan_alloc_stack(
+fn bsan_alloc_in_place(
     global_ctx: &GlobalCtx,
-    local_ctx: &mut LocalCtx,
     base_addr: *mut c_void,
     size: usize,
     alloc_id: AllocId,
     bor_tag: BorTag,
-) -> BorsanResult<NonNull<AllocInfo>> {
-    let mut alloc_info = local_ctx.allocate_stack_slot(AllocInfo {
-        alloc_id,
-        base_addr: FreeListAddrUnion { base_addr },
-        size,
-        tree_lock: Mutex::new(None),
-    })?;
+    mut alloc_info: NonNull<MaybeUninit<AllocInfo>>,
+) -> BorsanResult<()> {
     unsafe {
-        let mut tree = alloc_info.as_mut().tree_lock.lock();
-        let _ = tree.insert(Tree::new_in(
-            bor_tag,
-            Size::from_bytes(size),
-            Span::new(),
-            global_ctx.allocator(),
-        ));
+        alloc_info.as_mut().write(AllocInfo {
+            alloc_id,
+            base_addr: FreeListAddrUnion { base_addr },
+            size,
+            tree_lock: Mutex::new(Some(Tree::new_in(
+                bor_tag,
+                Size::from_bytes(size),
+                Span::new(),
+                global_ctx.allocator(),
+            ))),
+        });
     }
-    Ok(alloc_info)
+    Ok(())
 }
 
 /// Pushes a stack frame
 #[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_push_frame(_tls_len: usize) {
-    let ctx = unsafe { global_ctx() };
+unsafe extern "C" fn __bsan_push_retag_frame() {
+    let global_ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
-    local_ctx.push_frame().unwrap_or_else(|info| ctx.handle_error(info));
+    local_ctx
+        .protected_tags
+        .push_frame()
+        .unwrap_or_else(|info| global_ctx.handle_error(info.into()));
 }
 
-/// Pops a stack frame, deallocating all metadata for dynamic stack allocations created by `bsan_alloc_stack`
+/// Pushes a stack frame
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_pop_frame() {
-    let local_ctx: &mut LocalCtx = unsafe { local_ctx_mut() };
-    unsafe {
-        local_ctx.pop_frame();
+unsafe extern "C" fn __bsan_push_alloca_frame() {
+    let ctx = unsafe { global_ctx() };
+    let local_ctx = unsafe { local_ctx_mut() };
+    local_ctx
+        .allocas
+        .push_frame()
+        .unwrap_or_else(|info| ctx.handle_error(info.into()))
+}
+
+/// Pushes a stack frame
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __bsan_pop_alloca_frame() {
+    let local_ctx = unsafe { local_ctx_mut() };
+    for info in local_ctx.allocas.current_frame_mut() {
+        unsafe { info.force_dealloc() };
     }
+    unsafe { local_ctx.allocas.pop_frame() }
+}
+
+/// Pushes a stack frame
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __bsan_pop_retag_frame() {
+    let global_ctx: &GlobalCtx = unsafe { global_ctx() };
+    let local_ctx = unsafe { local_ctx_mut() };
+    global_ctx.remove_protected_tags(local_ctx.protected_tags.current_frame());
+    unsafe { local_ctx.protected_tags.pop_frame() }
 }
 
 /// Marks the borrow tag for `prov` as "exposed," allowing it to be resolved to
@@ -645,9 +674,17 @@ extern "C" fn __bsan_debug_print(alloc_id: AllocId, bor_tag: BorTag, alloc_info:
     crate::println!("{prov:?}");
 }
 
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(info: &PanicInfo<'_>) -> ! {
+    crate::eprintln!("The BorrowSanitizer runtime panicked!");
+    crate::eprintln!("{info}");
+    core::intrinsics::abort()
+}
+
 #[cfg(test)]
-mod test {
-    use super::*;
+mod tests {
+    use crate::*;
 
     fn with_init(unit_test: fn()) {
         unsafe { __bsan_init() };
@@ -751,11 +788,3 @@ mod test {
         });
     }
 }
-/*
-#[cfg(not(test))]
-#[panic_handler]
-fn panic(info: &PanicInfo<'_>) -> ! {
-    crate::eprintln!("The BorrowSanitizer runtime panicked!");
-    crate::eprintln!("{info}");
-    core::intrinsics::abort()
-}*/

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -582,10 +582,7 @@ unsafe extern "C" fn __bsan_push_retag_frame() {
 unsafe extern "C" fn __bsan_push_alloca_frame() {
     let ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
-    local_ctx
-        .allocas
-        .push_frame()
-        .unwrap_or_else(|info| ctx.handle_error(info.into()))
+    local_ctx.allocas.push_frame().unwrap_or_else(|info| ctx.handle_error(info.into()))
 }
 
 /// Pushes a stack frame

--- a/bsan-rt/src/local.rs
+++ b/bsan-rt/src/local.rs
@@ -20,39 +20,16 @@ pub static mut __BSAN_PARAM_TLS: [Provenance; TLS_SIZE] = [Provenance::wildcard(
 #[derive(Debug)]
 pub struct LocalCtx {
     pub thread_id: ThreadId,
-    pub stack: Stack<AllocInfo>,
+    pub allocas: Stack<AllocInfo>,
     pub protected_tags: Stack<BorTag>,
 }
 
 impl LocalCtx {
     pub fn new(ctx: &GlobalCtx) -> BorsanResult<Self> {
         let thread_id = ctx.new_thread_id();
-        let stack = Stack::<AllocInfo>::new(ctx)?;
-        let protected_tags = Stack::<BorTag>::new(ctx)?;
-        Ok(Self { thread_id, stack, protected_tags })
-    }
-
-    #[inline]
-    pub fn push_frame(&mut self) -> BorsanResult<()> {
-        Ok(self.stack.push_frame()?)
-    }
-
-    /// # Safety
-    /// A frame must have been pushed.
-    #[inline]
-    pub unsafe fn pop_frame(&mut self) {
-        unsafe { self.stack.pop_frame() }
-    }
-
-    #[inline]
-    pub fn allocate_stack_slot(&mut self, elem: AllocInfo) -> BorsanResult<NonNull<AllocInfo>> {
-        Ok(self.stack.push(elem)?)
-    }
-
-    #[inline]
-    pub fn add_protected_tag(&mut self, tag: BorTag) -> BorsanResult<()> {
-        let _ = self.protected_tags.push(tag)?;
-        Ok(())
+        let allocas = Stack::<AllocInfo>::new(*ctx.hooks())?;
+        let protected_tags = Stack::<BorTag>::new(*ctx.hooks())?;
+        Ok(Self { thread_id, allocas, protected_tags })
     }
 }
 

--- a/bsan-rt/src/memory/mod.rs
+++ b/bsan-rt/src/memory/mod.rs
@@ -12,7 +12,6 @@ use heap::Heapable;
 
 mod stack;
 pub use stack::Stack;
-use stack::Stackable;
 
 mod shadow;
 use core::ffi::c_void;
@@ -25,18 +24,24 @@ pub use shadow::ShadowHeap;
 use crate::{AllocInfo, BorTag};
 
 /// # Safety
+/// Values must be aligned to the word size of the current platform.
+pub(crate) unsafe trait WordAligned: Sized {
+    fn is_word_aligned() -> bool {
+        mem::align_of::<Self>() == mem::align_of::<usize>()
+    }
+}
+unsafe impl WordAligned for AllocInfo {}
+unsafe impl WordAligned for BorTag {}
+
+/// # Safety
 /// Values of type `AllocInfo` can fit within the size of a heap chunk.
-unsafe impl Heapable<AllocInfo> for AllocInfo {
+unsafe impl Heapable for AllocInfo {
     fn next(&mut self) -> *mut Option<NonNull<AllocInfo>> {
         // we are re-using the space of base_addr to store the free list pointer
         // SAFETY: this is safe because both union fields are raw pointers
         unsafe { &raw mut self.base_addr.free_list_next }
     }
 }
-
-unsafe impl Stackable for AllocInfo {}
-
-unsafe impl Stackable for BorTag {}
 
 /// All of our custom allocators depend on `mmap` and `munmap`. We propagate
 /// any nonzero exit-codes from these functions to the user as errors.
@@ -47,7 +52,6 @@ pub enum AllocError {
     StackOverflow,
     MMapFailed(InternalAllocKind, i32),
     MUnmapFailed(InternalAllocKind, i32),
-    InvalidHeapSize(usize),
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -59,7 +63,6 @@ pub enum InternalAllocKind {
 
 pub(crate) type AllocResult<T> = Result<T, AllocError>;
 
-/// Credit: bumpalo
 #[cold]
 #[inline(never)]
 pub(crate) fn unmap_failed<T>() -> T {
@@ -92,15 +95,6 @@ pub(crate) unsafe fn round_up_to_unchecked(n: usize, divisor: usize) -> usize {
 }
 
 /// Credit: bumpalo
-/// Same as `round_down_to` but preserves pointer provenance.
-#[inline]
-pub(crate) fn round_mut_ptr_down_to<T>(ptr: *mut T, divisor: usize) -> *mut T {
-    debug_assert!(divisor > 0);
-    debug_assert!(divisor.is_power_of_two());
-    ptr.wrapping_sub(ptr as usize & (divisor - 1))
-}
-
-/// Credit: bumpalo
 #[inline]
 pub(crate) unsafe fn round_mut_ptr_up_to_unchecked(ptr: *mut u8, divisor: usize) -> *mut u8 {
     debug_assert!(divisor > 0);
@@ -110,43 +104,13 @@ pub(crate) unsafe fn round_mut_ptr_up_to_unchecked(ptr: *mut u8, divisor: usize)
     unsafe { ptr.add(delta) }
 }
 
-/// # Safety
-/// The pointer must be offset from the beginning of its allocation
-/// by at least `mem::size_of::<B>()` bytes.
-#[inline]
-pub unsafe fn align_down<A, B>(ptr: NonNull<A>) -> NonNull<B> {
-    debug_assert!(ptr.as_ptr().is_aligned());
-    unsafe {
-        let ptr = ptr.cast::<u8>();
-        let ptr = round_mut_ptr_down_to(ptr.as_ptr(), mem::align_of::<B>());
-        let ptr = ptr.cast::<B>();
-        debug_assert!(ptr.is_aligned());
-        NonNull::<B>::new_unchecked(ptr)
-    }
-}
-
-/// # Safety
-/// If the parameter is rounded up to the nearest multiple of `mem::align_of::<B>()`, then it must still\
-/// be within the allocation.
-#[inline]
-pub unsafe fn align_up<A, B>(ptr: NonNull<A>) -> NonNull<B> {
-    debug_assert!(ptr.as_ptr().is_aligned());
-    unsafe {
-        let ptr = ptr.cast::<u8>();
-        let ptr = round_mut_ptr_up_to_unchecked(ptr.as_ptr(), mem::align_of::<B>());
-        let ptr = ptr.cast::<B>();
-        debug_assert!(ptr.is_aligned());
-        NonNull::<B>::new_unchecked(ptr)
-    }
-}
-
 /// A wrapper around `mmap` that converts non-zero exit codes into errors.
 #[inline]
-pub unsafe fn mmap<T>(
+pub unsafe fn mmap(
     mmap: hooks::MMap,
     kind: InternalAllocKind,
     size_bytes: NonZero<usize>,
-) -> AllocResult<NonNull<T>> {
+) -> AllocResult<NonNull<u8>> {
     let size_bytes = size_bytes.get();
     unsafe {
         let ptr = (mmap)(ptr::null_mut(), size_bytes, BSAN_PROT_FLAGS, BSAN_MAP_FLAGS, -1, 0);
@@ -154,7 +118,7 @@ pub unsafe fn mmap<T>(
             let errno = *libc::__errno_location();
             Err(AllocError::MMapFailed(kind, errno))
         } else {
-            Ok(NonNull::<T>::new_unchecked(ptr.cast::<T>()))
+            Ok(NonNull::new_unchecked(ptr.cast()))
         }
     }
 }

--- a/bsan-rt/src/memory/shadow.rs
+++ b/bsan-rt/src/memory/shadow.rs
@@ -117,8 +117,8 @@ impl<T: Sized + Default + Copy> ShadowHeap<T> {
         unsafe {
             let table = {
                 let size_bytes = NonZero::new_unchecked(mem::size_of::<L1Array<T>>());
-                mmap::<L1Array<T>>(hooks.mmap_ptr, InternalAllocKind::ShadowHeap, size_bytes)?
-                    .cast()
+                mmap(hooks.mmap_ptr, InternalAllocKind::ShadowHeap, size_bytes)?
+                    .cast::<L1Array<T>>()
             };
             Ok(Self {
                 table,
@@ -146,9 +146,8 @@ impl<T: Sized + Default + Copy> ShadowHeap<T> {
             let l2_table_ptr: *mut *mut L2Array<T> = &raw mut (*self.table.as_ptr())[idx.l1_index];
             if (*l2_table_ptr).is_null() {
                 let size_bytes = NonZero::new_unchecked(mem::size_of::<T>() * L2_LEN);
-                let l2_page: NonNull<L2Array<T>> =
-                    mmap::<L2Array<T>>(hooks.mmap_ptr, InternalAllocKind::ShadowHeap, size_bytes)?
-                        .cast();
+                let l2_page = mmap(hooks.mmap_ptr, InternalAllocKind::ShadowHeap, size_bytes)?
+                    .cast::<L2Array<T>>();
 
                 *l2_table_ptr = l2_page.as_ptr();
             }

--- a/bsan-rt/src/memory/shadow.rs
+++ b/bsan-rt/src/memory/shadow.rs
@@ -4,7 +4,7 @@ use core::ops::{BitAnd, Shr};
 use core::ptr::NonNull;
 use core::{mem, ptr};
 
-use super::hooks::{BsanAllocHooks, BsanHooks, MUnmap, BSAN_MAP_FLAGS, BSAN_PROT_FLAGS};
+use super::hooks::{BsanAllocHooks, BsanHooks, MUnmap};
 use super::{mmap, munmap};
 use crate::memory::{AllocResult, InternalAllocKind};
 
@@ -117,14 +117,8 @@ impl<T: Sized + Default + Copy> ShadowHeap<T> {
         unsafe {
             let table = {
                 let size_bytes = NonZero::new_unchecked(mem::size_of::<L1Array<T>>());
-                mmap::<L1Array<T>>(
-                    hooks.mmap_ptr,
-                    InternalAllocKind::ShadowHeap,
-                    size_bytes,
-                    BSAN_PROT_FLAGS,
-                    BSAN_MAP_FLAGS,
-                )?
-                .cast()
+                mmap::<L1Array<T>>(hooks.mmap_ptr, InternalAllocKind::ShadowHeap, size_bytes)?
+                    .cast()
             };
             Ok(Self {
                 table,
@@ -152,14 +146,9 @@ impl<T: Sized + Default + Copy> ShadowHeap<T> {
             let l2_table_ptr: *mut *mut L2Array<T> = &raw mut (*self.table.as_ptr())[idx.l1_index];
             if (*l2_table_ptr).is_null() {
                 let size_bytes = NonZero::new_unchecked(mem::size_of::<T>() * L2_LEN);
-                let l2_page: NonNull<L2Array<T>> = mmap::<L2Array<T>>(
-                    hooks.mmap_ptr,
-                    InternalAllocKind::ShadowHeap,
-                    size_bytes,
-                    BSAN_PROT_FLAGS,
-                    BSAN_MAP_FLAGS,
-                )?
-                .cast();
+                let l2_page: NonNull<L2Array<T>> =
+                    mmap::<L2Array<T>>(hooks.mmap_ptr, InternalAllocKind::ShadowHeap, size_bytes)?
+                        .cast();
 
                 *l2_table_ptr = l2_page.as_ptr();
             }

--- a/bsan-rt/src/memory/stack.rs
+++ b/bsan-rt/src/memory/stack.rs
@@ -1,54 +1,129 @@
 use core::marker::PhantomData;
-use core::mem;
+use core::mem::{self, MaybeUninit};
 use core::num::NonZero;
-use core::option::Iter;
+use core::ops::Deref;
 
-use super::{align_down, align_up};
-use crate::memory::hooks::{MMap, MUnmap};
-use crate::memory::{
-    allocation_size_overflow, round_up_to, unmap_failed, AllocResult, Chunk, InternalAllocKind,
-    TYPICAL_PAGE_SIZE,
-};
-use crate::{ptr, Debug, GlobalCtx, NonNull};
+use libc::rlimit;
 
-static DEFAULT_CHUNK_SIZE: NonZero<usize> = TYPICAL_PAGE_SIZE;
-
-#[derive(Debug)]
-pub struct Stack<T: Sized> {
-    chunk: StackChunk<T>,
-    checkpoint: *mut Checkpoint<T>,
-    mmap: MMap,
-    munmap: MUnmap,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct Checkpoint<T> {
-    limit: NonNull<T>,
-    prev_checkpoint: *mut Checkpoint<T>,
-}
+use crate::memory::hooks::{BsanHooks, MUnmap};
+use crate::memory::{mmap, munmap, unmap_failed, AllocError, AllocResult, InternalAllocKind};
+use crate::{ptr, Debug, NonNull};
 
 #[derive(Debug, Copy, Clone)]
-pub(crate) struct StackHeader {
-    raw_chunk: Chunk,
-    prev_header: Option<NonNull<StackHeader>>,
+struct StackSize(NonZero<usize>);
+
+impl Deref for StackSize {
+    type Target = NonZero<usize>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
-impl<T: Sized> Stack<T> {
-    pub fn new(ctx: &GlobalCtx) -> AllocResult<Self> {
-        let mmap = ctx.hooks().mmap_ptr;
-        let munmap = ctx.hooks().munmap_ptr;
-        let chunk = unsafe { StackChunk::<T>::new(mmap, None) }?;
-        Ok(Self { chunk, checkpoint: ptr::null_mut(), mmap, munmap })
+impl StackSize {
+    fn try_new() -> AllocResult<Self> {
+        let mut limits = MaybeUninit::<rlimit>::uninit();
+        #[cfg(not(miri))]
+        let exit_code = unsafe { libc::getrlimit(libc::RLIMIT_STACK, limits.as_mut_ptr()) };
+
+        #[cfg(miri)]
+        let exit_code = unsafe {
+            (*limits.as_mut_ptr()).rlim_cur = 1024;
+            (*limits.as_mut_ptr()).rlim_max = 1024;
+            0
+        };
+
+        let stack_size_bytes = if exit_code != 0 {
+            panic!("Failed to obtain stack size limit.");
+        } else {
+            let limits = unsafe { MaybeUninit::assume_init(limits) };
+            limits.rlim_cur as usize
+        };
+
+        NonZero::try_from(stack_size_bytes).map(Self).map_err(|_| AllocError::InvalidStackSize)
+    }
+}
+
+/// Types that can be allocated via a `Stack`.
+///
+/// # Safety
+/// `Stackable` types must be word-aligned.
+pub unsafe trait Stackable: Sized {
+    fn is_stackable() -> bool {
+        mem::align_of::<Self>() == mem::align_of::<usize>()
+    }
+}
+
+#[repr(align(8))]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Checkpoint {
+    prev_checkpoint: *mut Checkpoint,
+}
+
+unsafe impl Stackable for Checkpoint {}
+
+#[derive(Debug)]
+pub struct Stack<T: Stackable> {
+    cursor: NonNull<usize>,
+    limit: NonNull<usize>,
+    size: StackSize,
+    checkpoint: *mut Checkpoint,
+    munmap_ptr: MUnmap,
+    data: PhantomData<*mut T>,
+}
+
+impl<T: Stackable> Stack<T> {
+    pub fn new(hooks: BsanHooks) -> AllocResult<Self> {
+        assert!(T::is_stackable());
+
+        let munmap_ptr = hooks.munmap_ptr;
+
+        let size = StackSize::try_new()?;
+
+        let limit = unsafe { mmap(hooks.mmap_ptr, InternalAllocKind::Stack, *size)? };
+        debug_assert!(limit.is_aligned());
+
+        let cursor = unsafe { limit.byte_add((*size).into()) };
+        debug_assert!(cursor.is_aligned());
+
+        let mut stack = Self {
+            cursor,
+            limit,
+            size,
+            munmap_ptr,
+            checkpoint: ptr::null_mut(),
+            data: PhantomData,
+        };
+        stack.push_frame()?;
+        Ok(stack)
+    }
+
+    fn next<B: Stackable>(&mut self) -> AllocResult<NonNull<B>> {
+        self.extend(1)
+    }
+
+    fn extend<B: Stackable>(&mut self, num_elems: usize) -> AllocResult<NonNull<B>> {
+        debug_assert!(B::is_stackable());
+        let capacity = self.cursor.as_ptr() as usize - self.limit.as_ptr() as usize;
+        if (size_of::<B>() * num_elems) > capacity {
+            Err(AllocError::StackOverflow)
+        } else {
+            let next = unsafe { self.cursor.cast::<B>().sub(num_elems) };
+            self.cursor = next.cast::<usize>();
+            Ok(next)
+        }
     }
 
     pub fn push_frame(&mut self) -> AllocResult<()> {
-        let next_checkpoint = self.chunk.next::<Checkpoint<T>>(self.mmap)?;
-        unsafe {
-            next_checkpoint
-                .write(Checkpoint { limit: self.chunk.limit, prev_checkpoint: self.checkpoint })
-        };
+        let next_checkpoint = self.next::<Checkpoint>()?;
+        unsafe { next_checkpoint.write(Checkpoint { prev_checkpoint: self.checkpoint }) };
         self.checkpoint = next_checkpoint.as_ptr();
         Ok(())
+    }
+
+    pub fn push_frame_with(&mut self, num_elems: usize) -> AllocResult<NonNull<T>> {
+        self.push_frame()?;
+        self.reserve_slots(num_elems)
     }
 
     /// # Safety
@@ -56,141 +131,168 @@ impl<T: Sized> Stack<T> {
     pub unsafe fn pop_frame(&mut self) {
         debug_assert!(!self.checkpoint.is_null());
         let slot = unsafe { NonNull::new_unchecked(self.checkpoint) };
-        self.chunk.cursor = unsafe { align_up::<Checkpoint<T>, T>(slot.add(1)) };
+        self.cursor = unsafe { slot.add(1).cast::<usize>() };
         self.checkpoint = unsafe { slot.as_ref().prev_checkpoint };
-        self.chunk.limit = unsafe { slot.as_ref().limit };
     }
 
     pub fn push(&mut self, elem: T) -> AllocResult<NonNull<T>> {
-        let slot = self.chunk.next::<T>(self.mmap)?;
+        let slot = self.next::<T>()?;
         unsafe { slot.write(elem) };
         Ok(slot)
     }
-}
 
-#[derive(Debug)]
-struct StackChunk<T> {
-    header: NonNull<StackHeader>,
-    cursor: NonNull<T>,
-    limit: NonNull<T>,
-    data: PhantomData<*mut T>,
-}
-
-impl<T> StackChunk<T> {
-    const OVERHEAD: NonZero<usize> =
-        NonZero::new(mem::size_of::<StackHeader>() + mem::size_of::<Checkpoint<T>>()).unwrap();
-
-    unsafe fn new(mmap_ptr: MMap, prev_header: Option<NonNull<StackHeader>>) -> AllocResult<Self> {
-        let size = if let Some(prev_header) = prev_header {
-            unsafe { prev_header.as_ref().raw_chunk.size }
-        } else if mem::size_of::<T>() > DEFAULT_CHUNK_SIZE.get() {
-            let minimum_size = Self::OVERHEAD
-                .checked_add(mem::size_of::<T>())
-                .unwrap_or_else(allocation_size_overflow);
-
-            let next_page_multiple = round_up_to(minimum_size.get(), TYPICAL_PAGE_SIZE.get())
-                .unwrap_or_else(allocation_size_overflow);
-
-            // The result of rounding a non-zero number up to the nearest multiple of another non-zero
-            // number will also be non-zero, unless we overflow, but that will cause a panic.
-            unsafe { NonZero::new_unchecked(next_page_multiple) }
-        } else {
-            DEFAULT_CHUNK_SIZE
-        };
-
-        let raw_chunk = Chunk::new(mmap_ptr, size, InternalAllocKind::Stack)?;
-
-        let header = unsafe {
-            let high_end = raw_chunk.base_address.add(size.into());
-            align_down::<u8, StackHeader>(high_end).sub(1)
-        };
-
-        let cursor = unsafe { align_down::<StackHeader, T>(header) };
-        let limit = unsafe { align_up::<u8, T>(raw_chunk.base_address) };
-
-        unsafe {
-            header.write(StackHeader { raw_chunk, prev_header });
-        }
-
-        Ok(Self { header, cursor, limit, data: PhantomData })
+    pub fn reserve_slots(&mut self, num_elems: usize) -> AllocResult<NonNull<T>> {
+        self.extend::<T>(num_elems)
     }
 
-    fn next<B: Sized>(&mut self, mmap: MMap) -> AllocResult<NonNull<B>> {
-        let capacity = self.cursor.as_ptr() as usize - self.limit.as_ptr() as usize;
-        if size_of::<B>() > capacity {
-            *self = unsafe { StackChunk::<T>::new(mmap, Some(self.header))? };
-        }
-        let next = unsafe { align_down::<T, B>(self.cursor).sub(1) };
-        self.cursor = unsafe { align_down::<B, T>(next) };
-        Ok(next)
+    pub(crate) fn frame_len(&self) -> usize {
+        let cursor = self.cursor.cast::<T>().as_ptr();
+        let checkpoint = self.checkpoint.cast::<T>();
+        unsafe { checkpoint.offset_from_unsigned(cursor) }
+    }
+
+    pub fn current_frame(&self) -> &[T] {
+        let cursor = self.cursor.cast::<T>();
+        unsafe { core::slice::from_raw_parts(cursor.as_ptr(), self.frame_len()) }
+    }
+
+    pub fn current_frame_mut(&self) -> &mut [T] {
+        let cursor = self.cursor.cast::<T>();
+        unsafe { core::slice::from_raw_parts_mut(cursor.as_ptr(), self.frame_len()) }
     }
 }
 
-impl<T> Drop for Stack<T> {
+impl<T: Stackable> Drop for Stack<T> {
     fn drop(&mut self) {
-        let mut current_header = Some(unsafe { *self.chunk.header.as_ptr() });
-        while let Some(header) = current_header {
-            current_header = header.prev_header.map(|prev| unsafe { prev.read() });
-            header
-                .raw_chunk
-                .dispose(self.munmap, InternalAllocKind::Stack)
-                .unwrap_or_else(|_| unmap_failed());
+        unsafe {
+            munmap(self.munmap_ptr, InternalAllocKind::Stack, self.limit, *self.size)
+                .unwrap_or_else(|_| unmap_failed())
         }
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::Stack;
+    use super::{Stack, StackSize};
     use crate::memory::hooks::DEFAULT_HOOKS;
+    use crate::memory::stack::{Checkpoint, Stackable};
     use crate::memory::AllocResult;
     use crate::*;
 
-    fn test_info() -> AllocInfo {
+    fn test_info(size: usize) -> AllocInfo {
         AllocInfo {
             alloc_id: AllocId::invalid(),
             base_addr: FreeListAddrUnion { base_addr: core::ptr::null_mut() },
-            size: 0,
+            size,
             tree_lock: Mutex::new(None),
         }
     }
 
     #[test]
-    fn create_stack() {
-        let global_ctx = unsafe { init_global_ctx(DEFAULT_HOOKS) };
-        let _ = Stack::<AllocInfo>::new(global_ctx);
+    fn create_stack_size() -> AllocResult<()> {
+        assert!(StackSize::try_new()?.get() > 0);
+        Ok(())
+    }
+
+    #[test]
+    fn create_stack() -> AllocResult<()> {
+        let _ = Stack::<AllocInfo>::new(DEFAULT_HOOKS)?;
+        Ok(())
+    }
+
+    #[test]
+    fn empty_frame() -> AllocResult<()> {
+        let stack = Stack::<AllocInfo>::new(DEFAULT_HOOKS)?;
+        assert_eq!(stack.frame_len(), 0);
+        Ok(())
     }
 
     #[test]
     fn push_then_pop() -> AllocResult<()> {
-        let global_ctx = unsafe { init_global_ctx(DEFAULT_HOOKS) };
-        let mut prov = Stack::<AllocInfo>::new(global_ctx)?;
+        let mut prov = Stack::<AllocInfo>::new(DEFAULT_HOOKS)?;
         unsafe {
             prov.push_frame()?;
-            prov.push(test_info())?;
+            prov.push(test_info(0))?;
             prov.pop_frame();
         }
         Ok(())
     }
 
     #[test]
+    fn push_without_frame() -> AllocResult<()> {
+        let mut prov = Stack::<AllocInfo>::new(DEFAULT_HOOKS)?;
+        prov.push(test_info(5))?;
+        let frame = prov.current_frame();
+        assert_eq!(frame.len(), 1);
+        assert_eq!(frame[0].size, 5);
+        Ok(())
+    }
+
+    #[test]
+    fn read_frame_contents() -> AllocResult<()> {
+        let mut prov = Stack::<AllocInfo>::new(DEFAULT_HOOKS)?;
+        prov.push_frame()?;
+
+        for i in 0..10 {
+            prov.push(test_info(i))?;
+        }
+
+        assert_eq!(prov.frame_len(), 10);
+
+        unsafe { prov.pop_frame() };
+
+        assert_eq!(prov.frame_len(), 0);
+
+        prov.push_frame()?;
+
+        for i in 10..20 {
+            prov.push(test_info(i))?;
+        }
+
+        let frame = prov.current_frame();
+        assert_eq!(frame.len(), 10);
+        for (i, info) in frame.iter().enumerate() {
+            crate::println!("{i:?}");
+            assert_eq!(info.size, 19 - i);
+        }
+
+        unsafe { prov.pop_frame() };
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(not(miri))]
     fn smoke() -> AllocResult<()> {
-        let global_ctx = unsafe { init_global_ctx(DEFAULT_HOOKS) };
-        let mut prov = Stack::<AllocInfo>::new(global_ctx)?;
+        let mut prov = Stack::<AllocInfo>::new(DEFAULT_HOOKS)?;
         prov.push_frame()?;
         for _ in 0..1000 {
-            prov.push(test_info())?;
+            prov.push(test_info(0))?;
         }
         prov.push_frame()?;
         unsafe { prov.pop_frame() };
         prov.push_frame()?;
         for _ in 0..1000 {
-            prov.push(test_info())?;
+            prov.push(test_info(0))?;
         }
         unsafe {
             prov.pop_frame();
             prov.pop_frame();
         }
         Ok(())
+    }
+
+    #[test]
+    fn stackable_alloc_info() {
+        assert!(AllocInfo::is_stackable());
+    }
+
+    #[test]
+    fn stackable_bor_tag() {
+        assert!(BorTag::is_stackable());
+    }
+
+    #[test]
+    fn stackable_checkpoint() {
+        assert!(Checkpoint::is_stackable());
     }
 }


### PR DESCRIPTION
Refactors `Stack` to use an entire 8 MB virtual mapping instead of a linked list of blocks. Hopefully this will have performance benefits, and it makes it easier to iterate over the contents of a frame. 

With this change, we now have support for dynamic `alloca` instructions, and I re-enabled protectors. We store the `AllocInfo` and protected `BorTags` in two separate stacks, which are pushed and popped independently. This lets us remove checks in cases where a function adds protectors to reference-type arguments but does *not* allocate stack space, or vice versa.