### PR TITLE
Removes `AllocId` from provenance.

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -499,6 +499,7 @@ private:
                                Provenance Prov, AtomicOrdering Ordering) {
     ProvenancePointer ProvPtr;
     if (Prov.isVector()) {
+      report_fatal_error("Vectors are not supported.");
     } else {
       Value *ShadowPointer =
           IRB.CreateCall(BS.BsanFuncGetShadowDest, {ObjAddr});
@@ -515,7 +516,7 @@ private:
                                       AtomicOrdering Ordering) {
     ProvenancePointer ProvPtr;
     if (Comp.isVector()) {
-      report_fatal_error("Scalable vectors are not supported.");
+      report_fatal_error("Vectors are not supported.");
     } else {
       Value *ShadowPointer = IRB.CreateCall(BS.BsanFuncGetShadowSrc, {ObjAddr});
       ProvPtr = ProvenancePointerScalar(IRB, BS.PL, ShadowPointer);
@@ -573,7 +574,7 @@ private:
           getProvenanceComponents(EntryIRB, Arg.getType());
       for (auto &C : *Components) {
         Value *CurrentArrayByteOffset =
-            EntryIRB.CreateMul(TotalNumProvenanceValues, BS.ProvenanceSize);
+            EntryIRB.CreateMul(TotalNumProvenanceValues, BS.PL.ProvenanceSize);
         Value *CurrentArraySlot =
             addPointer(EntryIRB, BS.DL, BS.ParamTLS, CurrentArrayByteOffset);
         ProvenancePointer Ptr =
@@ -626,8 +627,6 @@ private:
   void patchAllocaPHINodes() {
     SmallVector<PHINode *> Worklist;
     for (const auto &[BB, AI, Prov] : AllocaProvPHINodes) {
-      PHINode *IdNode = cast<PHINode>(Prov.Id);
-      Worklist.push_back(IdNode);
       PHINode *TagNode = cast<PHINode>(Prov.Tag);
       Worklist.push_back(TagNode);
       PHINode *InfoNode = cast<PHINode>(Prov.Info);
@@ -636,7 +635,6 @@ private:
       for (BasicBlock *IncomingBlock : predecessors(BB)) {
         ProvenanceScalar IncomingProv =
             assertAllocaProvenance(IncomingBlock, AI);
-        IdNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Id);
         TagNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Tag);
         InfoNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Info);
       }
@@ -678,11 +676,6 @@ private:
     }
   }
 
-  Value *newAllocId(IRBuilder<> &IRB) {
-    return IRB.CreateAtomicRMW(AtomicRMWInst::Add, BS.AllocIdCounter, BS.One,
-                               std::nullopt, AtomicOrdering::Monotonic);
-  }
-
   Value *newBorrowTag(IRBuilder<> &IRB) {
     return IRB.CreateAtomicRMW(AtomicRMWInst::Add, BS.BorTagCounter, BS.One,
                                std::nullopt, AtomicOrdering::Monotonic);
@@ -691,10 +684,9 @@ private:
   // Allocates object metadata for a stack or heap allocation.
   ProvenanceScalar instrumentHeapAllocation(IRBuilder<> &IRB, Value *Address,
                                             Value *Size) {
-    Value *Id = newAllocId(IRB);
     Value *Tag = newBorrowTag(IRB);
-    Value *Info = IRB.CreateCall(BS.BsanFuncAlloc, {Address, Size, Id, Tag});
-    ProvenanceScalar Prov = ProvenanceScalar(Id, Tag, Info);
+    Value *Info = IRB.CreateCall(BS.BsanFuncAlloc, {Address, Size, Tag});
+    ProvenanceScalar Prov = ProvenanceScalar(Tag, Info);
     setProvenance(Address, Prov);
     return Prov;
   }
@@ -711,8 +703,7 @@ private:
   // Deallocates a pointer.
   void instrumentDeallocation(IRBuilder<> &IRB, Value *Ptr) {
     ProvenanceScalar Prov = assertProvenanceScalar(Ptr);
-    IRB.CreateCall(BS.BsanFuncDealloc,
-                   {Ptr, Prov.Id, Prov.Tag, Prov.Info, BS.False});
+    IRB.CreateCall(BS.BsanFuncDealloc, {Ptr, Prov.Tag, Prov.Info, BS.False});
   }
 
   bool isRustShim(CallBase &CB) {
@@ -763,8 +754,6 @@ private:
       Callee = BS.BsanFuncDebugPrint;
     } else if (Name == kBsanFuncDebugPrintBorrowState) {
       Callee = BS.BsanFuncDebugPrintBorrowState;
-    } else if (Name == kBsanFuncDebugGC) {
-      Callee = BS.BsanFuncDebugGC;
     } else if (Name == kBsanFuncDebugTreeSize) {
       Callee = BS.BsanFuncDebugTreeSize;
     } else if (Name == kBsanFuncDebugSnapshot) {
@@ -775,7 +764,7 @@ private:
       report_fatal_error("Unknown debug function: " + Twine(Name) + "\n");
     }
 
-    IRB.CreateCall(Callee, {Prov.Id, Prov.Tag, Prov.Info});
+    IRB.CreateCall(Callee, {Prov.Tag, Prov.Info});
     CB.eraseFromParent();
   }
 
@@ -848,15 +837,15 @@ private:
         }
       }
 
-      TargetProv.Tag = IRB.CreateCall(
-          BS.BsanFuncRetag,
-          {Target, CB.getOperand(2), CB.getOperand(3), TargetProv.Id,
-           TargetProv.Tag, TargetProv.Info, ImArray, ImArrayLen});
+      TargetProv.Tag = IRB.CreateCall(BS.BsanFuncRetag,
+                                      {Target, CB.getOperand(2),
+                                       CB.getOperand(3), TargetProv.Tag,
+                                       TargetProv.Info, ImArray, ImArrayLen});
 
       if (isFnEntryRetag(&CB)) {
         Value *PrevSlot = IRB.CreateLoad(BS.PtrTy, BS.ProvStack, true);
         Value *NextProvSlot =
-            subtractPointer(IRB, BS.DL, PrevSlot, BS.ProvenanceSize);
+            subtractPointer(IRB, BS.DL, PrevSlot, BS.PL.ProvenanceSize);
         TargetProv.store(IRB, BS.PL, NextProvSlot);
         IRB.CreateStore(NextProvSlot, BS.ProvStack, true);
       }
@@ -922,7 +911,7 @@ private:
         ProvSrc.store(Before, BS.PL, Dest);
 
         Value *ByteWidth =
-            Before.CreateMul(Comp.NumProvenanceValues, BS.ProvenanceSize);
+            Before.CreateMul(Comp.NumProvenanceValues, BS.PL.ProvenanceSize);
         ParamByteWidth = Before.CreateAdd(ParamByteWidth, ByteWidth);
       }
     }
@@ -977,7 +966,7 @@ private:
         ProvenancePointers.push_back({Idx, Ptr});
 
         Value *ByteWidth =
-            Before.CreateMul(Comp.NumProvenanceValues, BS.ProvenanceSize);
+            Before.CreateMul(Comp.NumProvenanceValues, BS.PL.ProvenanceSize);
         RetvalByteWidth = Before.CreateAdd(RetvalByteWidth, ByteWidth);
         NumProvenanceValues =
             Before.CreateAdd(NumProvenanceValues, Comp.NumProvenanceValues);
@@ -998,57 +987,26 @@ private:
     }
   }
 
-  ProvenanceVector
-  createVectorProvenancePHI(IRBuilder<> &IRB, ElementCount Elems,
-                            iterator_range<pred_iterator> Blocks) {
-    unsigned NumIncoming = std::distance(Blocks.begin(), Blocks.end());
-    Type *IntptrVector = VectorType::get(BS.IntptrTy, Elems);
-    Type *PtrVector = VectorType::get(BS.PtrTy, Elems);
-
-    PHINode *IdNode = IRB.CreatePHI(IntptrVector, NumIncoming, "_bsphi_vec_id");
-    IdNode->dropDbgRecords();
-    PHINode *TagNode =
-        IRB.CreatePHI(IntptrVector, NumIncoming, "_bsphi_vec_tag");
-    TagNode->dropDbgRecords();
-    PHINode *InfoNode =
-        IRB.CreatePHI(PtrVector, NumIncoming, "_bsphi_vec_info");
-    InfoNode->dropDbgRecords();
-
-    ProvenanceVector WildcardVector =
-        ProvenanceVector::wildcard(IRB, BS.PL, Elems);
-
-    for (BasicBlock *BB : Blocks) {
-      IdNode->addIncoming(WildcardVector.Id, BB);
-      TagNode->addIncoming(WildcardVector.Tag, BB);
-      InfoNode->addIncoming(WildcardVector.Info, BB);
-    }
-
-    return ProvenanceVector(IdNode, TagNode, InfoNode, Elems);
-  }
-
   ProvenanceScalar
   createScalarProvenancePHI(IRBuilder<> &IRB,
                             iterator_range<pred_iterator> Blocks) {
     unsigned NumIncoming = std::distance(Blocks.begin(), Blocks.end());
-    PHINode *IdNode = IRB.CreatePHI(BS.IntptrTy, NumIncoming, "_bsphi_id");
-    IdNode->dropDbgRecords();
     PHINode *TagNode = IRB.CreatePHI(BS.IntptrTy, NumIncoming, "_bsphi_tag");
     TagNode->dropDbgRecords();
     PHINode *InfoNode = IRB.CreatePHI(BS.PtrTy, NumIncoming, "_bsphi_info");
     InfoNode->dropDbgRecords();
 
     for (BasicBlock *BB : Blocks) {
-      IdNode->addIncoming(BS.WildcardProvenance.Id, BB);
       TagNode->addIncoming(BS.WildcardProvenance.Tag, BB);
       InfoNode->addIncoming(BS.WildcardProvenance.Info, BB);
     }
-    return ProvenanceScalar(IdNode, TagNode, InfoNode);
+    return ProvenanceScalar(TagNode, InfoNode);
   }
 
   Provenance createProvenancePHI(IRBuilder<> &IRB, ProvenanceComponent Comp,
                                  iterator_range<pred_iterator> Blocks) {
     if (Comp.isVector()) {
-      return createVectorProvenancePHI(IRB, Comp.Elems, Blocks);
+      report_fatal_error("Vectors are not supported.");
     }
     return createScalarProvenancePHI(IRB, Blocks);
   }
