### PR TITLE
Add LLVM weak attr wrapper for #118

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -169,13 +169,13 @@ extern "C" void __bsan_free_buffer(char *buf, uptr size) {
   }
 }
 
-// Weak (de)init attributes
+// Weak (de)init
 extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_init() {}
 extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_deinit() {}
 extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_local_init() {}
 extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_local_deinit() {}
 
-// Tagging operations
+// Weak tagging operations
 extern "C" SANITIZER_WEAK_ATTRIBUTE BorTag
 __bsan_retag(void *object_addr, usize access_size, u64 perm, BorTag bor_tag,
              AllocInfo *alloc_info, const usize im_data[2], usize im_len) {
@@ -206,14 +206,13 @@ __bsan_shadow_clear(void *dest, usize access_size) {}
 extern "C" SANITIZER_WEAK_ATTRIBUTE AllocInfo *__bsan_reserve_stack_slot() {
   return nullptr;
 }
-
 extern "C" SANITIZER_WEAK_ATTRIBUTE void
 __bsan_destroy_stack_slot(AllocInfo *slot) {}
 extern "C" SANITIZER_WEAK_ATTRIBUTE void
 __bsan_alloc_stack(void *base_addr, usize size, BorTag bor_tag,
                    AllocInfo *alloc_info) {}
 
-// Debugging
+// Weak Debugging
 extern "C" SANITIZER_WEAK_ATTRIBUTE void
 __bsan_debug_assert_null(BorTag bor_tag, AllocInfo *alloc_info) {}
 extern "C" SANITIZER_WEAK_ATTRIBUTE void

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -1,4 +1,5 @@
 #include "bsan.h"
+#include "bsan_interface.h"
 #include "bsan_thread.h"
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_file.h"
@@ -167,3 +168,65 @@ extern "C" void __bsan_free_buffer(char *buf, uptr size) {
     UnmapOrDie(buf, size);
   }
 }
