### PR TITLE
Added basic debug logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,10 +176,12 @@ name = "bsan_rt"
 version = "0.1.0"
 dependencies = [
  "bsan-shared",
+ "env_logger",
  "foldhash",
  "hashbrown",
  "libc",
  "libc-print",
+ "log",
  "rustc-hash",
  "spin",
  "thiserror-no-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,12 +176,10 @@ name = "bsan_rt"
 version = "0.1.0"
 dependencies = [
  "bsan-shared",
- "env_logger",
  "foldhash",
  "hashbrown",
  "libc",
  "libc-print",
- "log",
  "rustc-hash",
  "spin",
  "thiserror-no-std",

--- a/bsan-rt/Cargo.toml
+++ b/bsan-rt/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 ui_test = []
+debug = []
 
 [dependencies]
 libc = { version = "0.2.174", default-features = false }
@@ -15,6 +16,8 @@ bsan-shared = { path = "../bsan-shared" }
 spin = "0.10.0"
 thiserror-no-std = "2.0.2"
 foldhash = { version = "0.1.5", default-features = false }
+env_logger = "0.11.8"
+log = "0.4.27"
 
 [lib]
 name = "bsan_rt"

--- a/bsan-rt/Cargo.toml
+++ b/bsan-rt/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 
 [features]
 ui_test = []
-debug = []
 
 [dependencies]
 libc = { version = "0.2.174", default-features = false }
@@ -16,8 +15,8 @@ bsan-shared = { path = "../bsan-shared" }
 spin = "0.10.0"
 thiserror-no-std = "2.0.2"
 foldhash = { version = "0.1.5", default-features = false }
-env_logger = "0.11.8"
-log = "0.4.27"
+env_logger = { version = "0.11.8", default-features = false }
+log = { version = "0.4.27", default-features = false }
 
 [lib]
 name = "bsan_rt"

--- a/bsan-rt/Cargo.toml
+++ b/bsan-rt/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [features]
 ui_test = []
+debug = []
 
 [dependencies]
 libc = { version = "0.2.174", default-features = false }
@@ -15,8 +16,6 @@ bsan-shared = { path = "../bsan-shared" }
 spin = "0.10.0"
 thiserror-no-std = "2.0.2"
 foldhash = { version = "0.1.5", default-features = false }
-env_logger = { version = "0.11.8", default-features = false }
-log = { version = "0.4.27", default-features = false }
 
 [lib]
 name = "bsan_rt"

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -84,29 +84,37 @@ struct DebugSummary {
 #[cfg(feature = "debug")]
 impl fmt::Display for DebugSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "[{}] 0x{:x} @({:?}, {:?}) -> ({:?}, {:?}, {:?})",
-            self.op,
-            self.ptr,
-            self.alloc_id,
-            self.bor_tag,
-            self.info.alloc_id,
-            self.info.base_addr,
-            self.info.size
-        )
+        match self.info {
+            AllocInfoSummary::WildCard => write!(
+                f, "[{}] 0x{:x} @(*, {:?}) -> (wildcard)",
+                self.op, self.ptr, self.bor_tag),
+            AllocInfoSummary::Null => write!(
+                f, "[{}] 0x{:x} @({:?}, {:?}) -> (null)",
+                self.op, self.ptr, self.alloc_id, self.bor_tag
+            ),
+            AllocInfoSummary::Valid { alloc_id, base_addr, size } => write!(
+                f, "[{}] 0x{:x} @({:?}, {:?}) -> ({:?}, {:?}, {:?})",
+                self.op, self.ptr, self.alloc_id, self.bor_tag, alloc_id, base_addr, size
+            ),
+        }
     }
 }
 
 #[cfg(feature = "debug")]
 macro_rules! debug_bsan {
-    ($op:literal, $ptr:ident, $alloc_id:ident, $bor_tag:ident, $info:expr) => {{
+    ($op:literal, $ptr:ident, $alloc_id:ident, $bor_tag:ident, $alloc_info:expr) => {{
+        #[allow(unused_unsafe)]
+        let info = match $alloc_id.0 {
+            0 => AllocInfoSummary::WildCard,
+            1 => AllocInfoSummary::Null,
+            _ => unsafe { &*$alloc_info }.summarize(),
+        };
         let summary = DebugSummary {
             op: $op,
             ptr: $ptr.addr(),
             alloc_id: $alloc_id,
             bor_tag: $bor_tag,
-            info: $info.summarize(),
+            info,
         };
         println!("{}", summary);
     }};
@@ -343,18 +351,24 @@ impl AllocInfo {
 
     #[cfg(feature = "debug")]
     fn summarize(&self) -> AllocInfoSummary {
-        AllocInfoSummary { alloc_id: self.alloc_id, base_addr: self.base_addr, size: self.size }
+        AllocInfoSummary::Valid {
+            alloc_id: self.alloc_id,
+            base_addr: self.base_addr,
+            size: self.size,
+        }
     }
 }
 
 /// A shallow version of `AllocInfo`, for use in debug logging.
-/// Only difference is it does not include the tree_lock `Mutex` field.
 #[cfg(feature = "debug")]
 #[derive(Debug)]
-pub struct AllocInfoSummary {
-    pub alloc_id: AllocId,
-    pub base_addr: FreeListAddrUnion,
-    pub size: usize,
+pub enum AllocInfoSummary {
+    /// When Prov is wildcard, AllocInfo is invalid
+    WildCard,
+    /// When Prov is null, AllocInfo is invalid
+    Null,
+    /// When Prov is valid, only drop the tree_lock field
+    Valid { alloc_id: AllocId, base_addr: FreeListAddrUnion, size: usize },
 }
 
 /// Initializes the global state of the runtime library.
@@ -392,7 +406,7 @@ unsafe extern "C-unwind" fn __bsan_retag(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) -> BorTag {
-    debug_bsan!("retag", object_addr, alloc_id, bor_tag, unsafe { &*alloc_info });
+    debug_bsan!("retag", object_addr, alloc_id, bor_tag, alloc_info);
     let global_ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
@@ -413,9 +427,10 @@ unsafe extern "C-unwind" fn __bsan_read(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("read", ptr, alloc_id, bor_tag, unsafe { &*alloc_info });
+    debug_bsan!("read", ptr, alloc_id, bor_tag, alloc_info);
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
+
     BorrowTracker::new(prov, ptr, Some(access_size))
         .and_then(|bt| bt.iter().try_for_each(|t| t.access(global_ctx, AccessKind::Read)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
@@ -430,9 +445,10 @@ unsafe extern "C-unwind" fn __bsan_write(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("write", ptr, alloc_id, bor_tag, unsafe { &*alloc_info });
+    debug_bsan!("write", ptr, alloc_id, bor_tag, alloc_info);
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
+
     BorrowTracker::new(prov, ptr, Some(access_size))
         .and_then(|bt| bt.iter().try_for_each(|t| t.access(global_ctx, AccessKind::Write)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
@@ -446,9 +462,10 @@ extern "C" fn __bsan_dealloc(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("dealloc", ptr, alloc_id, bor_tag, unsafe { &*alloc_info });
+    debug_bsan!("dealloc", ptr, alloc_id, bor_tag, alloc_info);
     let global_ctx = unsafe { global_ctx() };
     let prov: Provenance = Provenance { alloc_id, bor_tag, alloc_info };
+
     BorrowTracker::new(prov, ptr, None)
         .and_then(|mut bt| bt.iter_mut().try_for_each(|t| t.dealloc(global_ctx)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
@@ -603,9 +620,13 @@ unsafe extern "C" fn __bsan_alloc_in_place(
     bor_tag: BorTag,
     alloc_info: NonNull<MaybeUninit<AllocInfo>>,
 ) {
-    debug_bsan!("alloc_in_place", base_addr, alloc_id, bor_tag, unsafe {
-        &*alloc_info.as_ptr().cast::<AllocInfo>()
-    });
+    debug_bsan!(
+        "alloc_in_place",
+        base_addr,
+        alloc_id,
+        bor_tag,
+        alloc_info.as_ptr().cast::<AllocInfo>()
+    );
     let ctx = unsafe { global_ctx() };
     bsan_alloc_in_place(ctx, base_addr, size, alloc_id, bor_tag, alloc_info)
         .unwrap_or_else(|info| ctx.handle_error(info))

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -26,6 +26,7 @@ use core::{fmt, ptr};
 
 use bsan_shared::{AccessKind, RetagInfo, Size};
 use libc_print::std_name::*;
+use log::debug;
 use spin::Mutex;
 
 mod global;
@@ -69,6 +70,19 @@ macro_rules! handle_err {
             $gtx.handle_error($err);
         }
     }};
+}
+
+struct DebugSummary {
+    op: &'static str,
+    ptr: usize,
+    alloc_id: AllocId,
+    bor_tag: BorTag,
+}
+
+impl fmt::Display for DebugSummary {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}] {}@({:?}, {:?})", self.op, self.ptr, self.alloc_id, self.bor_tag)
+    }
 }
 
 /// Unique identifier for an allocation
@@ -330,6 +344,7 @@ unsafe extern "C-unwind" fn __bsan_retag(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) -> BorTag {
+    debug!("{}", DebugSummary { op: "retag", ptr: object_addr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
@@ -350,6 +365,7 @@ unsafe extern "C-unwind" fn __bsan_read(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
+    debug!("{}", DebugSummary { op: "read", ptr: ptr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
@@ -366,6 +382,7 @@ unsafe extern "C-unwind" fn __bsan_write(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
+    debug!("{}", DebugSummary { op: "write", ptr: ptr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
@@ -381,6 +398,7 @@ extern "C" fn __bsan_dealloc(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
+    debug!("{}", DebugSummary { op: "dealloc", ptr: ptr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let prov: Provenance = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, None)
@@ -396,6 +414,7 @@ unsafe extern "C-unwind" fn __bsan_alloc(
     alloc_id: AllocId,
     bor_tag: BorTag,
 ) -> NonNull<AllocInfo> {
+    debug!("{}", DebugSummary { op: "alloc", ptr: base_addr.addr(), alloc_id, bor_tag });
     let ctx = unsafe { global_ctx() };
     unsafe {
         bsan_alloc(ctx, base_addr, size, alloc_id, bor_tag)
@@ -670,13 +689,13 @@ extern "C" fn __bsan_debug_print(alloc_id: AllocId, bor_tag: BorTag, alloc_info:
     crate::println!("{prov:?}");
 }
 
-#[cfg(not(test))]
-#[panic_handler]
-fn panic(info: &PanicInfo<'_>) -> ! {
-    crate::eprintln!("The BorrowSanitizer runtime panicked!");
-    crate::eprintln!("{info}");
-    core::intrinsics::abort()
-}
+// #[cfg(not(test))]
+// #[panic_handler]
+// fn panic(info: &PanicInfo<'_>) -> ! {
+//     crate::eprintln!("The BorrowSanitizer runtime panicked!");
+//     crate::eprintln!("{info}");
+//     core::intrinsics::abort()
+// }
 
 #[cfg(test)]
 mod tests {
@@ -765,6 +784,7 @@ mod tests {
     #[test]
     fn bsan_read() {
         with_init(|| {
+            env_logger::Builder::from_default_env().filter_level(log::LevelFilter::Debug).init();
             with_heap_object(|obj: *mut c_void, size: usize| unsafe {
                 let prov = create_metadata(obj, size);
                 __bsan_read(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -593,8 +593,13 @@ unsafe extern "C" fn __bsan_alloc_in_place(
     bor_tag: BorTag,
     alloc_info: NonNull<MaybeUninit<AllocInfo>>,
 ) {
-    debug_bsan!("alloc_in_place", base_addr, alloc_id, bor_tag,
-        unsafe { &*alloc_info.as_ptr().cast::<AllocInfo>() }.summarize());
+    debug_bsan!(
+        "alloc_in_place",
+        base_addr,
+        alloc_id,
+        bor_tag,
+        unsafe { &*alloc_info.as_ptr().cast::<AllocInfo>() }.summarize()
+    );
     let ctx = unsafe { global_ctx() };
     bsan_alloc_in_place(ctx, base_addr, size, alloc_id, bor_tag, alloc_info)
         .unwrap_or_else(|info| ctx.handle_error(info))
@@ -825,7 +830,6 @@ mod tests {
     #[test]
     fn bsan_read() {
         with_init(|| {
-            env_logger::Builder::from_default_env().filter_level(log::LevelFilter::Debug).init();
             with_heap_object(|obj: *mut c_void, size: usize| unsafe {
                 let prov = create_metadata(obj, size);
                 __bsan_read(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);
@@ -837,7 +841,6 @@ mod tests {
     #[test]
     fn bsan_write() {
         with_init(|| {
-            env_logger::Builder::from_default_env().filter_level(log::LevelFilter::Debug).init();
             with_heap_object(|obj, size| unsafe {
                 let prov = create_metadata(obj, size);
                 __bsan_write(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -77,11 +77,22 @@ struct DebugSummary {
     ptr: usize,
     alloc_id: AllocId,
     bor_tag: BorTag,
+    info: AllocInfoSummary,
 }
 
 impl fmt::Display for DebugSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "[{}] {}@({:?}, {:?})", self.op, self.ptr, self.alloc_id, self.bor_tag)
+        write!(
+            f,
+            "[{}] 0x{:x} @({:?}, {:?}) -> ({:?}, {:?}, {:?})",
+            self.op,
+            self.ptr,
+            self.alloc_id,
+            self.bor_tag,
+            self.info.alloc_id,
+            self.info.base_addr,
+            self.info.size
+        )
     }
 }
 
@@ -307,6 +318,19 @@ impl AllocInfo {
         self.size = 0;
         self.tree_lock.lock().take();
     }
+
+    fn summary(&self) -> AllocInfoSummary {
+        AllocInfoSummary { alloc_id: self.alloc_id, base_addr: self.base_addr, size: self.size }
+    }
+}
+
+/// A shallow version of `AllocInfo`, for use in debug logging.
+/// Only difference is it does not include the tree_lock `Mutex` field.
+#[derive(Debug)]
+pub struct AllocInfoSummary {
+    pub alloc_id: AllocId,
+    pub base_addr: FreeListAddrUnion,
+    pub size: usize,
 }
 
 /// Initializes the global state of the runtime library.
@@ -344,16 +368,26 @@ unsafe extern "C-unwind" fn __bsan_retag(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) -> BorTag {
-    debug!("{}", DebugSummary { op: "retag", ptr: object_addr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     let retag_info = unsafe { RetagInfo::from_raw(access_size, perm) };
 
-    BorrowTracker::new(prov, object_addr, Some(access_size))
+    let bt = BorrowTracker::new(prov, object_addr, Some(access_size))
         .and_then(|opt| opt.map(|bt| bt.retag(global_ctx, local_ctx, retag_info)).transpose())
         .unwrap_or_else(|err| handle_err!(err, global_ctx))
-        .unwrap_or(bor_tag)
+        .unwrap_or(bor_tag);
+    debug!(
+        "{}",
+        DebugSummary {
+            op: "retag",
+            ptr: object_addr.addr(),
+            alloc_id,
+            bor_tag,
+            info: unsafe { alloc_info.as_ref().unwrap().summary() }
+        }
+    );
+    bt // TODO: find a way to not have to do this because of the debug
 }
 
 /// Records a read access of size `access_size` at the given address `addr` using the provenance `prov`.
@@ -365,12 +399,21 @@ unsafe extern "C-unwind" fn __bsan_read(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug!("{}", DebugSummary { op: "read", ptr: ptr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
         .and_then(|bt| bt.iter().try_for_each(|t| t.access(global_ctx, AccessKind::Read)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
+    debug!(
+        "{}",
+        DebugSummary {
+            op: "read",
+            ptr: ptr.addr(),
+            alloc_id,
+            bor_tag,
+            info: unsafe { alloc_info.as_ref().unwrap().summary() }
+        }
+    );
 }
 
 /// Records a write access of size `access_size` at the given address `addr` using the provenance `prov`.
@@ -382,12 +425,21 @@ unsafe extern "C-unwind" fn __bsan_write(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug!("{}", DebugSummary { op: "write", ptr: ptr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
         .and_then(|bt| bt.iter().try_for_each(|t| t.access(global_ctx, AccessKind::Write)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
+    debug!(
+        "{}",
+        DebugSummary {
+            op: "write",
+            ptr: ptr.addr(),
+            alloc_id,
+            bor_tag,
+            info: unsafe { alloc_info.as_ref().unwrap().summary() }
+        }
+    );
 }
 
 /// Deregisters a heap allocation
@@ -398,12 +450,21 @@ extern "C" fn __bsan_dealloc(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug!("{}", DebugSummary { op: "dealloc", ptr: ptr.addr(), alloc_id, bor_tag });
     let global_ctx = unsafe { global_ctx() };
     let prov: Provenance = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, None)
         .and_then(|mut bt| bt.iter_mut().try_for_each(|t| t.dealloc(global_ctx)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
+    debug!(
+        "{}",
+        DebugSummary {
+            op: "dealloc",
+            ptr: ptr.addr(),
+            alloc_id,
+            bor_tag,
+            info: unsafe { alloc_info.as_ref().unwrap().summary() }
+        }
+    );
 }
 
 // Registers a heap allocation of size `size`, storing its provenance in the return pointer.
@@ -414,11 +475,21 @@ unsafe extern "C-unwind" fn __bsan_alloc(
     alloc_id: AllocId,
     bor_tag: BorTag,
 ) -> NonNull<AllocInfo> {
-    debug!("{}", DebugSummary { op: "alloc", ptr: base_addr.addr(), alloc_id, bor_tag });
     let ctx = unsafe { global_ctx() };
     unsafe {
-        bsan_alloc(ctx, base_addr, size, alloc_id, bor_tag)
-            .unwrap_or_else(|info| ctx.handle_error(info))
+        let alloc_info = bsan_alloc(ctx, base_addr, size, alloc_id, bor_tag)
+            .unwrap_or_else(|info| ctx.handle_error(info));
+        debug!(
+            "{}",
+            DebugSummary {
+                op: "alloc",
+                ptr: base_addr.addr(),
+                alloc_id,
+                bor_tag,
+                info: alloc_info.as_ref().summary()
+            }
+        );
+        alloc_info
     }
 }
 

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -85,15 +85,17 @@ struct DebugSummary {
 impl fmt::Display for DebugSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.info {
-            AllocInfoSummary::WildCard => write!(
-                f, "[{}] 0x{:x} @(*, {:?}) -> (wildcard)",
-                self.op, self.ptr, self.bor_tag),
+            AllocInfoSummary::WildCard => {
+                write!(f, "[{}] 0x{:x} @(*, {:?}) -> (wildcard)", self.op, self.ptr, self.bor_tag)
+            }
             AllocInfoSummary::Null => write!(
-                f, "[{}] 0x{:x} @({:?}, {:?}) -> (null)",
+                f,
+                "[{}] 0x{:x} @({:?}, {:?}) -> (null)",
                 self.op, self.ptr, self.alloc_id, self.bor_tag
             ),
             AllocInfoSummary::Valid { alloc_id, base_addr, size } => write!(
-                f, "[{}] 0x{:x} @({:?}, {:?}) -> ({:?}, {:?}, {:?})",
+                f,
+                "[{}] 0x{:x} @({:?}, {:?}) -> ({:?}, {:?}, {:?})",
                 self.op, self.ptr, self.alloc_id, self.bor_tag, alloc_id, base_addr, size
             ),
         }

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -72,6 +72,7 @@ macro_rules! handle_err {
     }};
 }
 
+/// A struct for summarizing debug information about memory operations
 struct DebugSummary {
     op: &'static str,
     ptr: usize,
@@ -94,6 +95,19 @@ impl fmt::Display for DebugSummary {
             self.info.size
         )
     }
+}
+
+macro_rules! debug_bsan {
+    ($op:literal, $ptr:ident, $alloc_id:ident, $bor_tag:ident, $info:expr) => {{
+        let summary = DebugSummary {
+            op: $op,
+            ptr: $ptr.addr(),
+            alloc_id: $alloc_id,
+            bor_tag: $bor_tag,
+            info: $info,
+        };
+        debug!("{}", summary);
+    }};
 }
 
 /// Unique identifier for an allocation
@@ -319,7 +333,7 @@ impl AllocInfo {
         self.tree_lock.lock().take();
     }
 
-    fn summary(&self) -> AllocInfoSummary {
+    fn summarize(&self) -> AllocInfoSummary {
         AllocInfoSummary { alloc_id: self.alloc_id, base_addr: self.base_addr, size: self.size }
     }
 }
@@ -368,26 +382,16 @@ unsafe extern "C-unwind" fn __bsan_retag(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) -> BorTag {
+    debug_bsan!("retag", object_addr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
     let global_ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     let retag_info = unsafe { RetagInfo::from_raw(access_size, perm) };
 
-    let bt = BorrowTracker::new(prov, object_addr, Some(access_size))
+    BorrowTracker::new(prov, object_addr, Some(access_size))
         .and_then(|opt| opt.map(|bt| bt.retag(global_ctx, local_ctx, retag_info)).transpose())
         .unwrap_or_else(|err| handle_err!(err, global_ctx))
-        .unwrap_or(bor_tag);
-    debug!(
-        "{}",
-        DebugSummary {
-            op: "retag",
-            ptr: object_addr.addr(),
-            alloc_id,
-            bor_tag,
-            info: unsafe { alloc_info.as_ref().unwrap().summary() }
-        }
-    );
-    bt // TODO: find a way to not have to do this because of the debug
+        .unwrap_or(bor_tag)
 }
 
 /// Records a read access of size `access_size` at the given address `addr` using the provenance `prov`.
@@ -399,21 +403,12 @@ unsafe extern "C-unwind" fn __bsan_read(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
+    debug_bsan!("read", ptr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
         .and_then(|bt| bt.iter().try_for_each(|t| t.access(global_ctx, AccessKind::Read)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
-    debug!(
-        "{}",
-        DebugSummary {
-            op: "read",
-            ptr: ptr.addr(),
-            alloc_id,
-            bor_tag,
-            info: unsafe { alloc_info.as_ref().unwrap().summary() }
-        }
-    );
 }
 
 /// Records a write access of size `access_size` at the given address `addr` using the provenance `prov`.
@@ -425,21 +420,12 @@ unsafe extern "C-unwind" fn __bsan_write(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
+    debug_bsan!("write", ptr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
         .and_then(|bt| bt.iter().try_for_each(|t| t.access(global_ctx, AccessKind::Write)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
-    debug!(
-        "{}",
-        DebugSummary {
-            op: "write",
-            ptr: ptr.addr(),
-            alloc_id,
-            bor_tag,
-            info: unsafe { alloc_info.as_ref().unwrap().summary() }
-        }
-    );
 }
 
 /// Deregisters a heap allocation
@@ -450,21 +436,12 @@ extern "C" fn __bsan_dealloc(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
+    debug_bsan!("dealloc", ptr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
     let global_ctx = unsafe { global_ctx() };
     let prov: Provenance = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, None)
         .and_then(|mut bt| bt.iter_mut().try_for_each(|t| t.dealloc(global_ctx)))
         .unwrap_or_else(|err| handle_err!(err, global_ctx));
-    debug!(
-        "{}",
-        DebugSummary {
-            op: "dealloc",
-            ptr: ptr.addr(),
-            alloc_id,
-            bor_tag,
-            info: unsafe { alloc_info.as_ref().unwrap().summary() }
-        }
-    );
 }
 
 // Registers a heap allocation of size `size`, storing its provenance in the return pointer.
@@ -479,16 +456,7 @@ unsafe extern "C-unwind" fn __bsan_alloc(
     unsafe {
         let alloc_info = bsan_alloc(ctx, base_addr, size, alloc_id, bor_tag)
             .unwrap_or_else(|info| ctx.handle_error(info));
-        debug!(
-            "{}",
-            DebugSummary {
-                op: "alloc",
-                ptr: base_addr.addr(),
-                alloc_id,
-                bor_tag,
-                info: alloc_info.as_ref().summary()
-            }
-        );
+        debug_bsan!("alloc", base_addr, alloc_id, bor_tag, alloc_info.as_ref().summarize());
         alloc_info
     }
 }
@@ -625,6 +593,8 @@ unsafe extern "C" fn __bsan_alloc_in_place(
     bor_tag: BorTag,
     alloc_info: NonNull<MaybeUninit<AllocInfo>>,
 ) {
+    debug_bsan!("alloc_in_place", base_addr, alloc_id, bor_tag,
+        unsafe { &*alloc_info.as_ptr().cast::<AllocInfo>() }.summarize());
     let ctx = unsafe { global_ctx() };
     bsan_alloc_in_place(ctx, base_addr, size, alloc_id, bor_tag, alloc_info)
         .unwrap_or_else(|info| ctx.handle_error(info))
@@ -867,6 +837,7 @@ mod tests {
     #[test]
     fn bsan_write() {
         with_init(|| {
+            env_logger::Builder::from_default_env().filter_level(log::LevelFilter::Debug).init();
             with_heap_object(|obj, size| unsafe {
                 let prov = create_metadata(obj, size);
                 __bsan_write(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -19,8 +19,8 @@ use core::cell::UnsafeCell;
 use core::ffi::c_void;
 use core::fmt::Debug;
 use core::mem::MaybeUninit;
-#[cfg(not(test))]
-use core::panic::PanicInfo;
+// #[cfg(not(test))]
+// use core::panic::PanicInfo;
 use core::ptr::NonNull;
 use core::{fmt, ptr};
 
@@ -104,7 +104,7 @@ macro_rules! debug_bsan {
             ptr: $ptr.addr(),
             alloc_id: $alloc_id,
             bor_tag: $bor_tag,
-            info: $info,
+            info: $info.summarize(),
         };
         debug!("{}", summary);
     }};
@@ -382,7 +382,7 @@ unsafe extern "C-unwind" fn __bsan_retag(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) -> BorTag {
-    debug_bsan!("retag", object_addr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
+    debug_bsan!("retag", object_addr, alloc_id, bor_tag, unsafe { &*alloc_info });
     let global_ctx = unsafe { global_ctx() };
     let local_ctx = unsafe { local_ctx_mut() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
@@ -403,7 +403,7 @@ unsafe extern "C-unwind" fn __bsan_read(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("read", ptr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
+    debug_bsan!("read", ptr, alloc_id, bor_tag, unsafe { &*alloc_info });
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
@@ -420,7 +420,7 @@ unsafe extern "C-unwind" fn __bsan_write(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("write", ptr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
+    debug_bsan!("write", ptr, alloc_id, bor_tag, unsafe { &*alloc_info });
     let global_ctx = unsafe { global_ctx() };
     let prov = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, Some(access_size))
@@ -436,7 +436,7 @@ extern "C" fn __bsan_dealloc(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("dealloc", ptr, alloc_id, bor_tag, unsafe { &*alloc_info }.summarize());
+    debug_bsan!("dealloc", ptr, alloc_id, bor_tag, unsafe { &*alloc_info });
     let global_ctx = unsafe { global_ctx() };
     let prov: Provenance = Provenance { alloc_id, bor_tag, alloc_info };
     BorrowTracker::new(prov, ptr, None)
@@ -456,7 +456,7 @@ unsafe extern "C-unwind" fn __bsan_alloc(
     unsafe {
         let alloc_info = bsan_alloc(ctx, base_addr, size, alloc_id, bor_tag)
             .unwrap_or_else(|info| ctx.handle_error(info));
-        debug_bsan!("alloc", base_addr, alloc_id, bor_tag, alloc_info.as_ref().summarize());
+        debug_bsan!("alloc", base_addr, alloc_id, bor_tag, alloc_info.as_ref());
         alloc_info
     }
 }
@@ -593,13 +593,9 @@ unsafe extern "C" fn __bsan_alloc_in_place(
     bor_tag: BorTag,
     alloc_info: NonNull<MaybeUninit<AllocInfo>>,
 ) {
-    debug_bsan!(
-        "alloc_in_place",
-        base_addr,
-        alloc_id,
-        bor_tag,
-        unsafe { &*alloc_info.as_ptr().cast::<AllocInfo>() }.summarize()
-    );
+    debug_bsan!("alloc_in_place", base_addr, alloc_id, bor_tag, unsafe {
+        &*alloc_info.as_ptr().cast::<AllocInfo>()
+    });
     let ctx = unsafe { global_ctx() };
     bsan_alloc_in_place(ctx, base_addr, size, alloc_id, bor_tag, alloc_info)
         .unwrap_or_else(|info| ctx.handle_error(info))
@@ -745,7 +741,21 @@ extern "C" fn __bsan_debug_print(alloc_id: AllocId, bor_tag: BorTag, alloc_info:
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Once;
+
     use crate::*;
+
+    static INIT: Once = Once::new();
+
+    fn init_logger() {
+        INIT.call_once(|| {
+            env_logger::builder()
+                .is_test(true)
+                .format_timestamp(None)
+                .filter_level(log::LevelFilter::Debug)
+                .init();
+        });
+    }
 
     fn with_init(unit_test: fn()) {
         unsafe { __bsan_init() };
@@ -776,6 +786,7 @@ mod tests {
     fn bsan_alloc_increasing_alloc_id() {
         with_init(|| {
             with_heap_object(|obj1, size1| {
+                init_logger();
                 let prov1 = create_metadata(obj1, size1);
                 assert_eq!(prov1.alloc_id, AllocId::min());
                 with_heap_object(|obj2, size2| {
@@ -792,6 +803,7 @@ mod tests {
     fn bsan_alloc_and_dealloc() {
         with_init(|| {
             with_heap_object(|obj, size| unsafe {
+                init_logger();
                 let prov = create_metadata(obj, size);
                 destroy_metadata(obj, prov);
                 let alloc_metadata = &*prov.alloc_info;
@@ -831,6 +843,7 @@ mod tests {
     fn bsan_read() {
         with_init(|| {
             with_heap_object(|obj: *mut c_void, size: usize| unsafe {
+                init_logger();
                 let prov = create_metadata(obj, size);
                 __bsan_read(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);
                 destroy_metadata(obj, prov);
@@ -842,6 +855,7 @@ mod tests {
     fn bsan_write() {
         with_init(|| {
             with_heap_object(|obj, size| unsafe {
+                init_logger();
                 let prov = create_metadata(obj, size);
                 __bsan_write(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);
                 destroy_metadata(obj, prov);

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -19,14 +19,13 @@ use core::cell::UnsafeCell;
 use core::ffi::c_void;
 use core::fmt::Debug;
 use core::mem::MaybeUninit;
-// #[cfg(not(test))]
-// use core::panic::PanicInfo;
+#[cfg(not(test))]
+use core::panic::PanicInfo;
 use core::ptr::NonNull;
 use core::{fmt, ptr};
 
 use bsan_shared::{AccessKind, RetagInfo, Size};
 use libc_print::std_name::*;
-use log::debug;
 use spin::Mutex;
 
 mod global;
@@ -73,6 +72,7 @@ macro_rules! handle_err {
 }
 
 /// A struct for summarizing debug information about memory operations
+#[cfg(feature = "debug")]
 struct DebugSummary {
     op: &'static str,
     ptr: usize,
@@ -81,6 +81,7 @@ struct DebugSummary {
     info: AllocInfoSummary,
 }
 
+#[cfg(feature = "debug")]
 impl fmt::Display for DebugSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
@@ -97,6 +98,7 @@ impl fmt::Display for DebugSummary {
     }
 }
 
+#[cfg(feature = "debug")]
 macro_rules! debug_bsan {
     ($op:literal, $ptr:ident, $alloc_id:ident, $bor_tag:ident, $info:expr) => {{
         let summary = DebugSummary {
@@ -106,8 +108,14 @@ macro_rules! debug_bsan {
             bor_tag: $bor_tag,
             info: $info.summarize(),
         };
-        debug!("{}", summary);
+        println!("{}", summary);
     }};
+}
+
+/// No-op macro when debug feature is disabled
+#[cfg(not(feature = "debug"))]
+macro_rules! debug_bsan {
+    ($op:literal, $ptr:ident, $alloc_id:ident, $bor_tag:ident, $info:expr) => {{}};
 }
 
 /// Unique identifier for an allocation
@@ -333,6 +341,7 @@ impl AllocInfo {
         self.tree_lock.lock().take();
     }
 
+    #[cfg(feature = "debug")]
     fn summarize(&self) -> AllocInfoSummary {
         AllocInfoSummary { alloc_id: self.alloc_id, base_addr: self.base_addr, size: self.size }
     }
@@ -340,6 +349,7 @@ impl AllocInfo {
 
 /// A shallow version of `AllocInfo`, for use in debug logging.
 /// Only difference is it does not include the tree_lock `Mutex` field.
+#[cfg(feature = "debug")]
 #[derive(Debug)]
 pub struct AllocInfoSummary {
     pub alloc_id: AllocId,
@@ -731,31 +741,18 @@ extern "C" fn __bsan_debug_print(alloc_id: AllocId, bor_tag: BorTag, alloc_info:
     crate::println!("{prov:?}");
 }
 
-// #[cfg(not(test))]
-// #[panic_handler]
-// fn panic(info: &PanicInfo<'_>) -> ! {
-//     crate::eprintln!("The BorrowSanitizer runtime panicked!");
-//     crate::eprintln!("{info}");
-//     core::intrinsics::abort()
-// }
+#[cfg(not(test))]
+#[panic_handler]
+fn panic(info: &PanicInfo<'_>) -> ! {
+    crate::eprintln!("The BorrowSanitizer runtime panicked!");
+    crate::eprintln!("{info}");
+    core::intrinsics::abort()
+}
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Once;
 
     use crate::*;
-
-    static INIT: Once = Once::new();
-
-    fn init_logger() {
-        INIT.call_once(|| {
-            env_logger::builder()
-                .is_test(true)
-                .format_timestamp(None)
-                .filter_level(log::LevelFilter::Debug)
-                .init();
-        });
-    }
 
     fn with_init(unit_test: fn()) {
         unsafe { __bsan_init() };
@@ -786,7 +783,6 @@ mod tests {
     fn bsan_alloc_increasing_alloc_id() {
         with_init(|| {
             with_heap_object(|obj1, size1| {
-                init_logger();
                 let prov1 = create_metadata(obj1, size1);
                 assert_eq!(prov1.alloc_id, AllocId::min());
                 with_heap_object(|obj2, size2| {
@@ -803,7 +799,6 @@ mod tests {
     fn bsan_alloc_and_dealloc() {
         with_init(|| {
             with_heap_object(|obj, size| unsafe {
-                init_logger();
                 let prov = create_metadata(obj, size);
                 destroy_metadata(obj, prov);
                 let alloc_metadata = &*prov.alloc_info;
@@ -843,7 +838,6 @@ mod tests {
     fn bsan_read() {
         with_init(|| {
             with_heap_object(|obj: *mut c_void, size: usize| unsafe {
-                init_logger();
                 let prov = create_metadata(obj, size);
                 __bsan_read(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);
                 destroy_metadata(obj, prov);
@@ -855,7 +849,6 @@ mod tests {
     fn bsan_write() {
         with_init(|| {
             with_heap_object(|obj, size| unsafe {
-                init_logger();
                 let prov = create_metadata(obj, size);
                 __bsan_write(obj, size, prov.alloc_id, prov.bor_tag, prov.alloc_info);
                 destroy_metadata(obj, prov);

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -129,7 +129,7 @@ impl Command {
         env.sh.set_var("BSAN_SYSROOT", &sysroot_dir);
 
         if debug {
-            env.sh.set_var("RUST_LOG", "bsan-rt=debug");
+            env.sh.set_var("RUST_LOG", "debug");
         }
 
         cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -117,7 +117,13 @@ impl Command {
 
     fn inst(env: &mut BsanEnv, file: String, debug: bool, args: &[String]) -> Result<()> {
         let plugin = env.build_artifact(BsanPass, &[])?;
-        let runtime = env.build_artifact(BsanRt, &[])?;
+
+        let runtime = if debug {
+            env.build_artifact(BsanRt, &["--features".to_string(), "debug".to_string()])?
+        } else {
+            env.build_artifact(BsanRt, &[])?
+        };
+
         let driver = env.build_artifact(BsanDriver, &[])?;
         let cargo_bsan = env.build_artifact(CargoBsan, &[])?;
 
@@ -127,10 +133,6 @@ impl Command {
         env.sh.set_var("BSAN_DRIVER", &driver);
         env.sh.set_var("BSAN_RT_DIR", runtime.parent().unwrap());
         env.sh.set_var("BSAN_SYSROOT", &sysroot_dir);
-
-        if debug {
-            env.sh.set_var("RUST_LOG", "debug");
-        }
 
         cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;
 

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -48,7 +48,7 @@ impl Command {
                 c.miri(env, &args)?;
                 Ok(())
             }),
-            Command::Inst { file, args } => Self::inst(env, file, &args),
+            Command::Inst { file, debug, args } => Self::inst(env, file, debug, &args),
         }
     }
 
@@ -115,7 +115,7 @@ impl Command {
         Ok(())
     }
 
-    fn inst(env: &mut BsanEnv, file: String, args: &[String]) -> Result<()> {
+    fn inst(env: &mut BsanEnv, file: String, debug: bool, args: &[String]) -> Result<()> {
         let plugin = env.build_artifact(BsanPass, &[])?;
         let runtime = env.build_artifact(BsanRt, &[])?;
         let driver = env.build_artifact(BsanDriver, &[])?;
@@ -127,6 +127,10 @@ impl Command {
         env.sh.set_var("BSAN_DRIVER", &driver);
         env.sh.set_var("BSAN_RT_DIR", runtime.parent().unwrap());
         env.sh.set_var("BSAN_SYSROOT", &sysroot_dir);
+
+        if debug {
+            env.sh.set_var("RUST_LOG", "bsan-rt=debug");
+        }
 
         cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;
 

--- a/bsan-script/src/main.rs
+++ b/bsan-script/src/main.rs
@@ -44,6 +44,8 @@ pub enum Command {
     /// Emits both LLVM IR (*.ll) and MIR
     Inst {
         file: String,
+        #[arg(long)]
+        debug: bool,
         #[arg(trailing_var_arg = true, allow_hyphen_values(true))]
         args: Vec<String>,
     },


### PR DESCRIPTION
## Features

- Simple `DebugSummary` struct which implements `Display` for emitting debug logs for the following:
```
__bsan_retag
__bsan_read
__bsan_write
 __bsan_dealloc 
__bsan_alloc 
__bsan_alloc_in_place
```

e.g. running `cargo test --features "debug" --package bsan_rt --lib -- tests::bsan_alloc_increasing_alloc_id --exact --show-output` returns:

```
[DEBUG bsan_rt] [alloc] 0xaaaaf5958b60 @(alloc3, <0>) -> (alloc3, 0xaaaaf5958b60, 64)
[DEBUG bsan_rt] [alloc] 0xffff80001240 @(alloc4, <1>) -> (alloc4, 0xffff80001240, 64)
[DEBUG bsan_rt] [dealloc] 0xffff80001240 @(alloc4, <1>) -> (alloc4, 0xffff80001240, 64)
[DEBUG bsan_rt] [dealloc] 0xaaaaf5958b60 @(alloc3, <0>) -> (alloc3, 0xaaaaf5958b60, 64)
```
- Can be called on operations with the custom `debug_bsan!()` macro
- Should be invoked with `./xb inst --debug program.rs`, theoretically. See TODO

## TODO

- I'm not sure if the `bsan-rt` library is being used anywhere yet, so I haven't had any luck yet in getting the debug statements to appear outside of inline tests. Make sure `println!` in general is still emitted where the library is used.
- ~~Custom panic impl had to be commented out, because `log` uses `std` somehow. Could switch to a more lightweight logging library like https://github.com/knurling-rs/defmt if this breaks stuff~~ switched to `println!`
- Extend to logging `shadow` operations if necessary, + would be nice to toggle them on/off depending on granularity needed
- Extend to `debug_assert` operations if they are used often enough