### PR TITLE
Handle inline assembly conservatively

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -833,11 +833,10 @@ private:
     }
 
     if (CB.isInlineAsm()) {
-      if (ClHandleAsmConservative) {
+      if (ClHandleAsmConservative)
         visitAsmInstruction(CB);
-      } else
-        // TODO: What is the difference in our case?
-        visitAsmInstruction(CB);
+      else
+        return;
     }
 
     // If we've made it here, then we don't have a hard-coded way to handle this
@@ -925,36 +924,24 @@ private:
   }
 
   void visitAsmInstruction(Instruction &I) {
-    // Conservative inline assembly handling: check for poisoned shadow of
-    // asm() arguments, then unpoison the result and all the memory locations
-    // pointed to by those arguments.
-    // An inline asm() statement in C++ contains lists of input and output
-    // arguments used by the assembly code. These are mapped to operands of the
-    // CallInst as follows:
-    //  - nR register outputs ("=r) are returned by value in a single structure
-    //  (SSA value of the CallInst);
-    //  - nO other outputs ("=m" and others) are returned by pointer as first
-    // nO operands of the CallInst;
-    //  - nI inputs ("r", "m" and others) are passed to CallInst as the
-    // remaining nI operands.
-    // The total number of asm() arguments in the source is nR+nO+nI, and the
-    // corresponding CallInst has nO+nI+1 operands (the last operand is the
-    // function to be called).
     CallBase *CB = cast<CallBase>(&I);
+    IRBuilder<> IRB(&I);
     InlineAsm *IA = cast<InlineAsm>(CB->getCalledOperand());
     int NumOutputs = getNumOutputArgs(IA, CB);
 
     // Get the output arguments
-    for (int I = 0; I < NumOutputs; I++) {
-      Value *Operand = CB->getOperand(I);
+    for (int J = 0; J < NumOutputs; J++) {
+      Value *Operand = CB->getOperand(J);
 
       Type *OpType = Operand->getType();
 
-      if (!OpType->isPointerTy())
-        return;
+      // Handle aggregate values
+      SmallVector<ProvenanceComponent> *Components =
+          getProvenanceComponents(IRB, OpType);
 
-      // Set provenance as wildcard for each output pointer
-      setProvenance(Operand, BS.WildcardProvenance);
+      for (const auto &[Idx, Comp] : llvm::enumerate(*Components)) {
+        setProvenance({Operand, Idx}, BS.WildcardProvenance);
+      }
     }
   }
 

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -28,6 +28,16 @@
 
 using namespace llvm;
 
+/*
+* CLI Argument for handling inline assembly
+*/
+static cl::opt<bool> ClHandleAsmConservative(
+  "bsan-asm-conservative",
+  cl::desc("Conservatively handle inline assembly by setting all pointer outputs to wildcard Provenance"),
+  cl::Hidden,
+  cl::init(true)
+);
+
 class BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
   friend class InstVisitor<BorrowSanitizerVisitor>;
   BorrowSanitizer &BS;
@@ -824,7 +834,13 @@ private:
     }
 
     if (CB.isInlineAsm())
-      return;
+    {
+      if (ClHandleAsmConservative) {
+          visitAsmInstruction(CB);
+      } else 
+        // TODO: What is the difference in our case?
+        visitAsmInstruction(CB);
+    }
 
     // If we've made it here, then we don't have a hard-coded way to handle this
     // function. We need to pass its arguments into our thread-local array and
@@ -910,6 +926,65 @@ private:
     }
   }
 
+  void visitAsmInstruction(Instruction &I) {
+    // Conservative inline assembly handling: check for poisoned shadow of
+    // asm() arguments, then unpoison the result and all the memory locations
+    // pointed to by those arguments.
+    // An inline asm() statement in C++ contains lists of input and output
+    // arguments used by the assembly code. These are mapped to operands of the
+    // CallInst as follows:
+    //  - nR register outputs ("=r) are returned by value in a single structure
+    //  (SSA value of the CallInst);
+    //  - nO other outputs ("=m" and others) are returned by pointer as first
+    // nO operands of the CallInst;
+    //  - nI inputs ("r", "m" and others) are passed to CallInst as the
+    // remaining nI operands.
+    // The total number of asm() arguments in the source is nR+nO+nI, and the
+    // corresponding CallInst has nO+nI+1 operands (the last operand is the
+    // function to be called).
+    CallBase *CB = cast<CallBase>(&I);
+    InlineAsm *IA = cast<InlineAsm>(CB->getCalledOperand());
+    int NumOutputs = getNumOutputArgs(IA, CB);
+
+    // Get the output arguments
+    for (int i = 0; i < NumOutputs; i++) {
+      Value *Operand = CB->getOperand(i);
+
+      Type *OpType = Operand->getType();
+
+      if (!OpType->isPointerTy()) return;
+
+      // Set provenance as wildcard for each output pointer
+      setProvenance(Operand, BS.WildcardProvenance);
+    }
+  }
+
+  // Ported from MSAN
+  /// Get the number of output arguments returned by pointers.
+  int getNumOutputArgs(InlineAsm *IA, CallBase *CB) {
+    int NumRetOutputs = 0;
+    int NumOutputs = 0;
+    Type *RetTy = cast<Value>(CB)->getType();
+    if (!RetTy->isVoidTy()) {
+      // Register outputs are returned via the CallInst return value.
+      auto *ST = dyn_cast<StructType>(RetTy);
+      if (ST)
+        NumRetOutputs = ST->getNumElements();
+      else
+        NumRetOutputs = 1;
+    }
+    InlineAsm::ConstraintInfoVector Constraints = IA->ParseConstraints();
+    for (const InlineAsm::ConstraintInfo &Info : Constraints) {
+      switch (Info.Type) {
+      case InlineAsm::isOutput:
+        NumOutputs++;
+        break;
+      default:
+        break;
+      }
+    }
+    return NumOutputs - NumRetOutputs;
+  }
   ProvenanceScalar
   createScalarProvenancePHI(IRBuilder<> &IRB,
                             iterator_range<pred_iterator> Blocks) {

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -29,14 +29,13 @@
 using namespace llvm;
 
 /*
-* CLI Argument for handling inline assembly
-*/
+ * CLI Argument for handling inline assembly
+ */
 static cl::opt<bool> ClHandleAsmConservative(
-  "bsan-asm-conservative",
-  cl::desc("Conservatively handle inline assembly by setting all pointer outputs to wildcard Provenance"),
-  cl::Hidden,
-  cl::init(true)
-);
+    "bsan-asm-conservative",
+    cl::desc("Conservatively handle inline assembly by setting all pointer "
+             "outputs to wildcard Provenance"),
+    cl::Hidden, cl::init(true));
 
 class BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
   friend class InstVisitor<BorrowSanitizerVisitor>;
