### PR TITLE
Update to 1.91.0 and temporarily disable retags.

### DIFF
--- a/bsan-driver/src/callbacks.rs
+++ b/bsan-driver/src/callbacks.rs
@@ -19,7 +19,7 @@ fn override_queries(_sess: &Session, providers: &mut Providers) {
 fn retag_perm<'tcx>(
     tcx: TyCtxt<'tcx>,
     key: (TypingEnv<'tcx>, Ty<'tcx>, Ty<'tcx>, RetagParams),
-) -> Option<(u64, bool)> {
+) -> Option<u64> {
     let (env, pointer_ty, pointee_ty, params) = key;
     let ty_is_freeze = pointee_ty.is_freeze(tcx, env);
     let ty_is_unpin = pointee_ty.is_unpin(tcx, env);
@@ -27,11 +27,11 @@ fn retag_perm<'tcx>(
     let info = match pointer_ty.kind() {
         ty::Ref(_, _, mutability) => {
             let (perm_kind, access_kind) = match mutability {
-                Mutability::Not if ty_is_unpin => (
+                Mutability::Mut if ty_is_unpin => (
                     Permission::new_reserved(ty_is_freeze && !params.in_unsafe_cell, is_protected),
                     Some(AccessKind::Read),
                 ),
-                Mutability::Mut if ty_is_freeze => {
+                Mutability::Not if ty_is_freeze => {
                     if params.in_unsafe_cell {
                         (Permission::new_cell(), None)
                     } else {
@@ -57,10 +57,5 @@ fn retag_perm<'tcx>(
         }
         _ => return None,
     };
-
-    let as_data = PermissionInfo::into_raw(info);
-    let as_struct = unsafe { PermissionInfo::from_raw(as_data) };
-    assert!(as_struct == info);
-
-    Some((PermissionInfo::into_raw(info), info.protector_kind.is_some()))
+    Some(PermissionInfo::into_raw(info))
 }

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -658,7 +658,7 @@ struct BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
         if(NumFnEntryRetags > 0) {
             FnPrologueStart = IRB.CreateCall(BS.BsanFuncPushRetagFrame, {});
         }else{
-            FnPrologueStart = IRB.CreateIntrinsic(Intrinsic::donothing, {}, {});
+            FnPrologueStart = IRB.CreateIntrinsic(Intrinsic::donothing, {});
         }
     }
 
@@ -737,12 +737,13 @@ struct BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
         }
         if (CallBase::classof(&I)) {
             CallBase *CB = dyn_cast<CallBase>(&I);
+            /*
             if(CB->getIntrinsicID() == Intrinsic::retag) {
                 assert(CB->arg_size() > 0 && "Missing arguments to retag.");
                 if(isFnEntryRetag(CB)) {
                     NumFnEntryRetags += 1;
                 }
-            }
+            }*/
         }
         Instructions.push_back(&I);
     }
@@ -909,11 +910,7 @@ struct BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
         }
     }
 
-    void visitIntrinsicInst(IntrinsicInst &I) {
-        if(I.getIntrinsicID() == Intrinsic::retag) {
-            instrumentRetag(I);
-        }
-    }
+    void visitIntrinsicInst(IntrinsicInst &I) {}
 
     void instrumentRetag(IntrinsicInst &I) {
         IRBuilder<> IRB(&I);

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -3,7 +3,6 @@
 #![warn(clippy::transmute_ptr_to_ptr)]
 #![warn(clippy::borrow_as_ptr)]
 #![feature(sync_unsafe_cell)]
-#![feature(strict_overflow_ops)]
 #![feature(thread_local)]
 #![feature(allocator_api)]
 #![feature(alloc_layout_extra)]

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.90.0-dev-06969f4"
-sha = "06969f46ec42538addbe7daab1db367a5edbb5cb"
-version = "1.90.0-dev"
+tag = "rolling-1.91.0-dev-936ff31"
+sha = "936ff31a2762709ce299990ef0965ccfd7b2522b"
+version = "1.91.0-dev"
 dependencies = ["cmake", "ninja", "curl"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
Pushing too many releases of our fork of `rustc` broke CI, since we only keep the last 12 versions. This temporarily updates to the latest version while disabling retags, while we put the finishing touches on our new changes to `rustc_codegen_ssa`.