### PR TITLE
Add hashbrown `lots_of_insertions` test

### DIFF
--- a/tests/pass-dep/lots_of_insertions.rs
+++ b/tests/pass-dep/lots_of_insertions.rs
@@ -1,4 +1,5 @@
 //@run:0
+// Taken from https://github.com/rust-lang/hashbrown
 use hashbrown::HashMap;
 
 const N: u32 = 10;


### PR DESCRIPTION
This pull request adds the `lots_of_insertions` test from the [`hashbrown`](https://github.com/rust-lang/hashbrown) crate. This test was taking an unreasonable amount of time to run when running `cargo bsan test` on `hashbrown`, so I have duplicated it with a constant parameter allowing one to change the amount of insertions (currently 10). The test stills runs relatively slowly (~30 seconds) but does pass. 