### PR TITLE
Add `--print-rustflags` to `cargo bsan`

### DIFF
--- a/bsan-driver/src/lib.rs
+++ b/bsan-driver/src/lib.rs
@@ -8,6 +8,7 @@ extern crate rustc_session;
 mod callbacks;
 use std::env;
 use std::path::PathBuf;
+use std::process::exit;
 
 pub use callbacks::BSanCallBacks;
 
@@ -47,13 +48,16 @@ pub struct Config {
 impl Config {
     pub fn new(raw_args: Vec<String>) -> Self {
         let (mut args, target_crate) = {
+            if env::var("PRINT_RUSTFLAGS").is_ok() {
+                println!("{}", Self::bsan_rustflags().join(" "));
+                exit(0);
+            }
             // If the `BSAN_BE_RUSTC` environment variable is set, we are being invoked as
             // rustc to build a crate for either the "target" architecture, or the "host"
             // architecture. In this case, "target" and "host" are the same platform, since we do not
             // support cross-compilation. However, "target" also indicates that the program needs
             // to be instrumented, while "host" indicates that it is a build script or procedural
             // macro, which we can skip.
-
             if let Ok(crate_kind) = env::var("BSAN_BE_RUSTC") {
                 let is_target = match crate_kind.as_str() {
                     "host" => false,
@@ -82,19 +86,21 @@ impl Config {
             }
         };
         if target_crate {
-            let rt = assert_env_file("BSAN_RT", BSAN_RT_EXPECTED);
-            let rt = rt.parent().unwrap().to_path_buf();
-
-            let plugin = assert_env_file("BSAN_PLUGIN", BSAN_PLUGIN_EXPECTED);
-
-            let mut additional_args =
-                BSAN_DEFAULT_ARGS.iter().map(ToString::to_string).collect::<Vec<_>>();
-            additional_args.push(format!("-Zllvm-plugins={}", plugin.display()));
-            additional_args.push(format!("-L{}", rt.display()));
-            additional_args.push("-lstatic=bsan_rt".to_string());
-            args.splice(1..1, additional_args);
+            args.splice(1..1, Self::bsan_rustflags());
         }
         Self { args, callbacks: BSanCallBacks {} }
+    }
+
+    fn bsan_rustflags() -> Vec<String> {
+        let rt = assert_env_file("BSAN_RT", BSAN_RT_EXPECTED);
+        let rt = rt.parent().unwrap().to_path_buf();
+        let plugin = assert_env_file("BSAN_PLUGIN", BSAN_PLUGIN_EXPECTED);
+        let mut additional_args =
+            BSAN_DEFAULT_ARGS.iter().map(ToString::to_string).collect::<Vec<_>>();
+        additional_args.push(format!("-Zllvm-plugins={}", plugin.display()));
+        additional_args.push(format!("-L{}", rt.display()));
+        additional_args.push("-lstatic=bsan_rt".to_string());
+        additional_args
     }
 }
 
@@ -105,11 +111,11 @@ fn assert_env_file(key: &str, expected_file_name: &str) -> PathBuf {
     }
     let rt = PathBuf::from(rt_var.unwrap());
     if !rt.exists() {
-        show_error!("The path specified in `BSAN_RT` does not exist: {}.", rt.display());
+        show_error!("The path specified in `{key}` does not exist: {}.", rt.display());
     }
     if !rt.is_file() || !rt.file_name().unwrap().eq(expected_file_name) {
         show_error!(
-            "Expected `BSAN_RT` to be the path to `{expected_file_name}`, but found: {}",
+            "Expected `{key}` to be the path to `{expected_file_name}`, but found: {}",
             rt.display()
         );
     }

--- a/cargo-bsan/src/main.rs
+++ b/cargo-bsan/src/main.rs
@@ -70,7 +70,6 @@ fn main() {
             "`cargo-bsan` called without first argument; please only invoke this binary through `cargo bsan`"
         )
     };
-
     match first.as_str() {
         "bsan" => {
             phase_cargo_bsan(args)

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -1,4 +1,5 @@
 use std::path;
+use std::path::PathBuf;
 
 use rustc_version::VersionMeta;
 
@@ -16,7 +17,6 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         show_version();
         return;
     }
-
     let Some(subcommand) = args.next() else {
         show_error!(
             "`cargo bsan` needs to be called with a subcommand (e.g `run`, `test`, `clean`)"
@@ -25,10 +25,10 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
 
     let subcommand = match &*subcommand {
         "setup" => BSANCommand::Setup,
-        "test" | "t" | "run" | "r" | "nextest" => BSANCommand::Forward(subcommand),
+        "build" | "test" | "t" | "run" | "r" | "nextest" => BSANCommand::Forward(subcommand),
         "clean" => BSANCommand::Clean,
         _ => show_error!(
-            "`cargo bsan` supports the following subcommands: `run`, `test`, `nextest`, `clean`, and `setup`."
+            "`cargo bsan` supports the following subcommands: `run`, `build`, `test`, `nextest`, `clean`, and `setup`."
         ),
     };
 
@@ -39,26 +39,6 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     let rustc_version = VersionMeta::for_command(bsan_for_host()).unwrap_or_else(|err| {
         panic!("failed to determine underlying rustc version of BSAN ({:?}):\n{err:?}", bsan())
     });
-
-    let host_sysroot = get_host_sysroot_dir(verbose);
-
-    let Some(bsan_plugin) = find_library("BSAN_PLUGIN", &host_sysroot, "libbsan_plugin.so") else {
-        show_error!(
-            "failed to locate the BorrowSanitizer LLVM plugin (libbsan_plugin.so) within the host sysroot."
-        );
-    };
-    unsafe {
-        env::set_var("BSAN_PLUGIN", bsan_plugin);
-    }
-
-    let Some(runtime_dir) = find_library("BSAN_RT", &host_sysroot, "libbsan_rt.a") else {
-        show_error!(
-            "failed to locate the BorrowSanitizer runtime (libbsan_rt.a) within the host sysroot."
-        );
-    };
-    unsafe {
-        env::set_var("BSAN_RT", runtime_dir);
-    }
 
     let targets = get_arg_flag_values("--target").collect::<Vec<_>>();
 
@@ -76,15 +56,22 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         return;
     }
 
-    setup_sysroot(&subcommand, rustc_version.host.as_str(), &rustc_version, verbose, quiet);
-
-    let bsan_sysroot = get_target_sysroot_dir();
+    let bsan_sysroot = ensure_sysroot(&subcommand, &rustc_version, verbose, quiet);
     let bsan_path = find_bsan();
+
+    if let BSANCommand::Setup = subcommand
+        && has_arg_flag("--print-rustflags")
+    {
+        let mut cmd = bsan();
+        cmd.env("PRINT_RUSTFLAGS", "1");
+        debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
+        exec(cmd);
+    }
 
     let cargo_cmd = match subcommand {
         BSANCommand::Forward(s) => s,
-        BSANCommand::Setup => return, // `cargo bsan setup` stops here.
         BSANCommand::Clean => unreachable!(),
+        BSANCommand::Setup => return,
     };
 
     let cargo_bsan_path = env::current_exe()
@@ -202,4 +189,34 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     }
     debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
     exec(cmd);
+}
+
+fn ensure_sysroot(
+    subcommand: &BSANCommand,
+    rustc_version: &VersionMeta,
+    verbose: usize,
+    quiet: bool,
+) -> PathBuf {
+    let host_sysroot = get_host_sysroot_dir(verbose);
+
+    let Some(bsan_plugin) = find_library("BSAN_PLUGIN", &host_sysroot, "libbsan_plugin.so") else {
+        show_error!(
+            "failed to locate the BorrowSanitizer LLVM plugin (libbsan_plugin.so) within the host sysroot."
+        );
+    };
+    unsafe {
+        env::set_var("BSAN_PLUGIN", bsan_plugin);
+    }
+
+    let Some(runtime_dir) = find_library("BSAN_RT", &host_sysroot, "libbsan_rt.a") else {
+        show_error!(
+            "failed to locate the BorrowSanitizer runtime (libbsan_rt.a) within the host sysroot."
+        );
+    };
+    unsafe {
+        env::set_var("BSAN_RT", runtime_dir);
+    }
+
+    setup_sysroot(subcommand, rustc_version.host.as_str(), rustc_version, verbose, quiet);
+    get_target_sysroot_dir()
 }

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -24,11 +24,15 @@ pub fn setup_sysroot(
 ) -> PathBuf {
     let only_setup = matches!(subcommand, BSANCommand::Setup);
     let ask_user = !only_setup;
+    let print_rustflags = only_setup && has_arg_flag("--print-rustflags");
     let print_sysroot = only_setup && has_arg_flag("--print-sysroot"); // whether we just print the sysroot path
-    let show_setup = only_setup && !print_sysroot;
+    let show_setup = only_setup && !print_sysroot && !print_rustflags;
 
     if !only_setup && let Some(sysroot) = std::env::var_os("BSAN_SYSROOT") {
         // Skip setup step if BSAN_SYSROOT is explicitly set, *unless* we are `cargo bsan setup`.
+        if print_sysroot {
+            println!("{}", sysroot.display());
+        }
         return sysroot.into();
     }
 


### PR DESCRIPTION
If you run:
```
cargo bsan setup --print-rustflags
```
Then it will print the flags we pass to `rustc` that enable our runtime.