@@ -1081,16 +1039,14 @@ private:
                                                             AllocaInst *AI) {
     TypeSize TS = BS.getAllocaSizeInBytes(*AI);
     Value *Size = IRB.CreateTypeSize(BS.IntptrTy, TS);
-    Value *Id = newAllocId(IRB);
     Value *Tag = newBorrowTag(IRB);
     Value *Info = IRB.CreateCall(BS.BsanFuncReserveStackSlot, {});
-    return std::make_pair(Size, ProvenanceScalar(Id, Tag, Info));
+    return std::make_pair(Size, ProvenanceScalar(Tag, Info));
   }
 
   void initAllocaMetadata(IRBuilder<> &IRB, AllocaInst *AI, Value *Size,
                           ProvenanceScalar Prov) {
-    IRB.CreateCall(BS.BsanFuncAllocStack,
-                   {AI, Size, Prov.Id, Prov.Tag, Prov.Info});
+    IRB.CreateCall(BS.BsanFuncAllocStack, {AI, Size, Prov.Tag, Prov.Info});
   }
 
   ProvenanceScalar createAndInitAllocaMetadata(IRBuilder<> &IRB,
@@ -1107,10 +1063,9 @@ private:
     IRBuilder<> IRB(&II);
 
     ProvenanceScalar CurrentProv = getAllocaProvenance(CurrentBlock, AI);
-    if (CurrentProv != BS.InvalidProvenance &&
-        CurrentProv != BS.WildcardProvenance) {
-      IRB.CreateCall(BS.BsanFuncDealloc, {AI, CurrentProv.Id, CurrentProv.Tag,
-                                          CurrentProv.Info, BS.True});
+    if (CurrentProv != BS.WildcardProvenance) {
+      IRB.CreateCall(BS.BsanFuncDealloc,
+                     {AI, CurrentProv.Tag, CurrentProv.Info, BS.True});
     }
     if (!shouldInstrumentAlloca(*AI))
       return;
@@ -1129,9 +1084,8 @@ private:
     IRBuilder<> IRB(&II);
 
     ProvenanceScalar Root = assertProvenanceScalar(AI);
-    if (Root != BS.InvalidProvenance && Root != BS.WildcardProvenance) {
-      IRB.CreateCall(BS.BsanFuncDealloc,
-                     {AI, Root.Id, Root.Tag, Root.Info, BS.True});
+    if (Root != BS.WildcardProvenance) {
+      IRB.CreateCall(BS.BsanFuncDealloc, {AI, Root.Tag, Root.Info, BS.True});
     }
   }
 
@@ -1158,8 +1112,7 @@ private:
                        Value *Size) {
     ProvenanceScalar Prov = assertProvenanceScalar(Ptr);
     if (Prov != BS.WildcardProvenance) {
-      IRB.CreateCall(BS.BsanFuncRead,
-                     {Ptr, Size, Prov.Id, Prov.Tag, Prov.Info});
+      IRB.CreateCall(BS.BsanFuncRead, {Ptr, Size, Prov.Tag, Prov.Info});
     }
   }
 
@@ -1168,8 +1121,7 @@ private:
                         Value *Size) {
     ProvenanceScalar Prov = assertProvenanceScalar(Ptr);
     if (Prov != BS.WildcardProvenance) {
-      IRB.CreateCall(BS.BsanFuncWrite,
-                     {Ptr, Size, Prov.Id, Prov.Tag, Prov.Info});
+      IRB.CreateCall(BS.BsanFuncWrite, {Ptr, Size, Prov.Tag, Prov.Info});
     }
   }
 
@@ -1362,11 +1314,10 @@ private:
         ProvenanceScalar ProvR =
             assertProvenanceScalar({SI.getFalseValue(), Idx});
 
-        Value *Id = IRB.CreateSelect(SI.getCondition(), ProvL.Id, ProvR.Id);
         Value *Tag = IRB.CreateSelect(SI.getCondition(), ProvL.Tag, ProvR.Tag);
         Value *Info =
             IRB.CreateSelect(SI.getCondition(), ProvL.Info, ProvR.Info);
-        setProvenance({&SI, Idx}, ProvenanceScalar(Id, Tag, Info));
+        setProvenance({&SI, Idx}, ProvenanceScalar(Tag, Info));
       }
     }
   }
@@ -1375,7 +1326,7 @@ private:
     if (NumFnEntryRetags) {
       Value *FrameBottom = IRB.CreateLoad(BS.PtrTy, BS.ProvStack, true);
       Value *FrameLen =
-          IRB.CreatePtrDiff(BS.ProvenanceTy, FrameTop, FrameBottom);
+          IRB.CreatePtrDiff(BS.PL.ProvenanceTy, FrameTop, FrameBottom);
       IRB.CreateCall(BS.BsanFuncPopFrame, {FrameBottom, FrameLen});
       IRB.CreateStore(FrameTop, BS.ProvStack, true);
     }
@@ -1385,7 +1336,7 @@ private:
         if (LifetimeInfo->isAliveAfter(AI, &I)) {
           ProvenanceScalar Root = assertProvenanceScalar(AI);
           IRB.CreateCall(BS.BsanFuncDealloc,
-                         {AI, Root.Id, Root.Tag, Root.Info, BS.True});
+                         {AI, Root.Tag, Root.Info, BS.True});
           IRB.CreateCall(BS.BsanFuncDestroyStackSlot, {Root.Info});
         }
       }
@@ -1408,7 +1359,7 @@ private:
         Prov.store(IRB, BS.PL, Dest);
 
         Value *ByteWidth =
-            IRB.CreateMul(Comp.NumProvenanceValues, BS.ProvenanceSize);
+            IRB.CreateMul(Comp.NumProvenanceValues, BS.PL.ProvenanceSize);
         RetvalByteWidth = IRB.CreateAdd(RetvalByteWidth, ByteWidth);
       }
     }
@@ -1431,7 +1382,7 @@ private:
         Prov.store(IRB, BS.PL, Dest);
 
         Value *ByteWidth =
-            IRB.CreateMul(Comp.NumProvenanceValues, BS.ProvenanceSize);
+            IRB.CreateMul(Comp.NumProvenanceValues, BS.PL.ProvenanceSize);
         RetvalByteWidth = IRB.CreateAdd(RetvalByteWidth, ByteWidth);
       }
     }
@@ -1538,12 +1489,37 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   AttributeList AL;
   AL = AL.addFnAttribute(*C, Attribute::NoUnwind);
 
-  BsanFuncRetag = M.getOrInsertFunction(kBsanFuncRetagName, AL, IntptrTy, PtrTy,
-                                        IntptrTy, Int64Ty, IntptrTy, IntptrTy,
-                                        PtrTy, PtrTy, IntptrTy);
+  BsanFuncRetag =
+      M.getOrInsertFunction(kBsanFuncRetagName, AL, IntptrTy, PtrTy, IntptrTy,
+                            Int64Ty, IntptrTy, PtrTy, PtrTy, IntptrTy);
 