+
+// Weak (de)init attributes
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_init() {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_deinit() {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_local_init() {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_local_deinit() {}
+
+// Tagging operations
+extern "C" SANITIZER_WEAK_ATTRIBUTE BorTag
+__bsan_retag(void *object_addr, usize access_size, u64 perm, BorTag bor_tag,
+             AllocInfo *alloc_info, const usize im_data[2], usize im_len) {
+  return bor_tag;
+}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_pop_frame(const Provenance *frame_start, usize protected_) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_read(void *ptr,
+                                                     usize access_size,
+                                                     BorTag bor_tag,
+                                                     AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_write(void *ptr,
+                                                      usize access_size,
+                                                      BorTag bor_tag,
+                                                      AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_dealloc(void *ptr, BorTag bor_tag, AllocInfo *alloc_info, bool weak) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE FramePtr __bsan_mark_tls() {
+  return nullptr;
+}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_validate_param_tls(usize len) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_validate_retval_tls(usize len, FramePtr prev_marker) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_shadow_copy(void *src, void *dest, usize access_size) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_shadow_clear(void *dest, usize access_size) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE AllocInfo *__bsan_reserve_stack_slot() {
+  return nullptr;
+}
+
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_destroy_stack_slot(AllocInfo *slot) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_alloc_stack(void *base_addr, usize size, BorTag bor_tag,
+                   AllocInfo *alloc_info) {}
+
+// Debugging
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_null(BorTag bor_tag, AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_wildcard(BorTag bor_tag, AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_valid(BorTag bor_tag, AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_invalid(BorTag bor_tag, AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_print(BorTag bor_tag, AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_print_borrow_state(BorTag bor_tag, AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_tree_size(BorTag bor_tag, AllocInfo *alloc_info) {}
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_print_diff(BorTag bor_tag, AllocInfo *alloc_info) {}

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -1,6 +1,5 @@
 #ifndef BSAN_H
 #define BSAN_H
-
 #include "sanitizer_common/sanitizer_internal_defs.h"
 
 extern THREADLOCAL void *__BSAN_CURR_THREAD;
@@ -11,8 +10,22 @@ extern bool bsan_deinit_is_running;
 
 #define BSAN_SANITIZER_TOOL_NAME "BorrowSanitizer"
 
+using namespace __sanitizer;
 namespace __bsan {
 void BsanTSDInit();
 void InitializeInterceptors();
 } // namespace __bsan
+
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE void
+__bsan_print_current_stack_trace();
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE void
+__bsan_print_stack_trace(u32 stackID);
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE uptr __bsan_get_top_frame_pc(uptr pc);
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE u32
+__bsan_StackDepotPut(uptr pc, uptr bp, u32 max_depth);
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE u32 __bsan_symbolize_pc(
+    uptr pc, char *file_buf, uptr file_buf_len, u32 *line, u32 *column);
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE uptr
+__bsan_read_file(const char *path, char **file_buf, uptr *file_buf_len);
+
 #endif // BSAN_H

--- a/bsan-rt/llvm-wrapper/bsan_interface.h
+++ b/bsan-rt/llvm-wrapper/bsan_interface.h
@@ -1,6 +1,6 @@
 #ifndef BSAN_INTERFACE_H
 #define BSAN_INTERFACE_H
-
+#include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_internal_defs.h"
 
 using namespace __sanitizer;
@@ -56,20 +56,6 @@ __bsan_destroy_stack_slot(AllocInfo *slot);
 extern "C" SANITIZER_WEAK_ATTRIBUTE void
 __bsan_alloc_stack(void *base_addr, usize size, BorTag bor_tag,
                    AllocInfo *alloc_info);
-
-// Symbolization
-extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_print_current_stack_trace();
-extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_print_stack_trace(u32 stackID);
-extern "C" SANITIZER_WEAK_ATTRIBUTE uptr __bsan_get_top_frame_pc(uptr pc);
-extern "C" SANITIZER_WEAK_ATTRIBUTE u32 __bsan_StackDepotPut(uptr pc, uptr bp,
-                                                             u32 max_depth);
-extern "C" SANITIZER_WEAK_ATTRIBUTE u32 __bsan_symbolize_pc(
-    uptr pc, char *file_buf, uptr file_buf_len, u32 *line, u32 *column);
-extern "C" SANITIZER_WEAK_ATTRIBUTE uptr __bsan_read_file(const char *path,
-                                                          char **file_buf,
-                                                          uptr *file_buf_len);
-extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_free_buffer(char *buf,
-                                                            uptr size);
 
 // Debuging
 extern "C" SANITIZER_WEAK_ATTRIBUTE void

--- a/bsan-rt/llvm-wrapper/bsan_interface.h
+++ b/bsan-rt/llvm-wrapper/bsan_interface.h
@@ -3,8 +3,90 @@
 
 #include "sanitizer_common/sanitizer_internal_defs.h"
 
+using namespace __sanitizer;
+using namespace __bsan;
+
+typedef usize BorTag;
+typedef struct AllocInfo AllocInfo;
+typedef struct Provenance Provenance;
+typedef const usize *FramePtr;
+
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __bsan_deinit();
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __bsan_init();
 extern "C" SANITIZER_INTERFACE_ATTRIBUTE void __bsan_reportError();
+
+// Weak (de)init attributes
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_deinit();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_init();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_reportError();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_init();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_deinit();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_local_init();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_local_deinit();
+
+// Tagging operations
+extern "C" SANITIZER_WEAK_ATTRIBUTE BorTag
+__bsan_retag(void *object_addr, usize access_size, u64 perm, BorTag bor_tag,
+             AllocInfo *alloc_info, const usize im_data[2], usize im_len);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_pop_frame(const Provenance *frame_start, usize protected_);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_read(void *ptr,
+                                                     usize access_size,
+                                                     BorTag bor_tag,
+                                                     AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_write(void *ptr,
+                                                      usize access_size,
+                                                      BorTag bor_tag,
+                                                      AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_dealloc(void *ptr, BorTag bor_tag, AllocInfo *alloc_info, bool weak);
+extern "C" SANITIZER_WEAK_ATTRIBUTE FramePtr __bsan_mark_tls();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_validate_param_tls(usize len);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_validate_retval_tls(usize len, FramePtr prev_marker);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_shadow_copy(void *src, void *dest, usize access_size);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_shadow_clear(void *dest,
+                                                             usize access_size);
+extern "C" SANITIZER_WEAK_ATTRIBUTE AllocInfo *__bsan_reserve_stack_slot();
+// TODO: __bsan_shadow_load
+// TODO: __bsan_shadow_store
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_destroy_stack_slot(AllocInfo *slot);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_alloc_stack(void *base_addr, usize size, BorTag bor_tag,
+                   AllocInfo *alloc_info);
+
+// Symbolization
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_print_current_stack_trace();
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_print_stack_trace(u32 stackID);
+extern "C" SANITIZER_WEAK_ATTRIBUTE uptr __bsan_get_top_frame_pc(uptr pc);
+extern "C" SANITIZER_WEAK_ATTRIBUTE u32 __bsan_StackDepotPut(uptr pc, uptr bp,
+                                                             u32 max_depth);
+extern "C" SANITIZER_WEAK_ATTRIBUTE u32 __bsan_symbolize_pc(
+    uptr pc, char *file_buf, uptr file_buf_len, u32 *line, u32 *column);
+extern "C" SANITIZER_WEAK_ATTRIBUTE uptr __bsan_read_file(const char *path,
+                                                          char **file_buf,
+                                                          uptr *file_buf_len);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void __bsan_free_buffer(char *buf,
+                                                            uptr size);
+
+// Debuging
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_null(BorTag bor_tag, AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_wildcard(BorTag bor_tag, AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_valid(BorTag bor_tag, AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_assert_invalid(BorTag bor_tag, AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_print(BorTag bor_tag, AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_print_borrow_state(BorTag bor_tag, AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_tree_size(BorTag bor_tag, AllocInfo *alloc_info);
+extern "C" SANITIZER_WEAK_ATTRIBUTE void
+__bsan_debug_print_diff(BorTag bor_tag, AllocInfo *alloc_info);
 
 #endif

--- a/bsan-rt/src/borrow_tracker/mod.rs
+++ b/bsan-rt/src/borrow_tracker/mod.rs
@@ -24,11 +24,11 @@ pub struct BorrowTracker<'b> {
 
 impl<'b> BorrowTracker<'b> {
     fn tree_mut(&mut self) -> &mut Tree {
-        &mut *self.tree
+        &mut self.tree
     }
 
     fn tree(&self) -> &Tree {
-        &*self.tree
+        &self.tree
     }
 
     pub fn for_alloc<T, F>(prov: Provenance, f: F) -> UBResult<Option<T>>


### PR DESCRIPTION
This pr adds `SANITIZER_WEAK_ATTRIBUTE` declarations and implementations for init/deinit, tagging and stack operations, and debug operations. It also adds internal symbolizer function declarations to `bsan.h`.

notes:
- The bug from this morning was because I hadn't added the `__sanitizer` namespace to `bsan.h` which would have been obvious if I had read the path in the error msg...
- Do symbolizer functions still need a weak attribute wrapper?
- fixes #118