@@ -833,11 +832,10 @@ private:
       }
     }
 
-    if (CB.isInlineAsm())
-    {
+    if (CB.isInlineAsm()) {
       if (ClHandleAsmConservative) {
-          visitAsmInstruction(CB);
-      } else 
+        visitAsmInstruction(CB);
+      } else
         // TODO: What is the difference in our case?
         visitAsmInstruction(CB);
     }
@@ -947,12 +945,13 @@ private:
     int NumOutputs = getNumOutputArgs(IA, CB);
 
     // Get the output arguments
-    for (int i = 0; i < NumOutputs; i++) {
-      Value *Operand = CB->getOperand(i);
+    for (int I = 0; I < NumOutputs; I++) {
+      Value *Operand = CB->getOperand(I);
 
       Type *OpType = Operand->getType();
 
-      if (!OpType->isPointerTy()) return;
+      if (!OpType->isPointerTy())
+        return;
 
       // Set provenance as wildcard for each output pointer
       setProvenance(Operand, BS.WildcardProvenance);

--- a/tests/fail/inline_asm.rs
+++ b/tests/fail/inline_asm.rs
@@ -1,0 +1,24 @@
+use std::arch::asm;
+
+extern "C" {
+    fn __bsan_debug_print(ptr: *mut u8);
+}
+//@ revisions: asm-conservative none
+
+// We are conservative by default
+// Note: It seems as though passing in flags to LLVM plugins is not supported by rustc due to versioning
+// concerns. See https://internals.rust-lang.org/t/should-rustc-support-custom-llvm-plugin/13807
+// TODO: Investigate this for future reference
+//@ [asm-conservative] compile-flags:
+//@ [none] compile-flags: -Z llvm-plugins=~/.rustup/toolchains/bsan/libbsan_plugin.so -C llvm-args="-bsan-asm-conservative=false" -C passes="bsan-pass"
+fn main() {
+    let x: u64;
+    unsafe {
+        asm!("mov {}, 67", out(reg) x); // very interesting syntax for the constraints
+    }
+
+    // We need to print out it's provenance value to check if it was correctly set to Wildcard
+    unsafe {
+        __bsan_debug_print(x as *mut u8);
+    }
+}

--- a/tests/pass/inline_asm.none.stderr
+++ b/tests/pass/inline_asm.none.stderr
@@ -1,0 +1,2 @@
+rustc -Cllvm-args="..." with: Unknown command line argument '-bsan-asm-conservative=false'.  Try: 'rustc -Cllvm-args="..." with --help'
+rustc -Cllvm-args="..." with: Did you mean '--msan-handle-asm-conservative=false'?

--- a/tests/pass/inline_asm.rs
+++ b/tests/pass/inline_asm.rs
@@ -3,14 +3,18 @@ use std::arch::asm;
 extern "C" {
     fn __bsan_debug_print(ptr: *mut u8);
 }
-//@ revisions: asm-conservative none
+// Note: Using `` as escapes for the directives
+// `@ revisions: asm-conservative none`
 
 // We are conservative by default
-// Note: It seems as though passing in flags to LLVM plugins is not supported by rustc due to versioning
+// `@ [asm-conservative] run`
+// It seems as though passing in flags to LLVM plugins is not supported by rustc due to versioning
 // concerns. See https://internals.rust-lang.org/t/should-rustc-support-custom-llvm-plugin/13807
-// TODO: Investigate this for future reference
-//@ [asm-conservative] compile-flags:
-//@ [none] compile-flags: -Z llvm-plugins=~/.rustup/toolchains/bsan/libbsan_plugin.so -C llvm-args="-bsan-asm-conservative=false" -C passes="bsan-pass"
+// TODO: Investigate this for future reference)
+// `@ [none] compile-flags: -Z llvm-plugins=~/.rustup/toolchains/bsan/libbsan_plugin.so -C llvm-args="-bsan-asm-conservative=false" -C passes="bsan-pass"`
+
+
+//@ run
 fn main() {
     let x: u64;
     unsafe {

--- a/tests/pass/inline_asm.run.stdout
+++ b/tests/pass/inline_asm.run.stdout
@@ -1,0 +1,1 @@
+Provenance { bor_tag: <TAG>(unprotected), alloc_info: 0x0 }


### PR DESCRIPTION
### Adds very simple implementation that sets output pointers in inline assembly to have `wildcard` provenance values.

TODOS:
- [x] Figure out the difference between handling it conservatively (default) and without the flag
- [x] Write a simple test case
- [x] Remove `llvm-sparse` artifact from `.devcontainer/Dockerfile` (moved)
- [x] Handle aggregate values



Closes #135 