-  BsanFuncRemoveProtectedTags = M.getOrInsertFunction(
-      kBsanFuncRemoveProtectedTags, AL, IRB.getVoidTy(), PtrTy, IntptrTy);
+  BsanFuncPopFrame = M.getOrInsertFunction(kBsanFuncPopFrame, AL,
+                                           IRB.getVoidTy(), PtrTy, IntptrTy);
+
+  BsanFuncRead = M.getOrInsertFunction(kBsanFuncReadName, AL, IRB.getVoidTy(),
+                                       PtrTy, IntptrTy, IntptrTy, PtrTy);
+
+  BsanFuncWrite = M.getOrInsertFunction(kBsanFuncWriteName, AL, IRB.getVoidTy(),
+                                        PtrTy, IntptrTy, IntptrTy, PtrTy);
+
+  BsanFuncAlloc = M.getOrInsertFunction(kBsanFuncAllocName, AL, PtrTy, PtrTy,
+                                        IntptrTy, IntptrTy);
+
+  BsanFuncAllocStack =
+      M.getOrInsertFunction(kBsanFuncAllocStackName, AL, IRB.getVoidTy(), PtrTy,
+                            IntptrTy, IntptrTy, PtrTy);
+  BsanFuncDealloc =
+      M.getOrInsertFunction(kBsanFuncDeallocName, AL, IRB.getVoidTy(), PtrTy,
+                            IntptrTy, PtrTy, Int8Ty);
+
+  BsanFuncMarkTLS = M.getOrInsertFunction(
+      kBsanFuncMarkTLSName, FunctionType::get(PtrTy, /*isVarArg=*/false), AL);
+
+  BsanFuncValidateParamTLS = M.getOrInsertFunction(
+      kBsanFuncValidateParamTLSName, AL, IRB.getVoidTy(), IntptrTy);
+
+  BsanFuncValidateRetvalTLS = M.getOrInsertFunction(
+      kBsanFuncValidateRetvalTLSName, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   BsanFuncShadowCopy = M.getOrInsertFunction(
       kBsanFuncShadowCopyName, AL, IRB.getVoidTy(), PtrTy, PtrTy, IntptrTy);
@@ -1551,14 +1527,11 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   BsanFuncShadowClear = M.getOrInsertFunction(kBsanFuncShadowClearName, AL,
                                               IRB.getVoidTy(), PtrTy, IntptrTy);
 
-  BsanFuncGetShadowDest =
-      M.getOrInsertFunction(kBsanFuncGetShadowDestName, AL, PtrTy, PtrTy);
-
   BsanFuncGetShadowSrc =
       M.getOrInsertFunction(kBsanFuncGetShadowSrcName, AL, PtrTy, PtrTy);
 
-  BsanFuncAlloc = M.getOrInsertFunction(kBsanFuncAllocName, AL, PtrTy, PtrTy,
-                                        IntptrTy, IntptrTy, IntptrTy);
+  BsanFuncGetShadowDest =
+      M.getOrInsertFunction(kBsanFuncGetShadowDestName, AL, PtrTy, PtrTy);
 
   BsanFuncReserveStackSlot =
       M.getOrInsertFunction(kBsanFuncReserveStackSlotName,
@@ -1567,85 +1540,32 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   BsanFuncDestroyStackSlot = M.getOrInsertFunction(
       kBsanFuncDestroyStackSlotName, AL, IRB.getVoidTy(), PtrTy);
 
-  BsanFuncAllocStack =
-      M.getOrInsertFunction(kBsanFuncAllocStackName, AL, IRB.getVoidTy(), PtrTy,
-                            IntptrTy, IntptrTy, IntptrTy, PtrTy);
+  BsanFuncAssertProvenanceNull = M.getOrInsertFunction(
+      kBsanFuncAssertProvenanceNull, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
-  BsanFuncDealloc =
-      M.getOrInsertFunction(kBsanFuncDeallocName, AL, IRB.getVoidTy(), PtrTy,
-                            IntptrTy, IntptrTy, PtrTy, Int8Ty);
+  BsanFuncAssertProvenanceWildcard = M.getOrInsertFunction(
+      kBsanFuncAssertProvenanceWildcard, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
-  BsanFuncExposeTag = M.getOrInsertFunction(
-      kBsanFuncExposeTagName, AL, IRB.getVoidTy(), IntptrTy, IntptrTy, PtrTy);
+  BsanFuncAssertProvenanceValid = M.getOrInsertFunction(
+      kBsanFuncAssertProvenanceValid, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
-  BsanFuncRead =
-      M.getOrInsertFunction(kBsanFuncReadName, AL, IRB.getVoidTy(), PtrTy,
-                            IntptrTy, IntptrTy, IntptrTy, PtrTy);
+  BsanFuncAssertProvenanceInvalid = M.getOrInsertFunction(
+      kBsanFuncAssertProvenanceInvalid, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
-  BsanFuncWrite =
-      M.getOrInsertFunction(kBsanFuncWriteName, AL, IRB.getVoidTy(), PtrTy,
-                            IntptrTy, IntptrTy, IntptrTy, PtrTy);
+  BsanFuncDebugPrint = M.getOrInsertFunction(kBsanFuncDebugPrint, AL,
+                                             IRB.getVoidTy(), IntptrTy, PtrTy);
 
-  BsanFuncShadowLoadVector =
-      M.getOrInsertFunction(kBsanFuncShadowLoadVectorName, AL, IRB.getVoidTy(),
-                            PtrTy, IntptrTy, PtrTy, PtrTy, PtrTy);
-
-  BsanFuncShadowStoreVector =
-      M.getOrInsertFunction(kBsanFuncShadowStoreVectorName, AL, IRB.getVoidTy(),
-                            PtrTy, IntptrTy, PtrTy, PtrTy, PtrTy);
-
-  BsanFuncAssertProvenanceNull =
-      M.getOrInsertFunction(kBsanFuncAssertProvenanceNull, AL, IRB.getVoidTy(),
-                            IntptrTy, IntptrTy, PtrTy);
-
-  BsanFuncAssertProvenanceWildcard =
-      M.getOrInsertFunction(kBsanFuncAssertProvenanceWildcard, AL,
-                            IRB.getVoidTy(), IntptrTy, IntptrTy, PtrTy);
-
-  BsanFuncAssertProvenanceValid =
-      M.getOrInsertFunction(kBsanFuncAssertProvenanceValid, AL, IRB.getVoidTy(),
-                            IntptrTy, IntptrTy, PtrTy);
-
-  BsanFuncAssertProvenanceInvalid =
-      M.getOrInsertFunction(kBsanFuncAssertProvenanceInvalid, AL,
-                            IRB.getVoidTy(), IntptrTy, IntptrTy, PtrTy);
-
-  BsanFuncDebugPrint = M.getOrInsertFunction(
-      kBsanFuncDebugPrint, AL, IRB.getVoidTy(), IntptrTy, IntptrTy, PtrTy);
-
-  BsanFuncDebugPrintBorrowState =
-      M.getOrInsertFunction(kBsanFuncDebugPrintBorrowState, AL, IRB.getVoidTy(),
-                            IntptrTy, IntptrTy, PtrTy);
-
-  BsanFuncDebugGC = M.getOrInsertFunction(kBsanFuncDebugGC, AL, IRB.getVoidTy(),
-                                          IntptrTy, IntptrTy, PtrTy);
+  BsanFuncDebugPrintBorrowState = M.getOrInsertFunction(
+      kBsanFuncDebugPrintBorrowState, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   BsanFuncDebugTreeSize = M.getOrInsertFunction(
-      kBsanFuncDebugTreeSize, AL, IRB.getVoidTy(), IntptrTy, IntptrTy, PtrTy);
+      kBsanFuncDebugTreeSize, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   BsanFuncDebugSnapshot = M.getOrInsertFunction(
-      kBsanFuncDebugSnapshot, AL, IRB.getVoidTy(), IntptrTy, IntptrTy, PtrTy);
+      kBsanFuncDebugSnapshot, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   BsanFuncDebugPrintDiff = M.getOrInsertFunction(
-      kBsanFuncDebugPrintDiff, AL, IRB.getVoidTy(), IntptrTy, IntptrTy, PtrTy);
-
-  BsanFuncDebugParamTLS = M.getOrInsertFunction(kBsanFuncDebugParamTLS, AL,
-                                                IRB.getVoidTy(), IntptrTy);
-
-  BsanFuncDebugRetvalTLS = M.getOrInsertFunction(kBsanFuncDebugRetvalTLS, AL,
-                                                 IRB.getVoidTy(), IntptrTy);
-
-  BsanFuncValidateParamTLS = M.getOrInsertFunction(
-      kBsanFuncValidateParamTLSName, AL, IRB.getVoidTy(), IntptrTy);
-
-  BsanFuncValidateRetvalTLS = M.getOrInsertFunction(
-      kBsanFuncValidateRetvalTLSName, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncMarkTLS = M.getOrInsertFunction(
-      kBsanFuncMarkTLSName, FunctionType::get(PtrTy, /*isVarArg=*/false), AL);
-
-  BsanFuncPopFrame = M.getOrInsertFunction(kBsanFuncPopFrame, AL,
-                                           IRB.getVoidTy(), PtrTy, IntptrTy);
+      kBsanFuncDebugPrintDiff, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   EHPersonality Pers = getDefaultEHPersonality(TargetTriple);
   DefaultPersonalityFn =
@@ -1660,11 +1580,10 @@ void BorrowSanitizer::createUserspaceApi(Module &M,
                                          const TargetLibraryInfo &TLI) {
   IRBuilder<> IRB(*C);
   RetvalTLS = getOrInsertTLSGlobal(M, kBsanRetvalTLSName,
-                                   ArrayType::get(ProvenanceTy, kTLSSize));
+                                   ArrayType::get(PL.ProvenanceTy, kTLSSize));
   ParamTLS = getOrInsertTLSGlobal(M, kBsanParamTLSName,
-                                  ArrayType::get(ProvenanceTy, kTLSSize));
+                                  ArrayType::get(PL.ProvenanceTy, kTLSSize));
   ProvStack = getOrInsertTLSGlobal(M, kBsanProvStackName, PtrTy);
-  AllocIdCounter = getOrInsertGlobal(M, kBsanAllocIdCounterName, IntptrTy);
   BorTagCounter = getOrInsertGlobal(M, kBsanBorTagCounterName, IntptrTy);
 }
 

--- a/bsan-pass/BorrowSanitizer.h
+++ b/bsan-pass/BorrowSanitizer.h
@@ -24,10 +24,6 @@ public:
     PtrTy = PointerType::getUnqual(*C);
     IntptrTy = Type::getIntNTy(*C, LongSize);
 
-    ProvenanceTy = StructType::get(IntptrTy, IntptrTy, PtrTy);
-    ProvenanceAlign = DL->getABITypeAlign(ProvenanceTy);
-    ProvenanceSize = ConstantInt::get(IntptrTy, kProvenanceSize);
-
     Zero = ConstantInt::get(IntptrTy, 0);
     One = ConstantInt::get(IntptrTy, 1);
 
@@ -36,8 +32,8 @@ public:
 
     Constant *InvalidPtr = ConstantPointerNull::get(PtrTy);
 
-    WildcardProvenance = ProvenanceScalar(Zero, Zero, InvalidPtr);
-    InvalidProvenance = ProvenanceScalar(One, Zero, InvalidPtr);
+    WildcardProvenance = ProvenanceScalar(Zero, InvalidPtr);
+    InvalidProvenance = ProvenanceScalar(One, InvalidPtr);
   }
 
   bool instrumentModule(Module &M);
@@ -71,60 +67,47 @@ public:
   Type *IntptrTy;
   Align IntptrAlign;
 
-  StructType *ProvenanceTy;
-  Align ProvenanceAlign;
-  Value *ProvenanceSize;
-
   bool CallbacksInitialized = false;
 
   Function *BsanCtorFunction = nullptr;
   Function *BsanDtorFunction = nullptr;
 
   FunctionCallee BsanFuncRetag;
-  FunctionCallee BsanFuncShadowCopy;
-  FunctionCallee BsanFuncShadowClear;
-  FunctionCallee BsanFuncGetShadowSrc;
-  FunctionCallee BsanFuncGetShadowDest;
-
-  FunctionCallee BsanFuncPopFrame;
-
-  FunctionCallee BsanFuncReserveStackSlot;
-  FunctionCallee BsanFuncDestroyStackSlot;
-  FunctionCallee BsanFuncAllocStack;
-  FunctionCallee BsanFuncRemoveProtectedTags;
-
-  FunctionCallee BsanFuncAlloc;
-  FunctionCallee BsanFuncDealloc;
-  FunctionCallee BsanFuncExposeTag;
   FunctionCallee BsanFuncRead;
   FunctionCallee BsanFuncWrite;
+  FunctionCallee BsanFuncAlloc;
+  FunctionCallee BsanFuncDealloc;
 
-  FunctionCallee BsanFuncShadowLoadVector;
-  FunctionCallee BsanFuncShadowStoreVector;
-
-  FunctionCallee BsanFuncAssertProvenanceInvalid;
-  FunctionCallee BsanFuncAssertProvenanceValid;
-  FunctionCallee BsanFuncAssertProvenanceNull;
-  FunctionCallee BsanFuncAssertProvenanceWildcard;
-  FunctionCallee BsanFuncDebugPrint;
-  FunctionCallee BsanFuncDebugPrintBorrowState;
-  FunctionCallee BsanFuncDebugGC;
-  FunctionCallee BsanFuncDebugTreeSize;
-  FunctionCallee BsanFuncDebugSnapshot;
-  FunctionCallee BsanFuncDebugPrintDiff;
-
-  FunctionCallee BsanFuncDebugParamTLS;
-  FunctionCallee BsanFuncDebugRetvalTLS;
+  FunctionCallee BsanFuncPopFrame;
 
   FunctionCallee BsanFuncMarkTLS;
   FunctionCallee BsanFuncValidateRetvalTLS;
   FunctionCallee BsanFuncValidateParamTLS;
 
+  FunctionCallee BsanFuncShadowCopy;
+  FunctionCallee BsanFuncShadowClear;
+  FunctionCallee BsanFuncGetShadowSrc;
+  FunctionCallee BsanFuncGetShadowDest;
+
+  FunctionCallee BsanFuncAllocStack;
+  FunctionCallee BsanFuncReserveStackSlot;
+  FunctionCallee BsanFuncDestroyStackSlot;
+
+  FunctionCallee BsanFuncAssertProvenanceNull;
+  FunctionCallee BsanFuncAssertProvenanceWildcard;
+  FunctionCallee BsanFuncAssertProvenanceValid;
+  FunctionCallee BsanFuncAssertProvenanceInvalid;
+
+  FunctionCallee BsanFuncDebugPrint;
+  FunctionCallee BsanFuncDebugPrintBorrowState;
+  FunctionCallee BsanFuncDebugTreeSize;
+  FunctionCallee BsanFuncDebugSnapshot;
+  FunctionCallee BsanFuncDebugPrintDiff;
+
   FunctionCallee DefaultPersonalityFn;
 
   ProvenanceScalar WildcardProvenance;
   ProvenanceScalar InvalidProvenance;
-
   // Thread-local storage for paramters
   // and return values.
   Value *ParamTLS = nullptr;

--- a/bsan-pass/Provenance.cpp
+++ b/bsan-pass/Provenance.cpp
@@ -57,43 +57,30 @@ ProvenancePointerScalar::ProvenancePointerScalar(IRBuilder<> &IRB,
                                                  Value *Base) {
 
   Value *ZeroIdx = ConstantInt::get(IRB.getInt64Ty(), 0);
-
-  this->IdPtr = Base;
-
-  this->TagPtr = IRB.CreateGEP(
-      PL.ProvenanceTy, Base, {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 1)});
-
+  this->TagPtr = Base;
   this->InfoPtr = IRB.CreateGEP(
-      PL.ProvenanceTy, Base, {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 2)});
+      PL.ProvenanceTy, Base, {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 1)});
 }
 
 ProvenancePointerVector::ProvenancePointerVector(IRBuilder<> &IRB,
                                                  const ProvenanceLayout &PL,
                                                  Value *Base,
                                                  ElementCount Elems) {
-  this->IdPtr = Base;
+  this->TagPtr = Base;
   this->Elems = Elems;
   Value *IntVecSize = IRB.CreateTypeSize(
       PL.IntptrTy,
       PL.DL->getTypeAllocSize(VectorType::get(PL.IntptrTy, Elems)));
-
-  Value *PtrVecSize = IRB.CreateTypeSize(
-      PL.PtrTy, PL.DL->getTypeAllocSize(VectorType::get(PL.PtrTy, Elems)));
-
-  Value *TagBase = IRB.CreatePointerCast(IdPtr, IRB.getIntPtrTy(*PL.DL));
-  Value *TagOffset = IRB.CreateAdd(Base, IntVecSize);
-  this->TagPtr = IRB.CreateIntToPtr(TagOffset, PL.PtrTy);
+  Value *TagOffset = IRB.CreateAdd(Base, this->TagPtr);
   this->InfoPtr =
       IRB.CreateIntToPtr(IRB.CreateAdd(TagOffset, IntVecSize), PL.PtrTy);
 }
 
 void Provenance::addIncoming(BasicBlock *IncomingBlock,
                              Provenance &IncomingProv) {
-  PHINode *IdNode = cast<PHINode>(this->Id);
   PHINode *TagNode = cast<PHINode>(this->Tag);
   PHINode *InfoNode = cast<PHINode>(this->Info);
 
-  IdNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Id);
   TagNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Tag);
   InfoNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Info);
 }
