### PR TITLE
Print the source location of the error.

### DIFF
--- a/bsan-rt/src/borrow_tracker/mod.rs
+++ b/bsan-rt/src/borrow_tracker/mod.rs
@@ -108,16 +108,16 @@ impl<'b> BorrowTracker<'b> {
                 return if access_size != 0 { Err(UBInfo::UseAfterFree) } else { Ok(None) };
             };
 
-            let relative_offset = start.addr().wrapping_sub(base_addr);
-            if start.addr() < base_addr || (relative_offset + access_size > alloc_size) {
+            let offset = start.addr().wrapping_sub(base_addr);
+            if start.addr() < base_addr || (offset + access_size > alloc_size) {
                 return if access_size != 0 {
-                    Err(UBInfo::AccessOutOfBounds(alloc_id, access_size, alloc_size))
+                    Err(UBInfo::AccessOutOfBounds { alloc_id, access_size, alloc_size, offset })
                 } else {
                     Ok(None)
                 };
             }
 
-            let start = Size::from_bytes(relative_offset);
+            let start = Size::from_bytes(offset);
             let size = Size::from_bytes(access_size);
             let range = AllocRange { start, size };
 

--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -2,44 +2,26 @@
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::fmt::{Debug, Display};
+use core::fmt::{Debug};
 
 use hashbrown::HashMap;
 
 use crate::borrow_tracker::Permission;
 use crate::diagnostics::{AccessCause, HistoryData, NodeDebugInfo};
 use crate::sanitizer_common_interface::SanitizerCommon;
-use crate::span::Symbol;
+use crate::span::{Span, Symbol};
 use crate::AllocId;
 
 pub type TreeTransitionResult<T> = core::result::Result<T, TransitionError>;
 
 #[derive(Debug)]
 pub enum UBInfo {
-    AccessOutOfBounds(AllocId, usize, usize),
+    AccessOutOfBounds { alloc_id: AllocId, access_size: usize, offset: usize, alloc_size: usize },
     UseAfterFree,
     AliasingViolation(Box<TreeError>),
 }
 
 pub type UBResult<T> = Result<T, UBInfo>;
-
-impl Display for UBInfo {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "Undefined Behavior: ")?;
-        match self {
-            UBInfo::UseAfterFree => {
-                write!(f, "trying to access an allocation that has been freed.")
-            }
-            UBInfo::AccessOutOfBounds(id, size, offset) => {
-                write!(
-                    f,
-                    "an access of size {size} at offset {offset:x} is out of bounds for {id:?}."
-                )
-            }
-            UBInfo::AliasingViolation(error) => write!(f, "{error}"),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Copy)]
 pub enum TransitionError {
@@ -80,15 +62,47 @@ pub struct TreeError {
     pub accessed_info: NodeDebugInfo,
 }
 
-impl core::fmt::Display for TreeError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+#[derive(Default)]
+pub struct ErrorFormatContext {
+    file_cache: HashMap<String, String>,
+}
+
+impl ErrorFormatContext {
+    pub fn display_ub(&mut self, info: UBInfo, current_span: Span) -> String {
+        let mut result = String::new();
+        let symbol = current_span.symbolize();
+        result.push_str("Undefined Behavior: ");
+        match info {
+            UBInfo::UseAfterFree => {
+                result.push_str("trying to access an allocation that has been freed.\n");
+                result.push_str(&self.format_symbol(symbol));
+                result.push_str("\n");
+
+            }
+            UBInfo::AccessOutOfBounds { alloc_id, access_size, alloc_size, offset } => {
+                result.push_str(&format!(
+                    "an access of size {access_size} at offset {offset:x} is out of bounds for {alloc_id:?} of size {alloc_size:x}.\n"
+                ));
+                result.push_str(&self.format_symbol(symbol));
+                result.push_str("\n");
+            }
+            UBInfo::AliasingViolation(error) => {
+                result.push_str(&self.display_tree_error(*error, symbol))
+            }
+        }
+        result
+    }
+
+    fn display_tree_error(&mut self, error: TreeError, symbol: Symbol) -> String {
+        let mut buffer = String::new();
+
         use TransitionError::*;
-        let cause = self.access_cause;
-        let error_offset = self.error_offset;
-        let access = self.access_cause;
-        let accessed = &self.accessed_info;
+        let cause = error.access_cause;
+        let error_offset = error.error_offset;
+        let access = error.access_cause;
+        let accessed = &error.accessed_info;
         let accessed_tag = accessed.tag;
-        let conflicting = &self.conflicting_info;
+        let conflicting = &error.conflicting_info;
 
         // An access is considered conflicting if it happened through a
         // different tag than the one who caused UB.
@@ -101,10 +115,10 @@ impl core::fmt::Display for TreeError {
         let accessed_is_conflicting = accessed.tag == conflicting.tag;
         let title = format!(
             "{cause} through {accessed_tag:?} at {alloc_id:?}[{error_offset:#x}] is forbidden",
-            alloc_id = self.alloc_id
+            alloc_id = error.alloc_id
         );
 
-        let (title, details, conflicting_tag_name) = match self.error_kind {
+        let (title, details, conflicting_tag_name) = match error.error_kind {
             ChildAccessForbidden(perm) => {
                 let conflicting_tag_name =
                     if accessed_is_conflicting { "accessed" } else { "conflicting" };
@@ -145,38 +159,47 @@ impl core::fmt::Display for TreeError {
         };
         let mut history = HistoryData::default();
         if !accessed_is_conflicting {
-            history.extend(self.accessed_info.history.forget(), "accessed", false);
+            history.extend(error.accessed_info.history.forget(), "accessed", false);
         }
         history.extend(
-            self.conflicting_info.history.extract_relevant(error_offset),
+            error.conflicting_info.history.extract_relevant(error_offset),
             conflicting_tag_name,
             true,
         );
 
-        writeln!(f, "{title}")?;
+        buffer.push_str(&title);
+        buffer.push_str("\n");
+        buffer.push_str(&self.format_symbol(symbol));
+        buffer.push_str("\n");
         for detail in details {
-            writeln!(f, "help: {}", detail)?;
+            buffer.push_str(&format!("help: {}\n", detail));
         }
 
-        let mut file_cache: HashMap<String, String> = HashMap::new();
         for event in history.events {
-            writeln!(f, "    help: {}", event.1)?;
+            buffer.push_str(&format!("    help: {}\n", event.1));
             if let Some(span) = event.0 {
                 let symbol = span.symbolize();
-                writeln!(f, "      --> {}", symbol)?;
-                if let Symbol::Resolved { file: path, line, col: _ } = symbol {
-                    let file = file_cache
-                        .entry(path.clone())
-                        .or_insert_with(|| SanitizerCommon::read_file(&path).unwrap_or_default());
-                    if let Some(content) = SanitizerCommon::get_source_line(file, line) {
-                        writeln!(f, "         |")?;
-                        writeln!(f, "{:>8} | {}", line, content)?;
-                        writeln!(f, "         |")?;
-                    }
-                }
+                buffer.push_str(&self.format_symbol(symbol));
             }
-            writeln!(f)?;
+            buffer.push('\n');
         }
-        Ok(())
+        buffer
+    }
+
+    fn format_symbol(&mut self, symbol: Symbol) -> String {
+        let mut buffer = String::new();
+        buffer.push_str(&format!("      --> {}\n", symbol));
+        if let Symbol::Resolved { file: path, line, col: _ } = symbol {
+            let file = self
+                .file_cache
+                .entry(path.clone())
+                .or_insert_with(|| SanitizerCommon::read_file(&path).unwrap_or_default());
+            if let Some(content) = SanitizerCommon::get_source_line(file, line) {
+                buffer.push_str("         |\n");
+                buffer.push_str(&format!("{:>8} | {}\n", line, content));
+                buffer.push_str("         |\n");
+            }
+        }
+        buffer
     }
 }

--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -2,7 +2,7 @@
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::fmt::{Debug};
+use core::fmt::Debug;
 
 use hashbrown::HashMap;
 
@@ -76,15 +76,14 @@ impl ErrorFormatContext {
             UBInfo::UseAfterFree => {
                 result.push_str("trying to access an allocation that has been freed.\n");
                 result.push_str(&self.format_symbol(symbol));
-                result.push_str("\n");
-
+                result.push('\n');
             }
             UBInfo::AccessOutOfBounds { alloc_id, access_size, alloc_size, offset } => {
                 result.push_str(&format!(
                     "an access of size {access_size} at offset {offset:x} is out of bounds for {alloc_id:?} of size {alloc_size:x}.\n"
                 ));
                 result.push_str(&self.format_symbol(symbol));
-                result.push_str("\n");
+                result.push('\n');
             }
             UBInfo::AliasingViolation(error) => {
                 result.push_str(&self.display_tree_error(*error, symbol))
@@ -168,9 +167,9 @@ impl ErrorFormatContext {
         );
 
         buffer.push_str(&title);
-        buffer.push_str("\n");
+        buffer.push('\n');
         buffer.push_str(&self.format_symbol(symbol));
-        buffer.push_str("\n");
+        buffer.push('\n');
         for detail in details {
             buffer.push_str(&format!("help: {}\n", detail));
         }

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -6,7 +6,7 @@ use core::ptr::NonNull;
 use borrow_tracker::ProtectorKind;
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
-use crate::errors::UBInfo;
+use crate::errors::{ErrorFormatContext, UBInfo};
 use crate::helpers::FxHashMap;
 use crate::local::{deinit_local_ctx, init_local_ctx, local_ctx, local_ctx_mut, LocalCtx};
 use crate::memory::{Heap, ShadowHeap};
@@ -146,7 +146,8 @@ impl GlobalCtx {
     }
 
     pub fn handle_error(&self, ub_info: UBInfo, fp: FramePtr) -> ! {
-        crate::eprintln!("error: {ub_info}");
+        let mut ctx = ErrorFormatContext::default();
+        crate::eprint!("error: {}", ctx.display_ub(ub_info, fp.caller_span()));
         crate::eprintln!("backtrace:");
         for (i, frame) in fp.take(3).enumerate() {
             crate::eprintln!("  {i}:\n    {}", frame.symbolize());

--- a/tests/fail/access_oob.run.stderr
+++ b/tests/fail/access_oob.run.stderr
@@ -1,4 +1,9 @@
-error: Undefined Behavior: an access of size 4 at offset 4 is out of bounds for ALLOC.
+error: Undefined Behavior: an access of size 4 at offset 4 is out of bounds for ALLOC of size 4.
+      --> RUSTLIB/core/src/ptr/mod.rs:1910:9
+         |
+    1910 | intrinsics::write_via_move(dst, src)
+         |
+
 backtrace:
   0:
     RUSTLIB/core/src/ptr/mod.rs:1910:9

--- a/tests/fail/forbidden_child_access.run.stderr
+++ b/tests/fail/forbidden_child_access.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> RUSTLIB/core/src/hint.rs:481:0
+         |
+     481 | pub const fn black_box<T>(dummy: T) -> T {
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/fail/forbidden_child_access.rs:5:23
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/fail/free_box.run.stderr
+++ b/tests/fail/free_box.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: trying to access an allocation that has been freed.
+      --> bsan/tests/fail/free_box.rs:12:9
+         |
+      12 | *ptr = 1;
+         |
+
 backtrace:
   0:
     bsan/tests/fail/free_box.rs:12:9

--- a/tests/fail/frozen_write.run.stderr
+++ b/tests/fail/frozen_write.run.stderr
@@ -1,11 +1,15 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/fail/frozen_write.rs:9:14
+         |
+       9 | unsafe { *(ptr as *mut i32) = 1 };
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/fail/frozen_write.rs:4:14
          |
        4 | let rx = &x;
          |
-
 
 backtrace:
   0:

--- a/tests/fail/protected_write.run.stderr
+++ b/tests/fail/protected_write.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/fail/protected_write.rs:10:14
+         |
+      10 | unsafe { *p = 1 };
+         |
+
 help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this write would cause the protected tag <TAG>(StrongProtector) (currently Reserved) to become Disabled
 help: protected tags must never be Disabled
@@ -13,7 +18,6 @@ help: protected tags must never be Disabled
          |
        9 | fn foo(_r: &mut i32, p: *mut i32) {
          |
-
 
 backtrace:
   0:

--- a/tests/fail/unique_ref.run.stderr
+++ b/tests/fail/unique_ref.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/fail/unique_ref.rs:9:9
+         |
+       9 | *ptr_x = 1;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/fail/unique_ref.rs:4:14
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/alias_through_mutation.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/alias_through_mutation.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: read through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/alias_through_mutation.rs:16:16
+         |
+      16 | let _val = *target_alias;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this read
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/alias_through_mutation.rs:6:14
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/aliasing_mut1.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/aliasing_mut1.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/aliasing_mut1.rs:6:5
+         |
+       6 | *x = 1;
+         |
+
 help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this write
     help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/both_borrows/aliasing_mut1.rs:4:0
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) wh
          |
 
     help: this transition corresponds to a temporary loss of write permissions until function exit
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/aliasing_mut2.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/aliasing_mut2.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/aliasing_mut2.rs:7:5
+         |
+       7 | *y = 2;
+         |
+
 help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this write
     help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/both_borrows/aliasing_mut2.rs:4:0
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) wh
          |
 
     help: this transition corresponds to a temporary loss of write permissions until function exit
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/aliasing_mut3.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/aliasing_mut3.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/aliasing_mut3.rs:6:5
+         |
+       6 | *x = 1;
+         |
+
 help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this write
     help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/both_borrows/aliasing_mut3.rs:4:0
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) wh
          |
 
     help: this transition corresponds to a temporary loss of write permissions until function exit
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/aliasing_mut4.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/aliasing_mut4.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> RUSTLIB/core/src/mem/mod.rs:901:9
+         |
+     901 | crate::intrinsics::write_via_move(dest, src);
+         |
+
 help: the accessed tag <TAG>(StrongProtector) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this write would cause the protected tag <TAG>(StrongProtector) (currently Frozen) to become Disabled
 help: protected tags must never be Disabled
@@ -13,7 +18,6 @@ help: protected tags must never be Disabled
          |
        6 | fn safe(x: &i32, y: &mut Cell<i32>) {
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/box_exclusive_violation1.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/box_exclusive_violation1.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/box_exclusive_violation1.rs:29:9
+         |
+      29 | *LEAK = 7;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/box_exclusive_violation1.rs:21:0
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/box_noalias_violation.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/box_noalias_violation.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: read through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/box_noalias_violation.rs:7:5
+         |
+       7 | *y
+         |
+
 help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(WeakProtector) (i.e., it is not a child)
 help: this read would cause the protected tag <TAG>(WeakProtector) (currently Active) to become Disabled
 help: protected tags must never be Disabled
@@ -21,7 +26,6 @@ help: protected tags must never be Disabled
          |
 
     help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/buggy_as_mut_slice.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/buggy_as_mut_slice.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x4] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/buggy_as_mut_slice.rs:16:5
+         |
+      16 | v2[1] = 7;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/both_borrows/buggy_as_mut_slice.rs:13:14
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/buggy_split_at_mut.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/buggy_split_at_mut.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x4] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/buggy_split_at_mut.rs:25:5
+         |
+      25 | b[1] = 6;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/both_borrows/buggy_split_at_mut.rs:14:17
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/illegal_write1.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/illegal_write1.run.stderr
@@ -1,11 +1,15 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/illegal_write1.rs:10:18
+         |
+      10 | unsafe { *x = 42 };
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/illegal_write1.rs:7:16
          |
        7 | let xref = &*target;
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/illegal_write5.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/illegal_write5.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: read through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/illegal_write5.rs:12:16
+         |
+      12 | let _val = *xref;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this read
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/both_borrows/illegal_write5.rs:9:25
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/illegal_write6.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/illegal_write6.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/illegal_write6.rs:12:14
+         |
+      12 | unsafe { *y = 2 };
+         |
+
 help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this write would cause the protected tag <TAG>(StrongProtector) (currently Active) to become Disabled
 help: protected tags must never be Disabled
@@ -21,7 +26,6 @@ help: protected tags must never be Disabled
          |
 
     help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/invalidate_against_protector2.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/invalidate_against_protector2.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/invalidate_against_protector2.rs:7:14
+         |
+       7 | unsafe { *x = 0 };
+         |
+
 help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this write would cause the protected tag <TAG>(StrongProtector) (currently Frozen) to become Disabled
 help: protected tags must never be Disabled
@@ -13,7 +18,6 @@ help: protected tags must never be Disabled
          |
        3 | fn inner(x: *mut i32, _y: &i32) {
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/invalidate_against_protector3.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/invalidate_against_protector3.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/invalidate_against_protector3.rs:9:14
+         |
+       9 | unsafe { *x = 0 };
+         |
+
 help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this write would cause the protected tag <TAG>(StrongProtector) (currently Frozen) to become Disabled
 help: protected tags must never be Disabled
@@ -9,7 +14,6 @@ help: protected tags must never be Disabled
          |
        5 | fn inner(x: *mut i32, _y: &i32) {
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/issue-miri-1050-1.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/issue-miri-1050-1.run.stderr
@@ -1,4 +1,9 @@
-error: Undefined Behavior: an access of size 4 at offset 2 is out of bounds for ALLOC.
+error: Undefined Behavior: an access of size 4 at offset 0 is out of bounds for ALLOC of size 2.
+      --> RUSTLIB/alloc/src/boxed.rs:1266:18
+         |
+    1266 | unsafe { Self::from_raw_in(raw, Global) }
+         |
+
 backtrace:
   0:
     RUSTLIB/alloc/src/boxed.rs:1266:18

--- a/tests/miri-tests/fail/both_borrows/mut_exclusive_violation1.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/mut_exclusive_violation1.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/mut_exclusive_violation1.rs:29:9
+         |
+      29 | *LEAK = 7;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/mut_exclusive_violation1.rs:21:0
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/mut_exclusive_violation2.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/mut_exclusive_violation2.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/mut_exclusive_violation2.rs:13:9
+         |
+      13 | *raw1 = 3;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/both_borrows/mut_exclusive_violation2.rs:9:25
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/newtype_pair_retagging.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/newtype_pair_retagging.run.stderr
@@ -1,4 +1,5 @@
 error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x0] is forbidden
+      --> RUSTLIB/std/src/sys/alloc/PLATFORM.rs:l:c
 help: the accessed tag <TAG>(WeakProtector) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this deallocation would cause the protected tag <TAG>(StrongProtector) (currently Reserved (conflicted)) to become Disabled
 help: protected tags must never be Disabled
@@ -21,7 +22,6 @@ help: protected tags must never be Disabled
          |
 
     help: this transition corresponds to a temporary loss of write permissions until function exit
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/newtype_retagging.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/newtype_retagging.run.stderr
@@ -1,4 +1,5 @@
 error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x0] is forbidden
+      --> RUSTLIB/std/src/sys/alloc/PLATFORM.rs:l:c
 help: the accessed tag <TAG>(WeakProtector) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this deallocation would cause the protected tag <TAG>(StrongProtector) (currently Reserved (conflicted)) to become Disabled
 help: protected tags must never be Disabled
@@ -21,7 +22,6 @@ help: protected tags must never be Disabled
          |
 
     help: this transition corresponds to a temporary loss of write permissions until function exit
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/outdated_local.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/outdated_local.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: read through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/outdated_local.rs:8:25
+         |
+       8 | assert_eq!(unsafe { *y }, 1);
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this read
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/outdated_local.rs:5:25
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/pass_invalid_shr.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/pass_invalid_shr.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/pass_invalid_shr.rs:11:9
+         |
+      11 | foo(xref);
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/pass_invalid_shr.rs:9:25
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/pass_invalid_shr_option.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/pass_invalid_shr_option.run.stderr
@@ -1,4 +1,6 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/pass_invalid_shr_option.rs:0:27
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/pass_invalid_shr_option.rs:9:35
@@ -13,7 +15,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/pass_invalid_shr_tuple.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/pass_invalid_shr_tuple.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/pass_invalid_shr_tuple.rs:4:0
+         |
+       4 | fn foo(_: (&i32, &i32)) {}
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/pass_invalid_shr_tuple.rs:10:31
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/return_invalid_shr.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/return_invalid_shr.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x4] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/return_invalid_shr.rs:8:5
+         |
+       8 | ret
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/return_invalid_shr.rs:6:24
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/return_invalid_shr_option.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/return_invalid_shr_option.run.stderr
@@ -1,4 +1,6 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x4] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/return_invalid_shr_option.rs:0:5
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/return_invalid_shr_option.rs:6:29
@@ -13,7 +15,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/return_invalid_shr_tuple.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/return_invalid_shr_tuple.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x4] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/return_invalid_shr_tuple.rs:14:5
+         |
+      14 | foo(&mut (1, 2)).0;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/return_invalid_shr_tuple.rs:6:25
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/shr_frozen_violation1.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/shr_frozen_violation1.run.stderr
@@ -1,11 +1,15 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/shr_frozen_violation1.rs:17:9
+         |
+      17 | *(x as *const i32 as *mut i32) = 7;
+         |
+
 help: the accessed tag <TAG>(StrongProtector) has state Frozen which forbids this write
     help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/shr_frozen_violation1.rs:15:0
          |
       15 | fn unknown_code(x: &i32) {
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/both_borrows/shr_frozen_violation2.run.stderr
+++ b/tests/miri-tests/fail/both_borrows/shr_frozen_violation2.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: read through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/both_borrows/shr_frozen_violation2.rs:9:20
+         |
+       9 | let _val = *frozen;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this read
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/both_borrows/shr_frozen_violation2.rs:6:22
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/alternate-read-write.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/alternate-read-write.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/alternate-read-write.rs:17:5
+         |
+      17 | *y += 1; // Failure
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/tree_borrows/alternate-read-write.rs:7:22
@@ -21,7 +26,6 @@ help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this wr
          |
 
     help: this transition corresponds to a loss of write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/error-range.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/error-range.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: read through <TAG>(unprotected) at ALLOC[0x5] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/error-range.rs:25:9
+         |
+      25 | rmut[5] += 1;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this read
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/tree_borrows/error-range.rs:12:20
@@ -29,7 +34,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/fnentry_invalidation.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/fnentry_invalidation.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/fnentry_invalidation.rs:19:9
+         |
+      19 | *z = 2;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/tree_borrows/fnentry_invalidation.rs:13:13
@@ -21,7 +26,6 @@ help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this wr
          |
 
     help: this transition corresponds to a loss of write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/frozen-lazy-write-to-surrounding.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/frozen-lazy-write-to-surrounding.run.stderr
@@ -1,11 +1,15 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> RUSTLIB/core/src/ptr/mod.rs:1910:9
+         |
+    1910 | intrinsics::write_via_move(dst, src)
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
       --> bsan/tests/miri-tests/fail/tree_borrows/frozen-lazy-write-to-surrounding.rs:6:13
          |
        6 | let x = &pair.0;
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/outside-range.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/outside-range.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x3] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/outside-range.rs:21:5
+         |
+      21 | *y.add(3) = 42;
+         |
+
 help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
 help: this write would cause the protected tag <TAG>(StrongProtector) (currently Reserved) to become Disabled
 help: protected tags must never be Disabled
@@ -13,7 +18,6 @@ help: protected tags must never be Disabled
          |
       13 | unsafe fn stuff(x: &mut u8, y: *mut u8) {
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/parent_read_freezes_raw_mut.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/parent_read_freezes_raw_mut.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/parent_read_freezes_raw_mut.rs:12:9
+         |
+      12 | *ptr = 0;
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/tree_borrows/parent_read_freezes_raw_mut.rs:8:20
@@ -21,7 +26,6 @@ help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this wr
          |
 
     help: this transition corresponds to a loss of write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/pass_invalid_mut.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/pass_invalid_mut.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/pass_invalid_mut.rs:10:5
+         |
+      10 | *nope = 31;
+         |
+
 help: the accessed tag <TAG>(StrongProtector) is a child of the conflicting tag <TAG>(unprotected)
 help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(StrongProtector) was created here
@@ -28,7 +33,6 @@ help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this
          |
 
     help: this transition corresponds to a loss of write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/protector-write-lazy.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/protector-write-lazy.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/protector-write-lazy.rs:34:14
+         |
+      34 | unsafe { println!("Value of funky: {}", *funky_ptr_lazy_on_fst_elem) }
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/tree_borrows/protector-write-lazy.rs:17:18
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.rs:11:5
+         |
+      11 | *(x as *mut u8).byte_sub(1) = 42;
+         |
+
 help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this write
     help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/tree_borrows/repeated_foreign_read_lazy_conflicted.rs:7:0
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) wh
          |
 
     help: this transition corresponds to a temporary loss of write permissions until function exit
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/return_invalid_mut.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/return_invalid_mut.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(unprotected) at ALLOC[0x4] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/return_invalid_mut.rs:21:5
+         |
+      21 | *ret = 3;
+         |
+
 help: the accessed tag <TAG>(unprotected) is a child of the conflicting tag <TAG>(unprotected)
 help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(unprotected) was created here
@@ -28,7 +33,6 @@ help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this
          |
 
     help: this transition corresponds to a loss of write permissions
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/strongly-protected.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/strongly-protected.run.stderr
@@ -1,4 +1,5 @@
 error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x0] is forbidden
+      --> RUSTLIB/std/src/sys/alloc/PLATFORM.rs:l:c
 help: the allocation of the accessed tag <TAG>(WeakProtector) also contains the strongly protected tag <TAG>(StrongProtector)
 help: the strongly protected tag <TAG>(StrongProtector) disallows deallocations
     help: the accessed tag <TAG>(WeakProtector) was created here
@@ -16,7 +17,6 @@ help: the strongly protected tag <TAG>(StrongProtector) disallows deallocations
     help: the strongly protected tag <TAG>(StrongProtector) later transitioned due to a deallocation (acting as a child write access)
       --> RUSTLIB/std/src/sys/alloc/PLATFORM.rs:l:c
     help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: write through <TAG>(StrongProtector) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/subtree_traversal_skipping_diagnostics.rs:19:5
+         |
+      19 | *m = 42;
+         |
+
 help: the accessed tag <TAG>(StrongProtector) is a child of the conflicting tag <TAG>(unprotected)
 help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this write
     help: the accessed tag <TAG>(StrongProtector) was created here
@@ -12,7 +17,6 @@ help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this
          |
       25 | let intermediary = &root;
          |
-
 
 backtrace:
   0:

--- a/tests/miri-tests/fail/tree_borrows/write-during-2phase.run.stderr
+++ b/tests/miri-tests/fail/tree_borrows/write-during-2phase.run.stderr
@@ -1,4 +1,9 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+      --> bsan/tests/miri-tests/fail/tree_borrows/write-during-2phase.rs:11:0
+         |
+      11 | fn add(&mut self, n: u64) -> u64 {
+         |
+
 help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow
     help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
       --> bsan/tests/miri-tests/fail/tree_borrows/write-during-2phase.rs:20:15
@@ -13,7 +18,6 @@ help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this 
          |
 
     help: this transition corresponds to a loss of read and write permissions
-
 
 backtrace:
   0:

--- a/tests/pass-dep/lots_of_insertions.rs
+++ b/tests/pass-dep/lots_of_insertions.rs
@@ -2,14 +2,14 @@
 // Taken from https://github.com/rust-lang/hashbrown
 use hashbrown::HashMap;
 
-const N: u32 = 10;
+const N: u32 = 3;
 
 fn main() {
     let mut m = HashMap::new();
 
     // Try this a few times to make sure we never screw up the hashmap's
     // internal state.
-    for _ in 0..10 {
+    for _ in 0..N {
         assert!(m.is_empty());
 
         for i in 1..(N + 1) {


### PR DESCRIPTION
Adds the source location where the error is triggered to our error messages. 

Access out-of-bounds errors have slightly different formatting to better indicate the offset and size of the allocation.