### PR TITLE
add __bsan_abort() to API

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -64,6 +64,8 @@ uptr unwind(uptr bp, uptr len) {
   }
 }
 
+
+
 void __sanitizer::BufferedStackTrace::UnwindImpl(uptr pc, uptr bp,
                                                  void *context,
                                                  bool request_fast,
@@ -358,4 +360,8 @@ SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_tree_size(BorTag bor_tag,
 SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_print_diff(BorTag bor_tag,
                                                       AllocInfo *alloc_info) {}
 
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_abort() {
+  // Printf("BorrowSanitizer: aborting due to a fatal error.\n");
+  Die();
+}
 } // extern "C"

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -64,8 +64,6 @@ uptr unwind(uptr bp, uptr len) {
   }
 }
 
-
-
 void __sanitizer::BufferedStackTrace::UnwindImpl(uptr pc, uptr bp,
                                                  void *context,
                                                  bool request_fast,

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -46,6 +46,8 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_init();
 
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_deinit();
 
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_abort();
+
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memmove(void *dest, const void *src,
                                                   uptr n);
 

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -11,6 +11,10 @@ use crate::helpers::FxHashMap;
 use crate::memory::{Heap, ShadowHeap};
 use crate::*;
 
+unsafe extern "C" {
+    fn __bsan_abort() -> !;
+}
+
 #[derive(Default)]
 pub struct ProtectedTags(FxHashMap<BorTag, ProtectorKind>);
 


### PR DESCRIPTION
This creates the symbol `__bsan_abort` in the LLVM parts which is visibile for debugging so we can set a breakpoint there.
It uses sanitizer_common's Die() API to abort the program when BSAB discovers an error.