@@ -105,12 +92,11 @@ Provenance Provenance::load(IRBuilder<> &IRB, const ProvenanceLayout &PL,
   Type *IntTy = PL.getIntTy(ProvPtr.Kind, ProvPtr.Elems);
   Type *PtrTy = PL.getPtrTy(ProvPtr.Kind, ProvPtr.Elems);
 
+  LoadInst *Tag = IRB.CreateLoad(IntTy, ProvPtr.TagPtr, true);
   LoadInst *Info = IRB.CreateLoad(PtrTy, ProvPtr.InfoPtr, true);
   Info->setAtomic(Ordering);
-  LoadInst *Id = IRB.CreateLoad(IntTy, ProvPtr.IdPtr, true);
-  LoadInst *Tag = IRB.CreateLoad(IntTy, ProvPtr.TagPtr, true);
 
-  return Provenance(Id, Tag, Info, ProvPtr.Elems, ProvPtr.Kind);
+  return Provenance(Tag, Info, ProvPtr.Elems, ProvPtr.Kind);
 }
 
 ProvenanceScalar
@@ -136,8 +122,7 @@ void Provenance::store(IRBuilder<> &IRB, const ProvenanceLayout &PL,
 void Provenance::store(IRBuilder<> &IRB, const ProvenanceLayout &PL,
                        ProvenancePointer Dest, AtomicOrdering Ordering) {
 
-  IRB.CreateStore(this->Id, Dest.IdPtr, true);
-  IRB.CreateStore(this->Tag, Dest.TagPtr, true);
+  StoreInst *Tag = IRB.CreateStore(this->Tag, Dest.TagPtr, true);
   StoreInst *Info = IRB.CreateStore(this->Info, Dest.InfoPtr, true);
   Info->setOrdering(Ordering);
 }
@@ -153,16 +138,15 @@ Provenance Provenance::wildcard(IRBuilder<> &IRB, const ProvenanceLayout &PL,
 ProvenanceScalar ProvenanceScalar::wildcard(const ProvenanceLayout &PL) {
   Value *Zero = ConstantInt::get(PL.IntptrTy, 0);
   Value *InvalidPtr = ConstantPointerNull::get(PL.PtrTy);
-  return ProvenanceScalar(Zero, Zero, InvalidPtr);
+  return ProvenanceScalar(Zero, InvalidPtr);
 }
 
 ProvenanceVector ProvenanceVector::wildcard(IRBuilder<> &IRB,
                                             const ProvenanceLayout &PL,
                                             ElementCount Elems) {
   Constant *Zero = ConstantInt::get(PL.IntptrTy, 0);
-  Value *Id = ConstantVector::getSplat(Elems, Zero);
   Value *Tag = ConstantVector::getSplat(Elems, Zero);
   Value *Info =
       ConstantVector::getSplat(Elems, ConstantPointerNull::get(PL.PtrTy));
-  return ProvenanceVector(Id, Tag, Info, Elems);
+  return ProvenanceVector(Tag, Info, Elems);
 }

--- a/bsan-pass/Provenance.h
+++ b/bsan-pass/Provenance.h
@@ -13,7 +13,7 @@ namespace llvm {
 // Provenance is three words, and consists of three
 // components: an allocation ID, a borrow tag, and
 // a pointer to an allocation metadata object.
-static const unsigned kProvenanceSize = 24;
+static const unsigned kProvenanceSize = 16;
 
 // We have two ways of loading provenance into memory. When we
 // need a singular provenance value, we create each of its component
@@ -29,12 +29,14 @@ struct ProvenanceLayout {
   PointerType *PtrTy = nullptr;
   Value *ProvenanceSize = nullptr;
   Type *ProvenanceTy = nullptr;
+  Align ProvenanceAlign = Align(1);
   ProvenanceLayout() {}
   ProvenanceLayout(LLVMContext *C, const DataLayout *DL) : DL(DL) {
     PtrTy = PointerType::getUnqual(*C);
     IntptrTy = Type::getIntNTy(*C, DL->getPointerSizeInBits());
-    ProvenanceTy = StructType::get(IntptrTy, IntptrTy, PtrTy);
+    ProvenanceTy = StructType::get(IntptrTy, PtrTy);
     ProvenanceSize = ConstantInt::get(IntptrTy, kProvenanceSize);
+    ProvenanceAlign = DL->getABITypeAlign(ProvenanceTy);
   }
   Type *getPtrTy(ProvenanceKind Kind, ElementCount Elems) const;
   Type *getIntTy(ProvenanceKind Kind, ElementCount Elems) const;
@@ -55,14 +57,13 @@ class ProvenancePointerVector;
 // Represents a "provenancy-carrying-component" of a typed value,
 // offset from a given location in an array of provenance values.
 struct ProvenancePointer : public WithProvenanceKind {
-  Value *IdPtr = nullptr;
   Value *TagPtr = nullptr;
   Value *InfoPtr = nullptr;
   ElementCount Elems;
   ProvenancePointer() : WithProvenanceKind(ProvenanceKind::Scalar) {}
-  ProvenancePointer(Value *Id, Value *Tag, Value *Info, ElementCount Elems,
+  ProvenancePointer(Value *Tag, Value *Info, ElementCount Elems,
                     ProvenanceKind Kind)
-      : IdPtr(Id), TagPtr(Tag), InfoPtr(Info), WithProvenanceKind(Kind) {}
+      : TagPtr(Tag), InfoPtr(Info), WithProvenanceKind(Kind) {}
 
   ProvenancePointer(IRBuilder<> &IRB, const ProvenanceLayout &PL, Value *Base,
                     ElementCount Elems, ProvenanceKind Kind);
@@ -72,8 +73,8 @@ class ProvenancePointerScalar : public ProvenancePointer {
   using ProvenancePointer::ProvenancePointer;
 
 public:
-  ProvenancePointerScalar(Value *I, Value *T, Value *F)
-      : ProvenancePointer(I, T, F, ElementCount::get(0, false),
+  ProvenancePointerScalar(Value *T, Value *F)
+      : ProvenancePointer(T, F, ElementCount::get(0, false),
                           ProvenanceKind::Scalar) {}
   ProvenancePointerScalar(IRBuilder<> &IRB, const ProvenanceLayout &PL,
                           Value *Base);
@@ -83,8 +84,8 @@ class ProvenancePointerVector : public ProvenancePointer {
   using ProvenancePointer::ProvenancePointer;
 
 public:
-  ProvenancePointerVector(Value *I, Value *T, Value *F, ElementCount Elems)
-      : ProvenancePointer(I, T, F, Elems, ProvenanceKind::Vector) {}
+  ProvenancePointerVector(Value *T, Value *F, ElementCount Elems)
+      : ProvenancePointer(T, F, Elems, ProvenanceKind::Vector) {}
   ProvenancePointerVector(IRBuilder<> &IRB, const ProvenanceLayout &PL,
                           Value *Base, ElementCount Elems);
   static ProvenancePointerVector
@@ -95,17 +96,16 @@ class ProvenanceScalar;
 class ProvenanceVector;
 class Provenance : public WithProvenanceKind {
 public:
-  Value *Id = nullptr;
   Value *Tag = nullptr;
   Value *Info = nullptr;
   ElementCount Elems;
 
   Provenance() : WithProvenanceKind(ProvenanceKind::Scalar) {}
-  Provenance(Value *I, Value *T, Value *F, ElementCount E, ProvenanceKind K)
-      : Id(I), Tag(T), Info(F), Elems(E), WithProvenanceKind(K) {}
+  Provenance(Value *T, Value *F, ElementCount E, ProvenanceKind K)
+      : Tag(T), Info(F), Elems(E), WithProvenanceKind(K) {}
   bool operator==(const Provenance &other) const {
-    return this->Id == other.Id && this->Tag == other.Tag &&
-           this->Info == other.Info && this->Elems == other.Elems;
+    return this->Tag == other.Tag && this->Info == other.Info &&
+           this->Elems == other.Elems;
   }
   bool operator!=(const Provenance &other) const { return !(*this == other); }
 
@@ -139,9 +139,8 @@ class ProvenanceScalar : public Provenance {
   using Provenance::Provenance;
 
 public:
-  ProvenanceScalar(Value *I, Value *T, Value *F)
-      : Provenance(I, T, F, ElementCount::get(0, false),
-                   ProvenanceKind::Scalar) {}
+  ProvenanceScalar(Value *T, Value *F)
+      : Provenance(T, F, ElementCount::get(0, false), ProvenanceKind::Scalar) {}
   static ProvenanceScalar wildcard(const ProvenanceLayout &PL);
 };
 
@@ -149,8 +148,8 @@ class ProvenanceVector : public Provenance {
   using Provenance::Provenance;
 
 public:
-  ProvenanceVector(Value *I, Value *T, Value *F, ElementCount E)
-      : Provenance(I, T, F, E, ProvenanceKind::Vector) {}
+  ProvenanceVector(Value *T, Value *F, ElementCount E)
+      : Provenance(T, F, E, ProvenanceKind::Vector) {}
   static ProvenanceVector wildcard(IRBuilder<> &IRB, const ProvenanceLayout &PL,
                                    ElementCount Elems);
 };

--- a/bsan-rt/src/borrow_tracker/mod.rs
+++ b/bsan-rt/src/borrow_tracker/mod.rs
@@ -141,6 +141,10 @@ impl<'b> BorrowTracker<'b> {
         let parent_tag = self.prov.bor_tag;
         let new_tag = BorTag::default();
 
+        if !self.tree().tag_mapping.contains_key(&self.prov.bor_tag) {
+            return Err(UBInfo::UseAfterFree);
+        }
+
         let protected = retag_info.perm.protector.is_some();
         if let Some(protector) = retag_info.perm.protector {
             // We register the protection in two different places.

--- a/bsan-rt/src/borrow_tracker/mod.rs
+++ b/bsan-rt/src/borrow_tracker/mod.rs
@@ -16,42 +16,47 @@ pub mod unimap;
 
 #[derive(Debug)]
 pub struct BorrowTracker<'b> {
+    alloc_id: AllocId,
     prov: Provenance,
     range: AllocRange,
-    tree: MutexGuard<'b, Option<Tree>>,
+    tree: MutexGuard<'b, Tree>,
 }
 
 impl<'b> BorrowTracker<'b> {
     fn tree_mut(&mut self) -> &mut Tree {
-        self.tree.as_mut().unwrap()
+        &mut *self.tree
     }
 
     fn tree(&self) -> &Tree {
-        self.tree.as_ref().unwrap()
+        &*self.tree
     }
 
     pub fn for_alloc<T, F>(prov: Provenance, f: F) -> UBResult<Option<T>>
     where
         F: FnOnce(Self) -> UBResult<T>,
     {
-        if prov.alloc_id == AllocId::wildcard() {
+        if prov.bor_tag == BorTag::wildcard() {
             Ok(None)
-        } else if prov.alloc_id == AllocId::invalid() {
-            Err(UBInfo::UseAfterFree(prov.alloc_id))
+        } else if prov.bor_tag == BorTag::invalid() {
+            Err(UBInfo::UseAfterFree)
         } else {
             // Safety:
             // Our instrumentation pass guarantees that if a pointer's
             // provenance is non-null and not wildcard, then it will contain
             // valid allocation info pointer.
             debug_assert!(!prov.alloc_info.is_null());
-            let root_alloc_id = unsafe { (*prov.alloc_info).alloc_id };
-            if prov.alloc_id != root_alloc_id {
-                return Err(UBInfo::UseAfterFree(prov.alloc_id));
-            }
+            let alloc_id = unsafe { (*prov.alloc_info).alloc_id };
+
+            let tree = if let Some(tree_lock) = unsafe { (*prov.alloc_info).tree_lock.as_ref() } {
+                tree_lock
+            } else {
+                return Err(UBInfo::UseAfterFree);
+            };
+
             let size = Size::from_bytes(unsafe { (*prov.alloc_info).size });
             let range = AllocRange { start: Size::ZERO, size };
-            let tree = unsafe { (*prov.alloc_info).tree_lock.lock() };
-            f(Self { prov, range, tree }).map(|v| Some(v))
+            let tree = tree.lock();
+            f(Self { alloc_id, prov, range, tree }).map(|v| Some(v))
         }
     }
 
@@ -66,15 +71,13 @@ impl<'b> BorrowTracker<'b> {
     where
         F: FnOnce(Self) -> UBResult<T>,
     {
-        if prov.alloc_id == AllocId::wildcard() {
+        if prov.bor_tag == BorTag::wildcard() {
             Ok(None)
-        } else if prov.alloc_id == AllocId::invalid() {
-            if let Some(size) = access_size
-                && size > 0
-            {
-                Err(UBInfo::UseAfterFree(prov.alloc_id))
-            } else {
+        } else if prov.bor_tag == BorTag::invalid() {
+            if access_size == Some(0) {
                 Ok(None)
+            } else {
+                Err(UBInfo::UseAfterFree)
             }
         } else {
             // Safety:
@@ -82,30 +85,34 @@ impl<'b> BorrowTracker<'b> {
             // provenance is non-null and not wildcard, then it will contain
             // valid allocation info pointer.
             debug_assert!(!prov.alloc_info.is_null());
-            let root_alloc_id = unsafe { (*prov.alloc_info).alloc_id };
+
+            let alloc_id = unsafe { (*prov.alloc_info).alloc_id };
+
             let (alloc_size, base_addr) =
-                unsafe { ((*prov.alloc_info).size, (*prov.alloc_info).base_addr.base_addr) };
+                unsafe { ((*prov.alloc_info).size, (*prov.alloc_info).base_addr.addr) };
+
             let access_size = access_size.unwrap_or(alloc_size);
-            if prov.alloc_id != root_alloc_id {
+            let tree = if let Some(tree_lock) = unsafe { (*prov.alloc_info).tree_lock.as_ref() } {
+                tree_lock
+            } else {
+                return if access_size != 0 { Err(UBInfo::UseAfterFree) } else { Ok(None) };
+            };
+
+            let relative_offset = start.addr().wrapping_sub(base_addr);
+            if start.addr() < base_addr || (relative_offset + access_size > alloc_size) {
                 return if access_size != 0 {
-                    Err(UBInfo::UseAfterFree(prov.alloc_id))
+                    Err(UBInfo::AccessOutOfBounds(alloc_id, access_size, alloc_size))
                 } else {
                     Ok(None)
                 };
             }
-            let relative_offset = start.addr().wrapping_sub(base_addr.addr());
-            if start.addr() < base_addr.addr() || (relative_offset + access_size > alloc_size) {
-                return if access_size != 0 {
-                    Err(UBInfo::AccessOutOfBounds(prov.alloc_id, access_size, alloc_size))
-                } else {
-                    Ok(None)
-                };
-            }
+
             let start = Size::from_bytes(relative_offset);
             let size = Size::from_bytes(access_size);
             let range = AllocRange { start, size };
-            let tree = unsafe { (*prov.alloc_info).tree_lock.lock() };
-            f(Self { prov, range, tree }).map(|r| Some(r))
+
+            let tree = tree.lock();
+            f(Self { alloc_id, prov, range, tree }).map(|r| Some(r))
         }
     }
 
@@ -113,20 +120,24 @@ impl<'b> BorrowTracker<'b> {
         ctx: &GlobalCtx,
         prov: Provenance,
         start: *mut c_void,
-        access_size: Option<usize>,
+        access_size: usize,
         retag_info: RetagInfo<'_>,
         span: Span,
     ) -> UBResult<BorTag> {
-        Self::for_access(prov, start, access_size, |mut bt| bt.retag_inner(ctx, retag_info, span))
-            .map(|opt| opt.unwrap_or(prov.bor_tag))
+        Self::for_access(prov, start, Some(access_size), |mut bt| {
+            bt.retag_inner(ctx, retag_info, span)
+        })
+        .map(|opt| opt.unwrap_or(prov.bor_tag))
     }
+
+    #[inline]
     pub fn retag_inner(
         &mut self,
         global_ctx: &GlobalCtx,
         retag_info: RetagInfo<'_>,
         span: Span,
     ) -> UBResult<BorTag> {
-        let alloc_id = self.prov.alloc_id;
+        let alloc_id = self.alloc_id;
         let parent_tag = self.prov.bor_tag;
         let new_tag = BorTag::default();
 
@@ -205,7 +216,7 @@ impl<'b> BorrowTracker<'b> {
     }
 
     pub fn protector_end(&mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
-        let (bor_tag, alloc_id) = (self.prov.bor_tag, self.prov.alloc_id);
+        let (bor_tag, alloc_id) = (self.prov.bor_tag, self.alloc_id);
         self.tree_mut().perform_access(
             bor_tag,
             None,
@@ -222,7 +233,7 @@ impl<'b> BorrowTracker<'b> {
         access_kind: AccessKind,
         span: Span,
     ) -> UBResult<()> {
-        let (range, bor_tag, alloc_id) = (self.range, self.prov.bor_tag, self.prov.alloc_id);
+        let (range, bor_tag, alloc_id) = (self.range, self.prov.bor_tag, self.alloc_id);
         self.tree_mut().perform_access(
             bor_tag,
             Some((range, access_kind, AccessCause::Explicit(access_kind))),
@@ -234,29 +245,28 @@ impl<'b> BorrowTracker<'b> {
     }
 
     pub fn dealloc(&mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
-        let prov = self.prov;
-        let range = self.range;
-        let mut tree = self.tree.take().unwrap();
+        let (range, bor_tag, alloc_id) = (self.range, self.prov.bor_tag, self.alloc_id);
+        let tree = self.tree_mut();
         tree.dealloc(
-            prov.bor_tag,
+            bor_tag,
             range,
             &global_ctx.protected_tags(),
-            prov.alloc_id,
+            alloc_id,
             span,
             alloc::alloc::Global,
         )?;
         let info = unsafe { &mut *self.prov.alloc_info };
-        info.alloc_id = AllocId::invalid();
+        drop(info.tree_lock.take());
         Ok(())
     }
 
     pub fn debug_take_snapshot(&self, ctx: &GlobalCtx) {
         let tree = self.tree();
-        ctx.take_snapshot(self.prov.alloc_id, tree.clone());
+        ctx.take_snapshot(self.alloc_id, tree.clone());
     }
 
     pub fn debug_print_diff(&self, ctx: &GlobalCtx) {
-        ctx.with_snapshot(self.prov.alloc_id, |old_tree| {
+        ctx.with_snapshot(self.alloc_id, |old_tree| {
             diagnostics::print_tree_diff(self.tree(), old_tree, &ctx.protected_tags());
         });
     }

--- a/bsan-rt/src/borrow_tracker/tree.rs
+++ b/bsan-rt/src/borrow_tracker/tree.rs
@@ -25,10 +25,12 @@ pub struct AllocRange {
 }
 
 #[inline]
+#[allow(unused)]
 pub fn alloc_range(start: Size, size: Size) -> AllocRange {
     AllocRange { start, size }
 }
 
+#[allow(unused)]
 impl AllocRange {
     #[inline]
     pub fn end(self) -> Size {
@@ -998,6 +1000,7 @@ where
 }
 
 /// Integration with the BorTag garbage collector
+#[allow(unused)]
 impl<A> Tree<A>
 where
     A: Allocator,

--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -13,7 +13,7 @@ pub type TreeTransitionResult<T> = core::result::Result<T, TransitionError>;
 #[derive(Debug)]
 pub enum UBInfo {
     AccessOutOfBounds(AllocId, usize, usize),
-    UseAfterFree(AllocId),
+    UseAfterFree,
     AliasingViolation(Box<TreeError>),
 }
 
@@ -23,8 +23,8 @@ impl Display for UBInfo {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "Undefined Behavior: ")?;
         match self {
-            UBInfo::UseAfterFree(id) => {
-                write!(f, "trying to access {id:?}, which has been freed.")
+            UBInfo::UseAfterFree => {
+                write!(f, "trying to access an allocation that has been freed.")
             }
             UBInfo::AccessOutOfBounds(id, size, offset) => {
                 write!(

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -20,10 +20,6 @@ impl ProtectedTags {
         self.0.get(&tag).copied()
     }
 
-    pub fn is_protected(&self, tag: BorTag) -> bool {
-        self.0.contains_key(&tag)
-    }
-
     pub fn add_protector(&mut self, tag: BorTag, kind: ProtectorKind) {
         self.0.insert(tag, kind);
     }

--- a/bsan-rt/src/helpers.rs
+++ b/bsan-rt/src/helpers.rs
@@ -3,5 +3,6 @@ use alloc::alloc::Global;
 use hashbrown::{HashMap, HashSet};
 use rustc_hash::FxBuildHasher;
 
+#[allow(unused)]
 pub type FxHashSet<T, A = Global> = HashSet<T, FxBuildHasher, A>;
 pub type FxHashMap<K, V, A = Global> = HashMap<K, V, FxBuildHasher, A>;

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -114,22 +114,16 @@ impl fmt::Display for DebugSummary {
 }
 
 macro_rules! debug_bsan {
-    ($op:literal, $ptr:ident, $alloc_id:ident, $bor_tag:ident, $alloc_info:expr) => {
+    ($op:literal, $ptr:ident, $bor_tag:ident, $alloc_info:expr) => {
         #[cfg(feature = "debug")]
         {
             #[allow(unused_unsafe)]
-            let info = match $alloc_id.0 {
+            let info = match $bor_tag.0 {
                 0 => AllocInfoSummary::WildCard,
                 1 => AllocInfoSummary::Null,
                 _ => unsafe { &*$alloc_info }.summarize(),
             };
-            let summary = DebugSummary {
-                op: $op,
-                ptr: $ptr.addr(),
-                alloc_id: $alloc_id,
-                bor_tag: $bor_tag,
-                info,
-            };
+            let summary = DebugSummary { op: $op, ptr: $ptr.addr(), bor_tag: $bor_tag, info };
             libc_print::std_name::println!("{}", summary);
         }
     };
@@ -256,13 +250,9 @@ impl fmt::Debug for BorTag {
     }
 }
 
-/// Pointers have provenance (RFC #3559). In Tree Borrows, this includes an allocation ID
-/// and a borrow tag. We also include a pointer to the "lock" location for the allocation,
-/// which contains all other metadata used to detect undefined behavior.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct Provenance {
-    alloc_id: AllocId,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 }
@@ -280,42 +270,13 @@ impl Provenance {
     /// The default provenance value, which is assigned to dangling or invalid
     /// pointers.
     const fn null() -> Self {
-        Provenance {
-            alloc_id: AllocId::invalid(),
-            bor_tag: BorTag::invalid(),
-            alloc_info: core::ptr::null_mut(),
-        }
+        Provenance { bor_tag: BorTag::invalid(), alloc_info: core::ptr::null_mut() }
     }
 
     /// Pointers cast from integers receive a "wildcard" provenance value,
     /// which permits any access.
     const fn wildcard() -> Self {
-        Provenance {
-            alloc_id: AllocId::wildcard(),
-            bor_tag: BorTag::wildcard(),
-            alloc_info: core::ptr::null_mut(),
-        }
-    }
-}
-
-/// A sumtype that represents the base address of `AllocInfo` and used as a pointer to
-/// the next free list `AllocInfo` object
-#[derive(Copy, Clone)]
-pub union FreeListAddrUnion {
-    free_list_next: Option<NonNull<AllocInfo>>,
-    // Must be a raw pointer for union field access safety
-    base_addr: *mut c_void,
-}
-
-impl fmt::Debug for FreeListAddrUnion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        unsafe { write!(f, "{:?}", self.base_addr) }
-    }
-}
-
-impl Default for FreeListAddrUnion {
-    fn default() -> Self {
-        Self { base_addr: core::ptr::null_mut() }
+        Provenance { bor_tag: BorTag::wildcard(), alloc_info: core::ptr::null_mut() }
     }
 }
 
@@ -325,42 +286,40 @@ static __BSAN_WILDCARD_PROVENANCE: Provenance = Provenance::wildcard();
 #[unsafe(no_mangle)]
 static __BSAN_NULL_PROVENANCE: Provenance = Provenance::null();
 
+pub(crate) union FreeListAddrUnion {
+    pub addr: usize,
+    pub free_list_next: Option<NonNull<AllocInfo>>,
+}
+
 /// Every allocation is associated with a "lock" object, which is an instance of `AllocInfo`.
 /// Provenance is the "key" to this lock. To validate a memory access, we compare the allocation ID
 /// of a pointer's provenance with the value stored in its corresponding `AllocInfo` object. If the values
 /// do not match, then the access is invalid. If they do match, then we proceed to validate the access against
 /// the tree for the allocation.
 #[repr(C)]
-#[derive(Debug)]
-pub struct AllocInfo {
+pub(crate) struct AllocInfo {
     pub alloc_id: AllocId,
     pub base_addr: FreeListAddrUnion,
     pub size: usize,
-    pub tree_lock: Mutex<Option<tree::Tree>>,
+    pub tree_lock: Option<Mutex<tree::Tree>>,
 }
 
 impl AllocInfo {
     fn invalid() -> Self {
         AllocInfo {
             alloc_id: AllocId::invalid(),
-            base_addr: FreeListAddrUnion { base_addr: ptr::null_mut() },
+            base_addr: FreeListAddrUnion { addr: 0 },
             size: 0,
-            tree_lock: Mutex::new(None),
+            tree_lock: None,
         }
     }
 
-    fn new(
-        base_addr: *mut c_void,
-        size: usize,
-        alloc_id: AllocId,
-        bor_tag: BorTag,
-        span: Span,
-    ) -> Self {
+    fn new(base_addr: *mut c_void, size: usize, bor_tag: BorTag, span: Span) -> Self {
         Self {
-            alloc_id,
-            base_addr: FreeListAddrUnion { base_addr },
+            alloc_id: AllocId::default(),
+            base_addr: FreeListAddrUnion { addr: base_addr.addr() },
             size,
-            tree_lock: Mutex::new(Some(Tree::new_in(
+            tree_lock: Some(Mutex::new(Tree::new_in(
                 bor_tag,
                 Size::from_bytes(size),
                 span,
@@ -371,11 +330,7 @@ impl AllocInfo {
 
     #[cfg(feature = "debug")]
     fn summarize(&self) -> AllocInfoSummary {
-        AllocInfoSummary::Valid {
-            alloc_id: self.alloc_id,
-            base_addr: self.base_addr,
-            size: self.size,
-        }
+        AllocInfoSummary::Valid { base_addr: self.base_addr, size: self.size }
     }
 }
 
@@ -428,19 +383,18 @@ unsafe extern "C-unwind" fn __bsan_retag(
     object_addr: *mut c_void,
     access_size: usize,
     perm: u64,
-    alloc_id: AllocId,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
     im_data: *const [usize; 2],
     im_len: usize,
 ) -> BorTag {
-    debug_bsan!("retag", object_addr, alloc_id, bor_tag, alloc_info);
+    debug_bsan!("retag", object_addr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     let fp = unsafe { fp!() };
 
     let retag_info = unsafe { RetagInfo::from_raw(access_size, perm, im_data, im_len) };
-    BorrowTracker::retag(ctx, prov, object_addr, Some(access_size), retag_info, fp.caller_span())
+    BorrowTracker::retag(ctx, prov, object_addr, access_size, retag_info, fp.caller_span())
         .unwrap_or_else(|err| ctx.handle_error(err, fp))
 }
 
@@ -460,13 +414,12 @@ extern "C" fn __bsan_pop_frame(frame_start: *const Provenance, protected: usize)
 unsafe extern "C-unwind" fn __bsan_read(
     ptr: *mut c_void,
     access_size: usize,
-    alloc_id: AllocId,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("read", ptr, alloc_id, bor_tag, alloc_info);
+    debug_bsan!("read", ptr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     let fp = unsafe { fp!() };
     BorrowTracker::for_access(prov, ptr, Some(access_size), |mut bt| {
         bt.access(ctx, AccessKind::Read, fp.caller_span())
@@ -479,13 +432,12 @@ unsafe extern "C-unwind" fn __bsan_read(
 unsafe extern "C-unwind" fn __bsan_write(
     ptr: *mut c_void,
     access_size: usize,
-    alloc_id: AllocId,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) {
-    debug_bsan!("write", ptr, alloc_id, bor_tag, alloc_info);
+    debug_bsan!("write", ptr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     let fp = unsafe { fp!() };
 
     BorrowTracker::for_access(prov, ptr, Some(access_size), |mut bt| {
@@ -494,29 +446,48 @@ unsafe extern "C-unwind" fn __bsan_write(
     .unwrap_or_else(|err| ctx.handle_error(err, fp));
 }
 
+// Registers a heap allocation of size `size`, storing its provenance in the return pointer.
+#[unsafe(no_mangle)]
+unsafe extern "C-unwind" fn __bsan_alloc(
+    base_addr: *mut c_void,
+    size: usize,
+    bor_tag: BorTag,
+) -> NonNull<AllocInfo> {
+    let ctx = unsafe { global_ctx() };
+    let span = unsafe { fp!().caller_span() };
+
+    #[allow(clippy::let_and_return)]
+    let alloc_info = ctx.create_alloc_info(AllocInfo::new(base_addr, size, bor_tag, span));
+    debug_bsan!("alloc", base_addr, bor_tag, alloc_info.as_ptr());
+    alloc_info
+}
+
 /// Deregisters a heap allocation
 #[unsafe(no_mangle)]
 extern "C" fn __bsan_dealloc(
     ptr: *mut c_void,
-    alloc_id: AllocId,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
     weak: bool,
 ) {
-    debug_bsan!("dealloc", ptr, alloc_id, bor_tag, alloc_info);
+    debug_bsan!("dealloc", ptr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
-    let prov: Provenance = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov: Provenance = Provenance { bor_tag, alloc_info };
     let fp = unsafe { fp!() };
     if weak {
         if alloc_info.is_null() {
             return;
         }
-        if alloc_id != unsafe { (*alloc_info).alloc_id } {
+        if prov.bor_tag == BorTag::invalid() {
+            return;
+        }
+        if unsafe { (*prov.alloc_info).tree_lock.is_none() } {
             return;
         }
     }
+
     BorrowTracker::for_access(prov, ptr, None, |mut bt| bt.dealloc(ctx, fp.caller_span()))
-        .unwrap_or_else(|err| ctx.handle_error(err, fp));
+        .unwrap_or_else(|e| ctx.handle_error(e, fp));
 
     if !weak && let Some(alloc_info) = NonNull::new(alloc_info) {
         unsafe { ctx.destroy_alloc_info(alloc_info) };
@@ -571,24 +542,6 @@ extern "C" fn __bsan_validate_retval_tls(len: usize, prev_marker: FramePtr) {
         }
         ptr::write_volatile(&raw mut __BSAN_TLS_MARKER, prev_marker);
     }
-}
-
-// Registers a heap allocation of size `size`, storing its provenance in the return pointer.
-#[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_alloc(
-    base_addr: *mut c_void,
-    size: usize,
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-) -> NonNull<AllocInfo> {
-    let ctx = unsafe { global_ctx() };
-    let span = unsafe { fp!().caller_span() };
-
-    #[allow(clippy::let_and_return)]
-    let alloc_info =
-        ctx.create_alloc_info(AllocInfo::new(base_addr, size, alloc_id, bor_tag, span));
-    debug_bsan!("alloc", base_addr, alloc_id, bor_tag, alloc_info.as_ptr());
-    alloc_info
 }
 
 /// Copies the provenance stored in the range `[src_addr, src_addr + access_size)` within the shadow heap
@@ -647,39 +600,22 @@ unsafe extern "C" fn __bsan_destroy_stack_slot(slot: NonNull<AllocInfo>) {
 unsafe extern "C" fn __bsan_alloc_stack(
     base_addr: *mut c_void,
     size: usize,
-    alloc_id: AllocId,
     bor_tag: BorTag,
     alloc_info: NonNull<AllocInfo>,
 ) {
-    debug_bsan!(
-        "alloc_stack",
-        base_addr,
-        alloc_id,
-        bor_tag,
-        alloc_info.as_ptr().cast::<AllocInfo>()
-    );
+    debug_bsan!("alloc_stack", base_addr, bor_tag, alloc_info.as_ptr().cast::<AllocInfo>());
     let span = unsafe { fp!().caller_span() };
     unsafe {
-        alloc_info.write(AllocInfo::new(base_addr, size, alloc_id, bor_tag, span));
+        alloc_info.write(AllocInfo::new(base_addr, size, bor_tag, span));
     }
 }
-
-/// Marks the borrow tag for `prov` as "exposed," allowing it to be resolved to
-/// validate accesses through "wildcard" pointers.
-#[allow(unused)]
-#[unsafe(no_mangle)]
-extern "C" fn __bsan_expose_tag(alloc_id: AllocId, bor_tag: BorTag, alloc_info: *mut AllocInfo) {}
 
 // Code is more readable with explicit return
 #[allow(clippy::needless_return)]
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_null(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
+extern "C" fn __bsan_debug_assert_null(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let global_ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     if prov != Provenance::null() {
         crate::eprintln!("Expected null provenance, got {prov:?}");
         global_ctx.exit(1);
@@ -687,13 +623,9 @@ extern "C" fn __bsan_debug_assert_null(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_wildcard(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
+extern "C" fn __bsan_debug_assert_wildcard(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let global_ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     if prov != Provenance::wildcard() {
         crate::eprintln!("Expected wildcard provenance, got {prov:?}");
         global_ctx.exit(1);
@@ -701,43 +633,31 @@ extern "C" fn __bsan_debug_assert_wildcard(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_valid(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+extern "C" fn __bsan_debug_assert_valid(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+    let prov = Provenance { bor_tag, alloc_info };
     assert_ne!(prov, Provenance::null());
     assert_ne!(prov, Provenance::wildcard());
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_invalid(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
+extern "C" fn __bsan_debug_assert_invalid(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let global_ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     if !(prov == Provenance::null() || prov == Provenance::wildcard()) {
         global_ctx.exit(1);
     }
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_print(alloc_id: AllocId, bor_tag: BorTag, alloc_info: *mut AllocInfo) {
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+extern "C" fn __bsan_debug_print(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+    let prov = Provenance { bor_tag, alloc_info };
     crate::println!("{prov:?}");
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_print_borrow_state(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
+extern "C" fn __bsan_debug_print_borrow_state(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {
         bt.debug_print_tree(ctx, false);
         Ok(())
@@ -745,12 +665,8 @@ extern "C" fn __bsan_debug_print_borrow_state(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_tree_size(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+extern "C" fn __bsan_debug_tree_size(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+    let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {
         crate::println!("Tree size: {}", bt.debug_tree_size());
         Ok(())
@@ -758,13 +674,9 @@ extern "C" fn __bsan_debug_tree_size(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_snapshot(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
+extern "C" fn __bsan_debug_snapshot(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {
         bt.debug_take_snapshot(ctx);
         Ok(())
@@ -772,13 +684,9 @@ extern "C" fn __bsan_debug_snapshot(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_print_diff(
-    alloc_id: AllocId,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) {
+extern "C" fn __bsan_debug_print_diff(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { alloc_id, bor_tag, alloc_info };
+    let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {
         bt.debug_print_diff(ctx);
         Ok(())

--- a/tests/fail/free_box.run.stderr
+++ b/tests/fail/free_box.run.stderr
@@ -1,4 +1,4 @@
-error: Undefined Behavior: trying to access ALLOC, which has been freed.
+error: Undefined Behavior: trying to access an allocation that has been freed.
 backtrace:
   0:
     bsan/tests/fail/free_box.rs:12:9


### PR DESCRIPTION
This begins to address #115 by removing `AllocId` values from provenance. To detect UAF errors, we check if the tree associated with the `AllocInfo` of a provenance value is `None`. We also report a UAF if a tag is missing from a tree, instead of panicking.