### PR TITLE
Fix doctests and enforce matching LLVM version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,10 +202,12 @@ name = "cargo-bsan"
 version = "0.1.0"
 dependencies = [
  "cargo_metadata 0.21.0",
+ "cfg-if",
  "directories",
  "env_logger",
  "log",
  "path_macro",
+ "regex",
  "rustc-build-sysroot",
  "rustc_tools_util",
  "rustc_version",

--- a/bsan-pass/BorrowSanitizerPass.cpp
+++ b/bsan-pass/BorrowSanitizerPass.cpp
@@ -49,6 +49,15 @@ static llvm::PassPluginLibraryInfo getBorrowSanitizerPluginInfo() {
                                                   ThinOrFullLTOPhase Phase) {
               MPM.addPass(BorrowSanitizerPass(BorrowSanitizerOptions()));
             });
+            PB.registerPipelineParsingCallback(
+                [](StringRef Name, ModulePassManager &MPM,
+                   ArrayRef<PassBuilder::PipelineElement>) {
+                  if (Name == "bsan") {
+                    MPM.addPass(BorrowSanitizerPass(BorrowSanitizerOptions()));
+                    return true;
+                  }
+                  return false;
+                });
           }};
 }
 

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -151,10 +151,11 @@ impl Command {
             let cargo_bsan = env.build_artifact(CargoBsan, &[])?;
             let sysroot_dir = path!(&env.build_dir / "sysroot");
 
-            let mut env_guards = vec![];
-            env_guards.push(env.sh.push_env("BSAN_PLUGIN", &plugin));
-            env_guards.push(env.sh.push_env("BSAN_RT", &runtime));
-            env_guards.push(env.sh.push_env("BSAN_SYSROOT", &sysroot_dir));
+            let env_guards = vec![
+                env.sh.push_env("BSAN_PLUGIN", &plugin),
+                env.sh.push_env("BSAN_RT", &runtime),
+                env.sh.push_env("BSAN_SYSROOT", &sysroot_dir),
+            ];
 
             cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;
             let flags = cmd!(env.sh, "{cargo_bsan} bsan setup --print-rustflags").output()?;
@@ -167,6 +168,8 @@ impl Command {
                 .arg(format!("--sysroot={}", sysroot_dir.display()))
                 .quiet()
                 .run()?;
+
+            drop(env_guards);
 
             Ok(())
         })
@@ -393,10 +396,9 @@ impl CompilerRt {
 impl Buildable for CompilerRt {
     fn artifact(&self, env: &BsanEnv) -> String {
         let host = &env.toolchain_config.meta.host;
-        let arch = host
-            .split("-")
-            .next()
-            .expect(&format!("Invalid target triple: `{}`", env.toolchain_config.meta.host));
+        let arch = host.split("-").next().unwrap_or_else(|| {
+            panic!("Invalid target triple: `{}`", env.toolchain_config.meta.host)
+        });
         format!("libclang_rt.bsan-{}.a", arch)
     }
 
@@ -438,7 +440,7 @@ impl Buildable for BsanRtCore {
     }
 
     fn test(&self, env: &mut BsanEnv, args: &[String]) -> Result<()> {
-        env.with_flags("RUSTFLAGS", &RT_FLAGS, |env| env.test("bsan-rt", args))
+        env.with_flags("RUSTFLAGS", RT_FLAGS, |env| env.test("bsan-rt", args))
     }
 
     fn clippy(&self, env: &mut BsanEnv, args: &[String]) -> Result<()> {

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -65,7 +65,7 @@ fn ensure_toolchain(
     }
 
     if let Some(meta) = metadata {
-        return Ok(meta);
+        Ok(meta)
     } else {
         // First, check if the current platform is supported.
         let current_target = &host.host;
@@ -77,13 +77,7 @@ fn ensure_toolchain(
         skip_prompt = skip_prompt || local_dir.is_some();
         if let Some(PromptResult::Yes) = prompt_user_unless(skip_prompt, INSTALL_PROMPT)? {
             fs::create_dir_all(toolchain_dir)?;
-            install_toolchain(
-                sh,
-                host,
-                config,
-                toolchain_dir,
-                local_dir.as_ref().map(|inner| inner.as_path()),
-            )
+            install_toolchain(sh, host, config, toolchain_dir, local_dir.as_deref())
         } else {
             std::process::exit(0)
         }
@@ -106,8 +100,6 @@ fn install_toolchain(
     let help_on_error = "Failed to download the custom Rust toolchain.";
 
     let tmp_dir = sh.create_temp_dir()?;
-
-    let local_dir: Option<&Path> = local_dir.map(|dir| dir);
 
     let download_unpack_install = |prefix: &str, needs_target: bool| -> Result<()> {
         // Download the .tar.xz file
@@ -196,7 +188,7 @@ pub fn ensure_llvm_cmake(
         cmd!(sh, "cp -fr {tmp_dir}/llvm {toolchain_dir}").run()?;
         cmd!(sh, "cp -fr {tmp_dir}/cmake {toolchain_dir}").run()?;
 
-        fs::write(lockfile, &branch)?;
+        fs::write(lockfile, branch)?;
     }
 
     let link_source = path!(root_dir / "bsan-rt" / "llvm-wrapper");

--- a/cargo-bsan/Cargo.toml
+++ b/cargo-bsan/Cargo.toml
@@ -17,6 +17,3 @@ cfg-if = "1.0.4"
 
 [build-dependencies]
 rustc_tools_util = "0.4"
-
-[package.metadata.rust-analyzer]
-rustc_private = true

--- a/cargo-bsan/Cargo.toml
+++ b/cargo-bsan/Cargo.toml
@@ -12,6 +12,8 @@ rustc-build-sysroot = "0.5.11"
 rustc_version = "0.4"
 path_macro = "1.0.0"
 which = "8.0.0"
+regex = "1.12.3"
+cfg-if = "1.0.4"
 
 [build-dependencies]
 rustc_tools_util = "0.4"

--- a/cargo-bsan/src/llvm.rs
+++ b/cargo-bsan/src/llvm.rs
@@ -1,0 +1,107 @@
+use std::env;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use regex::Regex;
+use rustc_version::{LlvmVersion, VersionMeta};
+
+use crate::util::{assert_host_binary, get_sysroot_target_dir, show_error};
+
+fn rustc_lld(sysroot_target_bindir: &Path) -> PathBuf {
+    let lld_binary = |prefix: &str| format!("{}.lld", prefix);
+    cfg_if::cfg_if! {
+        if #[cfg(target_family = "unix")] {
+            sysroot_target_bindir.join("gcc-ld").join(lld_binary("ld"))
+        } else {
+            show_error!("Only unix targets are supported.");
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct LlvmTools {
+    pub version: LlvmVersion,
+    pub clang: PathBuf,
+    pub llvm_symbolizer: PathBuf,
+    pub lld: PathBuf,
+}
+
+impl LlvmTools {
+    pub fn new(rustc_version: &VersionMeta, verbose: usize) -> Self {
+        let rustc_llvm_version = rustc_version.llvm_version.clone().unwrap_or_else(|| {
+            show_error!("Unable to resolve the LLVM version for the current `rustc`.")
+        });
+
+        let clang = assert_host_binary(&format!("clang-{}", rustc_llvm_version.major), verbose);
+        let llvm_symbolizer = assert_host_binary("llvm-symbolizer", verbose);
+
+        let clang_llvm_version = assert_llvm_version(&clang);
+
+        if rustc_llvm_version != clang_llvm_version {
+            show_error!(
+                "Mismatched LLVM versions between `rustc` ({}) and `clang` ({})",
+                rustc_llvm_version,
+                clang_llvm_version
+            );
+        }
+
+        let sysroot_target_dir = get_sysroot_target_dir(rustc_version, verbose);
+
+        let sysroot_target_bindir = sysroot_target_dir.join("bin");
+
+        let lld = rustc_lld(&sysroot_target_bindir);
+
+        let lld_llvm_version = assert_llvm_version(&lld);
+
+        if rustc_llvm_version != lld_llvm_version {
+            show_error!(
+                "Mismatched LLVM versions between `rustc` ({}) and `lld` ({})",
+                rustc_llvm_version,
+                lld_llvm_version
+            );
+        }
+
+        LlvmTools { version: rustc_llvm_version, clang, llvm_symbolizer, lld }
+    }
+
+    pub fn populate_env(&self, cmd: &mut Command) {
+        cmd.env("CC", &self.clang);
+        cmd.env("CXX", &self.clang);
+        cmd.env("LLD", &self.lld);
+    }
+
+    #[allow(unused)]
+    pub fn carry_env(cmd: &mut Command) {
+        for env in ["LLD", "CC", "CXX", "CFLAGS", "CXXFLAGS", "CPPFLAGS"] {
+            if let Some(val) = env::var_os(env) {
+                cmd.env(env, val);
+            }
+        }
+    }
+}
+
+fn assert_llvm_version(binary: &PathBuf) -> LlvmVersion {
+    let output = command_output(Command::new(binary).arg("--version")).unwrap_or_else(|| {
+        show_error!("Unable to obtain the LLVM version for `{}`", binary.display());
+    });
+
+    try_parse_llvm_version(&output).unwrap_or_else(|| {
+        show_error!("Unable to parse LLVM version for `{}`, found:\n{output}", binary.display());
+    })
+}
+
+fn command_output(cmd: &mut Command) -> Option<String> {
+    cmd.output().ok().and_then(|output| String::from_utf8(output.stdout).ok())
+}
+
+fn try_parse_llvm_version(version_string: &str) -> Option<LlvmVersion> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let version_regex = RE.get_or_init(|| Regex::new(r"(\d+)\.(\d+).\d+").expect("Invalid regex"));
+    let captures = version_regex.captures(version_string)?;
+    (captures.len() == 3).then(|| {
+        let major = captures.get(1)?.as_str().parse().ok()?;
+        let minor = captures.get(2)?.as_str().parse().ok()?;
+        Some(LlvmVersion { major, minor })
+    })?
+}

--- a/cargo-bsan/src/llvm.rs
+++ b/cargo-bsan/src/llvm.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use regex::Regex;
 use rustc_version::{LlvmVersion, VersionMeta};
 
-use crate::util::{assert_host_binary, get_sysroot_target_dir, show_error};
+use crate::util::{assert_host_binary, show_error, Sysroot};
 
 fn rustc_lld(sysroot_target_bindir: &Path) -> PathBuf {
     let lld_binary = |prefix: &str| format!("{}.lld", prefix);
@@ -28,13 +28,14 @@ pub struct LlvmTools {
 }
 
 impl LlvmTools {
-    pub fn new(rustc_version: &VersionMeta, verbose: usize) -> Self {
+    pub fn new(rustc_version: &VersionMeta, host_sysroot: &Sysroot) -> Self {
         let rustc_llvm_version = rustc_version.llvm_version.clone().unwrap_or_else(|| {
             show_error!("Unable to resolve the LLVM version for the current `rustc`.")
         });
 
-        let clang = assert_host_binary(&format!("clang-{}", rustc_llvm_version.major), verbose);
-        let llvm_symbolizer = assert_host_binary("llvm-symbolizer", verbose);
+        let clang =
+            assert_host_binary(host_sysroot, &format!("clang-{}", rustc_llvm_version.major));
+        let llvm_symbolizer = assert_host_binary(host_sysroot, "llvm-symbolizer");
 
         let clang_llvm_version = assert_llvm_version(&clang);
 
@@ -46,7 +47,7 @@ impl LlvmTools {
             );
         }
 
-        let sysroot_target_dir = get_sysroot_target_dir(rustc_version, verbose);
+        let sysroot_target_dir = host_sysroot.target_dir(rustc_version);
 
         let sysroot_target_bindir = sysroot_target_dir.join("bin");
 

--- a/cargo-bsan/src/llvm.rs
+++ b/cargo-bsan/src/llvm.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use regex::Regex;
 use rustc_version::{LlvmVersion, VersionMeta};
 
-use crate::util::{assert_host_binary, show_error, Sysroot};
+use crate::util::{assert_host_binary, expect_env_path, show_error, Sysroot};
 
 fn rustc_lld(sysroot_target_bindir: &Path) -> PathBuf {
     let lld_binary = |prefix: &str| format!("{}.lld", prefix);
@@ -21,7 +21,6 @@ fn rustc_lld(sysroot_target_bindir: &Path) -> PathBuf {
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LlvmTools {
-    pub version: LlvmVersion,
     pub clang: PathBuf,
     pub llvm_symbolizer: PathBuf,
     pub lld: PathBuf,
@@ -63,13 +62,21 @@ impl LlvmTools {
             );
         }
 
-        LlvmTools { version: rustc_llvm_version, clang, llvm_symbolizer, lld }
+        LlvmTools { clang, llvm_symbolizer, lld }
     }
 
     pub fn populate_env(&self, cmd: &mut Command) {
         cmd.env("CC", &self.clang);
         cmd.env("CXX", &self.clang);
+        cmd.env("LLVM_SYMBOLIZER", &self.clang);
         cmd.env("LLD", &self.lld);
+    }
+
+    pub fn from_env() -> Self {
+        let clang = expect_env_path("CC");
+        let llvm_symbolizer = expect_env_path("LLVM_SYMBOLIZER");
+        let lld = expect_env_path("LLD");
+        Self { clang, llvm_symbolizer, lld }
     }
 
     #[allow(unused)]

--- a/cargo-bsan/src/main.rs
+++ b/cargo-bsan/src/main.rs
@@ -1,16 +1,22 @@
-#![feature(rustc_private)]
-
 mod arg;
 mod llvm;
 mod phases;
 mod setup;
 mod util;
 
-use std::env;
+use std::{env, iter};
 
 use phases::*;
 
 use crate::util::*;
+
+/// Returns `true` if our flags look like they may be for rustdoc, i.e., this is cargo calling us to
+/// be rustdoc. It's hard to be sure as cargo does not have a RUSTDOC_WRAPPER or an env var that
+/// would let us get a clear signal.
+fn looks_like_rustdoc() -> bool {
+    // The `--test-run-directory` flag only exists for rustdoc and cargo always passes it. Perfect!
+    env::args().any(|arg| arg == "--test-run-directory")
+}
 
 fn main() {
     env_logger::init();
@@ -30,6 +36,29 @@ fn main() {
         )
     };
 
+    // The way rustdoc invokes rustc is indistinguishable from the way cargo invokes rustdoc by the
+    // arguments alone. `phase_cargo_rustdoc` sets this environment variable to let us disambiguate.
+    if env::var_os("BSAN_CALLED_FROM_RUSTDOC").is_some() {
+        // ...however, we then also see this variable when rustdoc invokes us as the testrunner!
+        // In that case the first argument is `runner` and there are no more arguments.
+        match first.as_str() {
+            flag if flag.starts_with("--") || flag.starts_with("@") => {
+                // This is probably rustdoc invoking us to build the test. But we need to get `first`
+                // "back onto the iterator", it is some part of the rustc invocation.
+                phase_rustc(iter::once(first).chain(args), RustcPhase::Rustdoc);
+            }
+            _ => {
+                show_error!(
+                    "`cargo-bsan` failed to recognize which phase of the build process this is, please report a bug.\n\
+                    We are inside BSAN_CALLED_FROM_RUSTDOC.\n\
+                    The command-line arguments were: {:#?}",
+                    Vec::from_iter(env::args()),
+                );
+            }
+        }
+        return;
+    }
+
     match first.as_str() {
         "bsan" => phase_cargo_bsan(args),
         arg if arg == env::var("RUSTC").unwrap_or_else(|_| {
@@ -42,6 +71,11 @@ fn main() {
             // behavior of having both RUSTC and RUSTC_WRAPPER set
             // (see https://github.com/rust-lang/cargo/issues/10886).
             phase_rustc(args, RustcPhase::Build)
+        }
+        _ if looks_like_rustdoc() => {
+            // This is probably rustdoc. But we need to get `first` "back onto the iterator",
+            // it is some part of the rustdoc invocation.
+            phase_rustdoc(iter::once(first).chain(args));
         }
         _ => {
             show_error!(

--- a/cargo-bsan/src/main.rs
+++ b/cargo-bsan/src/main.rs
@@ -8,56 +8,17 @@ mod util;
 
 use std::env;
 
-use log::debug;
 use phases::*;
 
 use crate::util::*;
 
-const CARGO_BSAN_HELP: &str = r"Runs binary crates and tests with BorrowSanitizer enabled.
-
-Usage:
-    cargo bsan [subcommand] [<cargo options>...] [--] [<program/test suite options>...]
-
-Subcommands:
-    run, r                   Run binaries
-    test, t                  Run tests
-    nextest                  Run tests with nextest (requires cargo-nextest installed)
-    setup                    Only perform automatic setup, but without asking questions (for getting a proper libstd)
-    clean                    Clean the BorrowSanitizer cache & target directory
-
-The cargo options are exactly the same as for `cargo run` and `cargo test`, respectively.
-
-Examples:
-    cargo bsan run
-    cargo bsan test -- test-suite-filter
-
-    cargo bsan setup --print-sysroot
-        This will print the path to the generated sysroot (and nothing else) on stdout.
-        stderr will still contain progress information about how the build is doing.
-";
-
-fn show_help() {
-    println!("{CARGO_BSAN_HELP}");
-}
-
-fn show_version() {
-    print!("bsan {}", env!("CARGO_PKG_VERSION"));
-    let version = format!("{} {}", env!("GIT_HASH"), env!("COMMIT_DATE"));
-    if version.len() > 1 {
-        // If there is actually something here, print it.
-        print!(" ({version})");
-    }
-    println!();
-}
-
 fn main() {
     env_logger::init();
     let mut args = env::args();
-    debug!("args: {args:?}",);
 
     // Skip binary name.
     args.next().unwrap();
-    // Dispatch running as part of sysroot compilation.
+
     if env::var_os("BSAN_CALLED_FROM_SETUP").is_some() {
         phase_rustc(args, RustcPhase::Setup);
         return;
@@ -71,15 +32,22 @@ fn main() {
 
     match first.as_str() {
         "bsan" => phase_cargo_bsan(args),
-
-        arg if Some(arg) == env::var("RUSTC").as_ref().ok().map(|s| s.as_str()) => {
+        arg if arg == env::var("RUSTC").unwrap_or_else(|_| {
+            show_error!(
+                "`cargo-bsan` called without RUSTC set; please only invoke this binary through `cargo bsan`"
+            )
+        }) => {
             // If the first arg is equal to the RUSTC env variable (which should be set at this
             // point), then we need to behave as rustc. This is the somewhat counter-intuitive
             // behavior of having both RUSTC and RUSTC_WRAPPER set
             // (see https://github.com/rust-lang/cargo/issues/10886).
             phase_rustc(args, RustcPhase::Build)
         }
-
-        _ => show_help(),
+        _ => {
+            show_error!(
+                "`cargo-bsan` failed to recognize which phase of the build process this is, please report a bug.\nThe command-line arguments were: {:#?}",
+                Vec::from_iter(env::args()),
+            );
+        }
     }
 }

--- a/cargo-bsan/src/main.rs
+++ b/cargo-bsan/src/main.rs
@@ -3,7 +3,6 @@ mod llvm;
 mod phases;
 mod setup;
 mod util;
-
 use std::{env, iter};
 
 use phases::*;

--- a/cargo-bsan/src/main.rs
+++ b/cargo-bsan/src/main.rs
@@ -1,6 +1,7 @@
 #![feature(rustc_private)]
 
 mod arg;
+mod llvm;
 mod phases;
 mod setup;
 mod util;

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -107,8 +107,9 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     }
 
     let llvm_tools = LlvmTools::new(&rustc_version, &host_sysroot);
-    let deps =
-        Deps::setup(&subcommand, &rustc_version, &host_sysroot, target_sysroot, verbose, quiet);
+    let deps = Deps::setup(&host_sysroot);
+
+    setup_sysroot(&subcommand, &rustc_version, &target_sysroot, verbose, quiet);
 
     let cargo_cmd = match subcommand {
         BsanCommand::Forward(s) => s,
@@ -186,7 +187,7 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     cmd.env("RUSTDOC", &cargo_bsan_path);
 
     cmd.env("BSAN_SYMBOLIZER", llvm_tools.llvm_symbolizer);
-    cmd.env("BSAN_SYSROOT", &deps.target_sysroot.as_os_str());
+    cmd.env("BSAN_SYSROOT", &target_sysroot.as_os_str());
 
     // Run cargo.
     debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
@@ -220,12 +221,16 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     // Arguments are treated very differently depending on whether this crate needs to be
     // instrumented by BorrowSanitizer or if it's for a build script / proc macro.
     if target_crate {
-        if phase != RustcPhase::Setup && phase != RustcPhase::Rustdoc {
-            // Set the sysroot -- except during setup, where we don't have an existing sysroot yet
-            // and where the bootstrap wrapper adds its own `--sysroot` flag so we can't set ours.
+        if phase == RustcPhase::Build {
+            // We only set the sysroot during an explicit build step.
+            // During setup, where we don't have an existing sysroot yet
+            // and the bootstrap wrapper adds its own `--sysroot` flag, so we can't set ours.
+            // Rustdoc already receives the sysroot via its dedicated phase, so we do not want
+            // to set it twice.
             cmd.arg("--sysroot").arg(expect_env("BSAN_SYSROOT"));
         }
-        // During setup, patch the panic runtime for `libpanic_abort` (mirroring what bootstrap usually does).
+        // During setup, patch the panic runtime for `libpanic_abort`
+        // (mirroring what bootstrap usually does).
         if phase == RustcPhase::Setup
             && get_arg_flag_value("--crate-name").as_deref() == Some("panic_abort")
         {
@@ -245,7 +250,7 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
     if in_rustdoc {
         if verbose > 0 {
-            eprintln!("[cargo-miri rustc inside rustdoc] going to run:\n{cmd:?}");
+            eprintln!("[cargo-miri rustc inside rustdoc]");
         }
         exec_with_pipe(cmd);
     } else {

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -1,8 +1,7 @@
-use std::path::PathBuf;
-
 use rustc_version::VersionMeta;
 
 use crate::arg::*;
+use crate::llvm::LlvmTools;
 use crate::setup::*;
 use crate::util::*;
 use crate::*;
@@ -49,7 +48,7 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
 
     // Determine the involved architectures.
     let rustc_version = VersionMeta::for_command(rustc())
-        .unwrap_or_else(|err| panic!("failed to determine underlying rustc version:\n{err:?}"));
+        .unwrap_or_else(|err| show_error!("Unknown `rustc` version: {err:?}"));
 
     let targets = get_arg_flag_values("--target").collect::<Vec<_>>();
 
@@ -67,21 +66,22 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         return;
     }
 
-    let bsan_sysroot = ensure_sysroot(&subcommand, &rustc_version, verbose, quiet);
+    let llvm_tools = LlvmTools::new(&rustc_version, verbose);
+    let deps = Deps::setup(&subcommand, &rustc_version, verbose, quiet);
 
     let cargo_cmd = match subcommand {
         BsanCommand::Forward(s) => s,
         BsanCommand::Clean => unreachable!(),
         BsanCommand::Setup => {
             if has_arg_flag("--print-rustflags") {
-                println!("{}", bsan_rustflags().join(" "))
+                println!("{}", bsan_rustflags(&deps).join(" "))
             }
             return;
         }
     };
 
-    let metadata = get_cargo_metadata();
-    let mut cmd = cargo();
+    let metadata = Cargo::metadata();
+    let mut cmd = Cargo::cmd();
     cmd.arg(&cargo_cmd);
     // In nextest we have to also forward the main `verb`.
     if cargo_cmd == "nextest" {
@@ -117,22 +117,21 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     }
     cmd.env_remove("RUSTC_WORKSPACE_WRAPPER");
 
-    // At this point, we've completed setup, so we have a sysroot.
-    cmd.env("BSAN_SYSROOT", &bsan_sysroot);
-
     if verbose > 0 {
         cmd.env("BSAN_VERBOSE", verbose.to_string()); // This makes the other phases verbose.
     }
 
-    let llvm_symbolizer = get_host_sysroot_binary("llvm-symbolizer", verbose);
-    cmd.env("BSAN_SYMBOLIZER", llvm_symbolizer);
+    llvm_tools.populate_env(&mut cmd);
 
-    let mut rustflags = bsan_rustflags();
-    let sysroot_flag = format!("--sysroot={}", bsan_sysroot.display());
-    rustflags.push(format!("--sysroot={}", bsan_sysroot.display()));
+    cmd.env("BSAN_SYMBOLIZER", llvm_tools.llvm_symbolizer);
+
+    let mut rustflags = bsan_rustflags(&deps);
+    let sysroot_flag = format!("--sysroot={}", deps.target_sysroot.display());
+    rustflags.push(sysroot_flag.clone());
 
     cmd.env("RUSTFLAGS", rustflags.join(" "));
     cmd.env("RUSTDOCFLAGS", sysroot_flag);
+
     // Run cargo.
     debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
     exec(cmd)
@@ -152,6 +151,8 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     fn is_target_crate() -> bool {
         get_arg_flag_value("--target").is_some()
     }
+
+    let deps = Deps::from_env();
 
     let verbose = env::var("BSAN_VERBOSE")
         .map_or(0, |verbose| verbose.parse().expect("verbosity flag must be an integer"));
@@ -177,7 +178,7 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     }
 
     if target_crate {
-        cmd.args(bsan_rustflags());
+        cmd.args(bsan_rustflags(&deps));
     }
 
     // Forward everything else.
@@ -190,42 +191,10 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     exec(cmd);
 }
 
-fn ensure_sysroot(
-    subcommand: &BsanCommand,
-    rustc_version: &VersionMeta,
-    verbose: usize,
-    quiet: bool,
-) -> PathBuf {
-    let host_sysroot = get_host_sysroot_dir(verbose);
-    let Some(bsan_plugin) = find_library("BSAN_PLUGIN", &host_sysroot, "libbsan_plugin.so") else {
-        show_error!(
-            "failed to locate the BorrowSanitizer LLVM plugin (libbsan_plugin.so) within the host sysroot: {}",
-                host_sysroot.display()
-        );
-    };
-    unsafe {
-        env::set_var("BSAN_PLUGIN", bsan_plugin);
-    }
-
-    let Some(runtime_dir) = find_library("BSAN_RT", &host_sysroot, "libbsan_rt.a") else {
-        show_error!(
-            "failed to locate the BorrowSanitizer runtime (libbsan_rt.a) within the host sysroot."
-        );
-    };
-    unsafe {
-        env::set_var("BSAN_RT", runtime_dir);
-    }
-
-    setup_sysroot(subcommand, rustc_version.host.as_str(), rustc_version, verbose, quiet);
-    get_target_sysroot_dir()
-}
-
-fn bsan_rustflags() -> Vec<String> {
-    let rt = expect_env_path("BSAN_RT");
-    let plugin = expect_env_path("BSAN_PLUGIN");
-    let rt_dir = rt.parent().unwrap();
+fn bsan_rustflags(deps: &Deps) -> Vec<String> {
+    let rt_dir = deps.runtime.parent().unwrap();
     let mut additional_args = BSAN_DEFAULT_ARGS.iter().map(ToString::to_string).collect::<Vec<_>>();
-    additional_args.push(format!("-Zllvm-plugins={}", plugin.display()));
+    additional_args.push(format!("-Zllvm-plugins={}", deps.llvm_pass.display()));
     additional_args.push(format!("-L{}", rt_dir.display()));
     additional_args.push("-lstatic=bsan_rt".to_string());
     additional_args

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -16,7 +16,7 @@ Usage:
 Subcommands:
     run, r                   Run binaries
     test, t                  Run tests
-    nextest                  Run tests with nextest (requires cargo-nextest installed)
+    nextest                  Run tests with nextest (requires `cargo-nextest` to be installed)
     setup                    Only perform automatic setup, but without asking questions (for getting a proper libstd)
     clean                    Clean the BorrowSanitizer cache & target directory
 
@@ -39,7 +39,6 @@ fn show_version() {
     print!("bsan {}", env!("CARGO_PKG_VERSION"));
     let version = format!("{} {}", env!("GIT_HASH"), env!("COMMIT_DATE"));
     if version.len() > 1 {
-        // If there is actually something here, print it.
         print!(" ({version})");
     }
     println!();
@@ -181,6 +180,10 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     llvm_tools.populate_env(&mut cmd);
 
     cmd.env("RUSTC", rustc_path());
+    if let Some(orig_rustdoc) = env::var_os("RUSTDOC") {
+        cmd.env("BSAN_ORIG_RUSTDOC", orig_rustdoc);
+    }
+    cmd.env("RUSTDOC", &cargo_bsan_path);
 
     cmd.env("BSAN_SYMBOLIZER", llvm_tools.llvm_symbolizer);
     cmd.env("BSAN_SYSROOT", &deps.target_sysroot.as_os_str());
@@ -217,7 +220,7 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     // Arguments are treated very differently depending on whether this crate needs to be
     // instrumented by BorrowSanitizer or if it's for a build script / proc macro.
     if target_crate {
-        if phase != RustcPhase::Setup {
+        if phase != RustcPhase::Setup && phase != RustcPhase::Rustdoc {
             // Set the sysroot -- except during setup, where we don't have an existing sysroot yet
             // and where the bootstrap wrapper adds its own `--sysroot` flag so we can't set ours.
             cmd.arg("--sysroot").arg(expect_env("BSAN_SYSROOT"));
@@ -230,6 +233,8 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
         }
     }
 
+    let in_rustdoc = phase == RustcPhase::Rustdoc;
+
     if target_crate {
         cmd.args(bsan_rustflags(&deps));
     }
@@ -237,11 +242,18 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     // Forward everything else.
     cmd.args(args);
 
-    if verbose > 0 {
-        eprintln!("[cargo-bsan rustc] target_crate={target_crate}");
-    }
     debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
-    exec(cmd);
+    if in_rustdoc {
+        if verbose > 0 {
+            eprintln!("[cargo-miri rustc inside rustdoc] going to run:\n{cmd:?}");
+        }
+        exec_with_pipe(cmd);
+    } else {
+        if verbose > 0 {
+            eprintln!("[cargo-bsan rustc] target_crate={target_crate}");
+        }
+        exec(cmd);
+    }
 }
 
 fn bsan_rustflags(deps: &Deps) -> Vec<String> {
@@ -251,4 +263,36 @@ fn bsan_rustflags(deps: &Deps) -> Vec<String> {
     additional_args.push(format!("-L{}", rt_dir.display()));
     additional_args.push("-lstatic=bsan_rt".to_string());
     additional_args
+}
+
+pub fn phase_rustdoc(args: impl Iterator<Item = String>) {
+    let verbose = env::var("BSAN_VERBOSE")
+        .map_or(0, |verbose| verbose.parse().expect("verbosity flag must be an integer"));
+    let mut cmd = rustdoc();
+    cmd.args(args);
+
+    // For each doctest, rustdoc starts two child processes: first the test is compiled,
+    // then the produced executable is invoked. We want to reroute both of these to cargo-miri,
+    // such that the first time we'll enter phase_cargo_rustc, and phase_cargo_runner second.
+    //
+    // rustdoc invokes the test-builder by forwarding most of its own arguments, which makes
+    // it difficult to determine when phase_cargo_rustc should run instead of phase_cargo_rustdoc.
+    // Furthermore, the test code is passed via stdin, rather than a temporary file, so we need
+    // to let phase_cargo_rustc know to expect that. We'll use this environment variable as a flag:
+    cmd.env("BSAN_CALLED_FROM_RUSTDOC", "1");
+
+    // The `--test-builder` is an unstable rustdoc features,
+    // which is disabled by default. We first need to enable them explicitly:
+    cmd.arg("-Zunstable-options");
+
+    // rustdoc needs to know the right sysroot.
+    cmd.arg("--sysroot").arg(env::var_os("BSAN_SYSROOT").unwrap());
+
+    // Make rustdoc call us back for the build.
+    // (cargo already sets `--test-runtool` to us since we are the cargo test runner.)
+    let cargo_bsan_path = env::current_exe().expect("current executable path invalid");
+    cmd.arg("--test-builder").arg(&cargo_bsan_path); // invoked by forwarding most arguments
+
+    debug_cmd("[cargo-bsan rustdoc]", verbose, &cmd);
+    exec(cmd)
 }

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -107,16 +107,16 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     }
 
     let llvm_tools = LlvmTools::new(&rustc_version, &host_sysroot);
-    let deps = Deps::setup(&host_sysroot);
+    let deps = Dependencies::setup(&host_sysroot);
 
-    setup_sysroot(&subcommand, &rustc_version, &target_sysroot, verbose, quiet);
+    setup_sysroot(&subcommand, &rustc_version, &deps, &llvm_tools, &target_sysroot, verbose, quiet);
 
     let cargo_cmd = match subcommand {
         BsanCommand::Forward(s) => s,
         BsanCommand::Clean => unreachable!(),
         BsanCommand::Setup => {
             if has_arg_flag("--print-rustflags") {
-                println!("{}", bsan_rustflags(&deps).join(" "))
+                println!("{}", bsan_rustflags(&deps, &llvm_tools).join(" "))
             }
             return;
         }
@@ -179,6 +179,7 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     }
 
     llvm_tools.populate_env(&mut cmd);
+    deps.populate_env(&mut cmd);
 
     cmd.env("RUSTC", rustc_path());
     if let Some(orig_rustdoc) = env::var_os("RUSTDOC") {
@@ -209,7 +210,8 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
         get_arg_flag_value("--target").is_some()
     }
 
-    let deps = Deps::from_env();
+    let deps = Dependencies::from_env();
+    let llvm_tools = LlvmTools::from_env();
 
     let verbose = env::var("BSAN_VERBOSE")
         .map_or(0, |verbose| verbose.parse().expect("verbosity flag must be an integer"));
@@ -241,7 +243,7 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     let in_rustdoc = phase == RustcPhase::Rustdoc;
 
     if target_crate {
-        cmd.args(bsan_rustflags(&deps));
+        cmd.args(bsan_rustflags(&deps, &llvm_tools));
     }
 
     // Forward everything else.
@@ -261,12 +263,14 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     }
 }
 
-fn bsan_rustflags(deps: &Deps) -> Vec<String> {
+fn bsan_rustflags(deps: &Dependencies, llvm_tools: &LlvmTools) -> Vec<String> {
     let rt_dir = deps.runtime.parent().unwrap();
     let mut additional_args = BSAN_DEFAULT_ARGS.iter().map(ToString::to_string).collect::<Vec<_>>();
     additional_args.push(format!("-Zllvm-plugins={}", deps.llvm_pass.display()));
     additional_args.push(format!("-L{}", rt_dir.display()));
     additional_args.push("-lstatic=bsan_rt".to_string());
+    additional_args.push(format!("-Clinker={}", llvm_tools.clang.display()));
+    additional_args.push(format!("-Clink-arg=-fuse-ld={}", llvm_tools.lld.display()));
     additional_args
 }
 

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -8,6 +8,43 @@ use crate::setup::*;
 use crate::util::*;
 use crate::*;
 
+const CARGO_BSAN_HELP: &str = r"Runs binary crates and tests with BorrowSanitizer enabled.
+
+Usage:
+    cargo bsan [subcommand] [<cargo options>...] [--] [<program/test suite options>...]
+
+Subcommands:
+    run, r                   Run binaries
+    test, t                  Run tests
+    nextest                  Run tests with nextest (requires cargo-nextest installed)
+    setup                    Only perform automatic setup, but without asking questions (for getting a proper libstd)
+    clean                    Clean the BorrowSanitizer cache & target directory
+
+The cargo options are exactly the same as for `cargo run` and `cargo test`, respectively.
+
+Examples:
+    cargo bsan run
+    cargo bsan test -- test-suite-filter
+
+    cargo bsan setup --print-sysroot
+        This will print the path to the generated sysroot (and nothing else) on stdout.
+        stderr will still contain progress information about how the build is doing.
+";
+
+fn show_help() {
+    println!("{CARGO_BSAN_HELP}");
+}
+
+fn show_version() {
+    print!("bsan {}", env!("CARGO_PKG_VERSION"));
+    let version = format!("{} {}", env!("GIT_HASH"), env!("COMMIT_DATE"));
+    if version.len() > 1 {
+        // If there is actually something here, print it.
+        print!(" ({version})");
+    }
+    println!();
+}
+
 pub const BSAN_DEFAULT_ARGS: &[&str] = &[
     "--cfg=bsan",
     "-Copt-level=0",
@@ -85,6 +122,12 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         }
     };
 
+    let cargo_bsan_path = env::current_exe()
+        .expect("current executable path invalid")
+        .into_os_string()
+        .into_string()
+        .expect("current executable path is not valid UTF-8");
+
     let mut cmd = Cargo::cmd();
     cmd.arg(&cargo_cmd);
     // In nextest we have to also forward the main `verb`.
@@ -114,6 +157,13 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     }
     cmd.args(args);
 
+    if env::var_os("RUSTC_WRAPPER").is_some() {
+        println!(
+            "WARNING: Ignoring `RUSTC_WRAPPER` environment variable, BSAN does not support wrapping."
+        );
+    }
+    cmd.env("RUSTC_WRAPPER", &cargo_bsan_path);
+
     // If both RUSTC_WORKSPACE_WRAPPER and RUSTC_WRAPPER are set,
     // then both are executed in succession. Providing an independent
     // workspace-level wrapper is not supported, so we clear this variable.
@@ -130,14 +180,10 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
 
     llvm_tools.populate_env(&mut cmd);
 
+    cmd.env("RUSTC", rustc_path());
+
     cmd.env("BSAN_SYMBOLIZER", llvm_tools.llvm_symbolizer);
-
-    let mut rustflags = bsan_rustflags(&deps);
-    let sysroot_flag = format!("--sysroot={}", deps.target_sysroot.display());
-    rustflags.push(sysroot_flag.clone());
-
-    cmd.env("RUSTFLAGS", rustflags.join(" "));
-    cmd.env("RUSTDOCFLAGS", sysroot_flag);
+    cmd.env("BSAN_SYSROOT", &deps.target_sysroot.as_os_str());
 
     // Run cargo.
     debug_cmd("[cargo-bsan rustc]", verbose, &cmd);

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use rustc_version::VersionMeta;
 
 use crate::arg::*;
@@ -56,18 +58,21 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     if targets.len() > 1 || targets.iter().any(|t| t != &rustc_version.host) {
         show_error!("Cross-compilation is not supported.");
     }
+    let target_sysroot = Sysroot::target();
+    let host_sysroot = Sysroot::host(verbose);
 
     // If cleaning the target directory & sysroot cache,
     // delete them then exit. There is no reason to setup a new
     // sysroot in this execution.
     if let BsanCommand::Clean = subcommand {
-        clean_sysroot_dir();
+        clean_sysroot_dir(&target_sysroot);
         clean_target_dir();
         return;
     }
 
-    let llvm_tools = LlvmTools::new(&rustc_version, verbose);
-    let deps = Deps::setup(&subcommand, &rustc_version, verbose, quiet);
+    let llvm_tools = LlvmTools::new(&rustc_version, &host_sysroot);
+    let deps =
+        Deps::setup(&subcommand, &rustc_version, &host_sysroot, target_sysroot, verbose, quiet);
 
     let cargo_cmd = match subcommand {
         BsanCommand::Forward(s) => s,
@@ -80,7 +85,6 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         }
     };
 
-    let metadata = Cargo::metadata();
     let mut cmd = Cargo::cmd();
     cmd.arg(&cargo_cmd);
     // In nextest we have to also forward the main `verb`.
@@ -95,7 +99,10 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     cmd.arg(&rustc_version.host);
 
     // Set `--target-dir` to `bsan` inside the original target directory.
-    let target_dir = get_target_dir(&metadata);
+    let target_dir = match get_arg_flag_value("--target-dir") {
+        Some(dir) => PathBuf::from(dir),
+        None => Cargo::get_target_dir(),
+    };
     cmd.arg("--target-dir").arg(target_dir);
 
     // *After* we set all the flags that need setting, forward everything else. Make sure to skip

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -62,10 +62,12 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         show_help();
         return;
     }
+
     if has_arg_flag("--version") || has_arg_flag("-V") {
         show_version();
         return;
     }
+
     let Some(subcommand) = args.next() else {
         show_error!(
             "`cargo bsan` needs to be called with a subcommand (e.g `run`, `test`, `clean`)"
@@ -81,8 +83,7 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         ),
     };
 
-    let verbose = num_arg_flag("-v");
-    let quiet = has_arg_flag("-q") || has_arg_flag("--quiet");
+    let env = EnvConfig::from_args();
 
     // Determine the involved architectures.
     let rustc_version = VersionMeta::for_command(rustc())
@@ -94,8 +95,8 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     if targets.len() > 1 || targets.iter().any(|t| t != &rustc_version.host) {
         show_error!("Cross-compilation is not supported.");
     }
-    let target_sysroot = Sysroot::target();
-    let host_sysroot = Sysroot::host(verbose);
+    let target_sysroot = Sysroot::target(&env);
+    let host_sysroot = Sysroot::host(&env);
 
     // If cleaning the target directory & sysroot cache,
     // delete them then exit. There is no reason to setup a new
@@ -109,14 +110,14 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     let llvm_tools = LlvmTools::new(&rustc_version, &host_sysroot);
     let deps = Dependencies::setup(&host_sysroot);
 
-    setup_sysroot(&subcommand, &rustc_version, &deps, &llvm_tools, &target_sysroot, verbose, quiet);
+    setup_sysroot(&subcommand, &rustc_version, &deps, &llvm_tools, &target_sysroot, &env);
 
     let cargo_cmd = match subcommand {
         BsanCommand::Forward(s) => s,
         BsanCommand::Clean => unreachable!(),
         BsanCommand::Setup => {
             if has_arg_flag("--print-rustflags") {
-                println!("{}", bsan_rustflags(&deps, &llvm_tools).join(" "))
+                println!("{}", bsan_rustflags(&env, &deps, &llvm_tools).join(" "))
             }
             return;
         }
@@ -174,12 +175,17 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     }
     cmd.env_remove("RUSTC_WORKSPACE_WRAPPER");
 
-    if verbose > 0 {
-        cmd.env("BSAN_VERBOSE", verbose.to_string()); // This makes the other phases verbose.
+    if env.verbose {
+        cmd.env("BSAN_VERBOSE", env.verbose.to_string()); // This makes the other phases verbose.
+    }
+
+    if env.lto {
+        cmd.env("BSAN_LTO", "1");
     }
 
     llvm_tools.populate_env(&mut cmd);
     deps.populate_env(&mut cmd);
+    env.populate_env(&mut cmd);
 
     cmd.env("RUSTC", rustc_path());
     if let Some(orig_rustdoc) = env::var_os("RUSTDOC") {
@@ -188,10 +194,10 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     cmd.env("RUSTDOC", &cargo_bsan_path);
 
     cmd.env("BSAN_SYMBOLIZER", llvm_tools.llvm_symbolizer);
-    cmd.env("BSAN_SYSROOT", &target_sysroot.as_os_str());
+    cmd.env("BSAN_SYSROOT", target_sysroot.as_os_str());
 
     // Run cargo.
-    debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
+    debug_cmd("[cargo-bsan rustc]", env.verbose, &cmd);
     exec(cmd)
 }
 
@@ -212,6 +218,7 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
 
     let deps = Dependencies::from_env();
     let llvm_tools = LlvmTools::from_env();
+    let env = EnvConfig::from_env();
 
     let verbose = env::var("BSAN_VERBOSE")
         .map_or(0, |verbose| verbose.parse().expect("verbosity flag must be an integer"));
@@ -243,13 +250,13 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     let in_rustdoc = phase == RustcPhase::Rustdoc;
 
     if target_crate {
-        cmd.args(bsan_rustflags(&deps, &llvm_tools));
+        cmd.args(bsan_rustflags(&env, &deps, &llvm_tools));
     }
 
     // Forward everything else.
     cmd.args(args);
 
-    debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
+    debug_cmd("[cargo-bsan rustc]", env.verbose, &cmd);
     if in_rustdoc {
         if verbose > 0 {
             eprintln!("[cargo-miri rustc inside rustdoc]");
@@ -263,20 +270,27 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
     }
 }
 
-fn bsan_rustflags(deps: &Dependencies, llvm_tools: &LlvmTools) -> Vec<String> {
+fn bsan_rustflags(env: &EnvConfig, deps: &Dependencies, llvm_tools: &LlvmTools) -> Vec<String> {
     let rt_dir = deps.runtime.parent().unwrap();
     let mut additional_args = BSAN_DEFAULT_ARGS.iter().map(ToString::to_string).collect::<Vec<_>>();
-    additional_args.push(format!("-Zllvm-plugins={}", deps.llvm_pass.display()));
     additional_args.push(format!("-L{}", rt_dir.display()));
-    additional_args.push("-lstatic=bsan_rt".to_string());
+    additional_args.push(String::from("-lstatic=bsan_rt"));
     additional_args.push(format!("-Clinker={}", llvm_tools.clang.display()));
     additional_args.push(format!("-Clink-arg=-fuse-ld={}", llvm_tools.lld.display()));
+    if env.lto {
+        additional_args.push(String::from("-Clinker-plugin-lto"));
+        additional_args
+            .push(format!("-Clink-arg=-Wl,--load-pass-plugin={}", deps.llvm_pass.display()));
+        additional_args.push(String::from("-Clink-arg=-Wl,--lto-newpm-passes=bsan"));
+        additional_args.push(String::from("-Clink-arg=-Wl,--lto-O0"));
+    } else {
+        additional_args.push(format!("-Zllvm-plugins={}", deps.llvm_pass.display()));
+    }
     additional_args
 }
 
 pub fn phase_rustdoc(args: impl Iterator<Item = String>) {
-    let verbose = env::var("BSAN_VERBOSE")
-        .map_or(0, |verbose| verbose.parse().expect("verbosity flag must be an integer"));
+    let config = EnvConfig::from_env();
     let mut cmd = rustdoc();
     cmd.args(args);
 
@@ -302,6 +316,6 @@ pub fn phase_rustdoc(args: impl Iterator<Item = String>) {
     let cargo_bsan_path = env::current_exe().expect("current executable path invalid");
     cmd.arg("--test-builder").arg(&cargo_bsan_path); // invoked by forwarding most arguments
 
-    debug_cmd("[cargo-bsan rustdoc]", verbose, &cmd);
+    debug_cmd("[cargo-bsan rustdoc]", config.verbose, &cmd);
     exec(cmd)
 }

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -10,20 +10,20 @@ use rustc_build_sysroot::{BuildMode, SysrootBuilder, SysrootConfig, SysrootStatu
 use rustc_version::VersionMeta;
 
 use crate::arg::*;
+use crate::llvm::LlvmTools;
 use crate::util::*;
 
-pub struct Deps {
+pub struct Dependencies {
     pub runtime: PathBuf,
     pub llvm_pass: PathBuf,
 }
 
-impl Deps {
+impl Dependencies {
     pub fn setup(host_sysroot: &Sysroot) -> Self {
         let ensure_library_var = |var: &str, sysroot: &Sysroot, libname: &str| {
             env::var_os(var).map(|o| o.into()).or_else(|| {
                 let plugin: PathBuf = (*sysroot).join("lib").join(libname).to_path_buf();
                 if plugin.exists() {
-                    unsafe { env::set_var(var, &plugin) };
                     Some(plugin)
                 } else {
                     None
@@ -48,6 +48,11 @@ impl Deps {
         Self { runtime, llvm_pass }
     }
 
+    pub fn populate_env(&self, cmd: &mut Command) {
+        cmd.env("BSAN_RT", &self.runtime);
+        cmd.env("BSAN_PLUGIN", &self.llvm_pass);
+    }
+
     pub fn from_env() -> Self {
         let runtime = expect_env_path("BSAN_RT");
         let llvm_pass = expect_env_path("BSAN_PLUGIN");
@@ -61,6 +66,8 @@ impl Deps {
 pub fn setup_sysroot(
     subcommand: &BsanCommand,
     rustc_version: &VersionMeta,
+    deps: &Dependencies,
+    llvm_tools: &LlvmTools,
     sysroot_dir: &Sysroot,
     verbose: usize,
     quiet: bool,
@@ -171,7 +178,8 @@ pub fn setup_sysroot(
                 command.arg("--quiet");
             }
         }
-
+        deps.populate_env(&mut command);
+        llvm_tools.populate_env(&mut command);
         command
     };
     // Disable debug assertions in the standard library -- Miri is already slow enough.

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -6,7 +6,6 @@ use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process::{self, Command};
 
-use path_macro::path;
 use rustc_build_sysroot::{BuildMode, SysrootBuilder, SysrootConfig, SysrootStatus};
 use rustc_version::VersionMeta;
 
@@ -14,7 +13,7 @@ use crate::arg::*;
 use crate::util::*;
 
 pub struct Deps {
-    pub target_sysroot: PathBuf,
+    pub target_sysroot: Sysroot,
     pub runtime: PathBuf,
     pub llvm_pass: PathBuf,
 }
@@ -23,14 +22,14 @@ impl Deps {
     pub fn setup(
         subcommand: &BsanCommand,
         rustc_version: &VersionMeta,
+        host_sysroot: &Sysroot,
+        target_sysroot: Sysroot,
         verbose: usize,
         quiet: bool,
     ) -> Self {
-        let host_sysroot = get_host_sysroot_dir(verbose);
-
-        let ensure_library_var = |var: &str, sysroot: &PathBuf, libname: &str| {
+        let ensure_library_var = |var: &str, sysroot: &Sysroot, libname: &str| {
             env::var_os(var).map(|o| o.into()).or_else(|| {
-                let plugin: PathBuf = path!(sysroot / "lib" / libname);
+                let plugin: PathBuf = (*sysroot).join("lib").join(libname).to_path_buf();
                 if plugin.exists() {
                     unsafe { env::set_var(var, &plugin) };
                     Some(plugin)
@@ -54,14 +53,13 @@ impl Deps {
             );
         };
 
-        let target_sysroot =
-            setup_sysroot(subcommand, rustc_version.host.as_str(), rustc_version, verbose, quiet);
+        setup_sysroot(subcommand, rustc_version, &target_sysroot, verbose, quiet);
 
         Self { target_sysroot, runtime, llvm_pass }
     }
 
     pub fn from_env() -> Self {
-        let target_sysroot = expect_env_path("BSAN_SYSROOT");
+        let target_sysroot = Sysroot::target();
         let runtime = expect_env_path("BSAN_RT");
         let llvm_pass = expect_env_path("BSAN_PLUGIN");
         Self { target_sysroot, runtime, llvm_pass }
@@ -73,11 +71,11 @@ impl Deps {
 /// done all this already.
 pub fn setup_sysroot(
     subcommand: &BsanCommand,
-    target: &str,
     rustc_version: &VersionMeta,
+    sysroot_dir: &Sysroot,
     verbose: usize,
     quiet: bool,
-) -> PathBuf {
+) {
     let only_setup = matches!(subcommand, BsanCommand::Setup);
     let ask_user = !only_setup;
     let print_rustflags = only_setup && has_arg_flag("--print-rustflags");
@@ -89,7 +87,7 @@ pub fn setup_sysroot(
         if print_sysroot {
             println!("{}", sysroot.display());
         }
-        return sysroot.into();
+        return;
     }
 
     // Determine where the rust sources are located.  The env var trumps auto-detection.
@@ -128,8 +126,7 @@ pub fn setup_sysroot(
         );
     }
 
-    // Determine where to put the sysroot.
-    let sysroot_dir = get_target_sysroot_dir();
+    let target = rustc_version.host.as_str();
 
     // Sysroot configuration and build details.
     let no_std = match std::env::var_os("BSAN_NO_STD") {
@@ -166,7 +163,7 @@ pub fn setup_sysroot(
 
         command.env("BSAN_CALLED_FROM_SETUP", "1");
         // BSAN expects `BSAN_SYSROOT` to be set when invoked in target mode. Even if that directory is empty.
-        command.env("BSAN_SYSROOT", &sysroot_dir);
+        command.env("BSAN_SYSROOT", sysroot_dir.as_os_str());
         // Make sure there are no other wrappers getting in our way (Cc
         // https://github.com/rust-lang/miri/issues/1421,
         // https://github.com/rust-lang/miri/issues/2429). Looks like setting
@@ -246,7 +243,5 @@ pub fn setup_sysroot(
         println!("{}", sysroot_dir.display());
     }
 
-    unsafe { env::set_var("BSAN_SYSROOT", &sysroot_dir) }
-
-    sysroot_dir
+    unsafe { env::set_var("BSAN_SYSROOT", &sysroot_dir.as_os_str()) }
 }

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -1,15 +1,72 @@
 //! Implements `cargo bsan setup`.
 //! This was copied directly from cargo-miri, with only small changes
 //! to comments and the names of environment variables.
+use std::env;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::process::{self, Command};
 
+use path_macro::path;
 use rustc_build_sysroot::{BuildMode, SysrootBuilder, SysrootConfig, SysrootStatus};
 use rustc_version::VersionMeta;
 
 use crate::arg::*;
 use crate::util::*;
+
+pub struct Deps {
+    pub target_sysroot: PathBuf,
+    pub runtime: PathBuf,
+    pub llvm_pass: PathBuf,
+}
+
+impl Deps {
+    pub fn setup(
+        subcommand: &BsanCommand,
+        rustc_version: &VersionMeta,
+        verbose: usize,
+        quiet: bool,
+    ) -> Self {
+        let host_sysroot = get_host_sysroot_dir(verbose);
+
+        let ensure_library_var = |var: &str, sysroot: &PathBuf, libname: &str| {
+            env::var_os(var).map(|o| o.into()).or_else(|| {
+                let plugin: PathBuf = path!(sysroot / "lib" / libname);
+                if plugin.exists() {
+                    unsafe { env::set_var(var, &plugin) };
+                    Some(plugin)
+                } else {
+                    None
+                }
+            })
+        };
+
+        let Some(llvm_pass) = ensure_library_var("BSAN_PLUGIN", &host_sysroot, "libbsan_plugin.so")
+        else {
+            show_error!(
+                "failed to locate the BorrowSanitizer LLVM plugin (libbsan_plugin.so) within the host sysroot: {}",
+                    host_sysroot.display()
+            );
+        };
+
+        let Some(runtime) = ensure_library_var("BSAN_RT", &host_sysroot, "libbsan_rt.a") else {
+            show_error!(
+                "failed to locate the BorrowSanitizer runtime (libbsan_rt.a) within the host sysroot."
+            );
+        };
+
+        let target_sysroot =
+            setup_sysroot(subcommand, rustc_version.host.as_str(), rustc_version, verbose, quiet);
+
+        Self { target_sysroot, runtime, llvm_pass }
+    }
+
+    pub fn from_env() -> Self {
+        let target_sysroot = expect_env_path("BSAN_SYSROOT");
+        let runtime = expect_env_path("BSAN_RT");
+        let llvm_pass = expect_env_path("BSAN_PLUGIN");
+        Self { target_sysroot, runtime, llvm_pass }
+    }
+}
 
 /// Performs the setup required to make `cargo bsan` work: Getting a custom-built libstd. Then sets
 /// `BSAN_SYSROOT`. Skipped if `BSAN_SYSROOT` is already set, in which case we expect the user has
@@ -95,7 +152,7 @@ pub fn setup_sysroot(
         }
     };
     let cargo_cmd = {
-        let mut command = cargo();
+        let mut command = Cargo::cmd();
         // Use Miri as rustc to build a libstd compatible with us (and use the right flags).
         // We set ourselves (`cargo-bsan`) instead of bsan directly to be able to patch the flags
         // for `libpanic_abort` (usually this is done by bootstrap but we have to do it ourselves).
@@ -188,6 +245,8 @@ pub fn setup_sysroot(
         // Print just the sysroot and nothing else to stdout; this way we do not need any escaping.
         println!("{}", sysroot_dir.display());
     }
+
+    unsafe { env::set_var("BSAN_SYSROOT", &sysroot_dir) }
 
     sysroot_dir
 }

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -13,6 +13,40 @@ use crate::arg::*;
 use crate::llvm::LlvmTools;
 use crate::util::*;
 
+pub struct EnvConfig {
+    pub verbose: bool,
+    pub quiet: bool,
+    pub lto: bool,
+}
+
+impl EnvConfig {
+    pub fn from_args() -> Self {
+        let verbose = has_arg_flag("-v");
+        let quiet = has_arg_flag("-q") || has_arg_flag("--quiet");
+        let lto = has_arg_flag("--lto");
+        Self { verbose, quiet, lto }
+    }
+
+    pub fn from_env() -> Self {
+        let verbose = env::var_os("BSAN_VERBOSE").is_some();
+        let quiet = env::var_os("BSAN_QUIET").is_some();
+        let lto = env::var_os("BSAN_LTO").is_some();
+        Self { verbose, quiet, lto }
+    }
+
+    pub fn populate_env(&self, cmd: &mut Command) {
+        if self.verbose {
+            cmd.env("BSAN_VERBOSE", "1");
+        }
+        if self.quiet {
+            cmd.env("BSAN_QUIET", "1");
+        }
+        if self.lto {
+            cmd.env("BSAN_LTO", "1");
+        }
+    }
+}
+
 pub struct Dependencies {
     pub runtime: PathBuf,
     pub llvm_pass: PathBuf,
@@ -31,7 +65,7 @@ impl Dependencies {
             })
         };
 
-        let Some(llvm_pass) = ensure_library_var("BSAN_PLUGIN", &host_sysroot, "libbsan_plugin.so")
+        let Some(llvm_pass) = ensure_library_var("BSAN_PLUGIN", host_sysroot, "libbsan_plugin.so")
         else {
             show_error!(
                 "failed to locate the BorrowSanitizer LLVM plugin (libbsan_plugin.so) within the host sysroot: {}",
@@ -39,7 +73,7 @@ impl Dependencies {
             );
         };
 
-        let Some(runtime) = ensure_library_var("BSAN_RT", &host_sysroot, "libbsan_rt.a") else {
+        let Some(runtime) = ensure_library_var("BSAN_RT", host_sysroot, "libbsan_rt.a") else {
             show_error!(
                 "failed to locate the BorrowSanitizer runtime (libbsan_rt.a) within the host sysroot."
             );
@@ -69,8 +103,7 @@ pub fn setup_sysroot(
     deps: &Dependencies,
     llvm_tools: &LlvmTools,
     sysroot_dir: &Sysroot,
-    verbose: usize,
-    quiet: bool,
+    env: &EnvConfig,
 ) {
     let only_setup = matches!(subcommand, BsanCommand::Setup);
     let ask_user = !only_setup;
@@ -171,28 +204,30 @@ pub fn setup_sysroot(
             // Forward output. Even make it verbose, if requested.
             command.stdout(process::Stdio::inherit());
             command.stderr(process::Stdio::inherit());
-            for _ in 0..verbose {
+            if env.verbose {
                 command.arg("-v");
             }
-            if quiet {
+            if env.quiet {
                 command.arg("--quiet");
             }
         }
         deps.populate_env(&mut command);
         llvm_tools.populate_env(&mut command);
+        env.populate_env(&mut command);
         command
     };
     // Disable debug assertions in the standard library -- Miri is already slow enough.
     // But keep the overflow checks, they are cheap. This completely overwrites flags
     // the user might have set, which is consistent with normal `cargo build` that does
     // not apply `RUSTFLAGS` to the sysroot either.
-    let rustflags = &["-Cdebug-assertions=off", "-Coverflow-checks=on", "-Cdebuginfo=2"];
+    let rustflags =
+        &["-Cdebug-assertions=off", "-Coverflow-checks=on", "-Cdebuginfo=2", "-Cembed-bitcode"];
 
     let mut after_build_output = String::new(); // what should be printed when the build is done.
     let notify = || {
-        if !quiet {
+        if !env.quiet {
             eprint!("Preparing a sysroot for BorrowSanitizer (target: {target})");
-            if verbose > 0 {
+            if env.verbose {
                 eprint!(" in {}", sysroot_dir.display());
             }
             if show_setup {
@@ -211,7 +246,7 @@ pub fn setup_sysroot(
     };
 
     // Do the build.
-    let status = SysrootBuilder::new(&sysroot_dir, target)
+    let status = SysrootBuilder::new(sysroot_dir, target)
         .build_mode(BuildMode::Build)
         .rustc_version(rustc_version.clone())
         .sysroot_config(sysroot_config)
@@ -219,9 +254,10 @@ pub fn setup_sysroot(
         .cargo(cargo_cmd)
         .when_build_required(notify)
         .build_from_source(&rust_src);
+
     match status {
         Ok(SysrootStatus::AlreadyCached) => {
-            if !quiet && show_setup {
+            if !env.quiet && show_setup {
                 eprintln!(
                     "A sysroot for BorrowSanitizer is already available in `{}`.",
                     sysroot_dir.display()
@@ -240,5 +276,5 @@ pub fn setup_sysroot(
         println!("{}", sysroot_dir.display());
     }
 
-    unsafe { env::set_var("BSAN_SYSROOT", &sysroot_dir.as_os_str()) }
+    unsafe { env::set_var("BSAN_SYSROOT", sysroot_dir.as_os_str()) }
 }

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -13,20 +13,12 @@ use crate::arg::*;
 use crate::util::*;
 
 pub struct Deps {
-    pub target_sysroot: Sysroot,
     pub runtime: PathBuf,
     pub llvm_pass: PathBuf,
 }
 
 impl Deps {
-    pub fn setup(
-        subcommand: &BsanCommand,
-        rustc_version: &VersionMeta,
-        host_sysroot: &Sysroot,
-        target_sysroot: Sysroot,
-        verbose: usize,
-        quiet: bool,
-    ) -> Self {
+    pub fn setup(host_sysroot: &Sysroot) -> Self {
         let ensure_library_var = |var: &str, sysroot: &Sysroot, libname: &str| {
             env::var_os(var).map(|o| o.into()).or_else(|| {
                 let plugin: PathBuf = (*sysroot).join("lib").join(libname).to_path_buf();
@@ -53,16 +45,13 @@ impl Deps {
             );
         };
 
-        setup_sysroot(subcommand, rustc_version, &target_sysroot, verbose, quiet);
-
-        Self { target_sysroot, runtime, llvm_pass }
+        Self { runtime, llvm_pass }
     }
 
     pub fn from_env() -> Self {
-        let target_sysroot = Sysroot::target();
         let runtime = expect_env_path("BSAN_RT");
         let llvm_pass = expect_env_path("BSAN_PLUGIN");
-        Self { target_sysroot, runtime, llvm_pass }
+        Self { runtime, llvm_pass }
     }
 }
 

--- a/cargo-bsan/src/util.rs
+++ b/cargo-bsan/src/util.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::ffi::OsString;
 use std::io::{self, Write};
-use std::ops::Not;
+use std::ops::{Deref, Not};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -84,29 +84,6 @@ pub fn exec_with_pipe(mut cmd: Command) -> ! {
     std::process::exit(exit_status.code().unwrap_or(-1))
 }
 
-/// Determines where the host sysroot of this execution is
-pub fn get_host_sysroot_dir(verbose: usize) -> PathBuf {
-    let mut cmd = rustc();
-    cmd.args(["--print", "sysroot"]);
-    debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
-    let libdir = exec_stdout(cmd);
-    PathBuf::from(libdir.trim())
-}
-
-/// Determines where the sysroot of this execution is
-///
-/// Either in a user-specified spot by an envar, or in a default cache location.
-pub fn get_target_sysroot_dir() -> PathBuf {
-    match std::env::var_os("BSAN_SYSROOT") {
-        Some(dir) => PathBuf::from(dir),
-        None => {
-            let user_dirs =
-                directories::ProjectDirs::from("org", "borrowsanitizer", "bsan").unwrap();
-            user_dirs.cache_dir().to_owned()
-        }
-    }
-}
-
 pub fn ask_to_run(mut cmd: Command, ask: bool, text: &str) {
     // Disable interactive prompts in CI (GitHub Actions, Travis, AppVeyor, etc).
     // Azure doesn't set `CI` though (nothing to see here, just Microsoft being Microsoft),
@@ -132,21 +109,12 @@ pub fn ask_to_run(mut cmd: Command, ask: bool, text: &str) {
     }
 }
 
-/// Get the target directory for bsan output.
-///
-/// Either in an argument passed-in, or from cargo metadata.
-pub fn get_target_dir(meta: &Metadata) -> PathBuf {
-    let mut output = match get_arg_flag_value("--target-dir") {
-        Some(dir) => PathBuf::from(dir),
-        None => meta.target_directory.clone().into_std_path_buf(),
-    };
-    output.push("bsan");
-    output
-}
-
 pub struct Cargo;
 
 impl Cargo {
+    pub fn get_target_dir() -> PathBuf {
+        Self::metadata().target_directory.clone().into_std_path_buf().join("bsan")
+    }
     pub fn cmd() -> Command {
         // Honor the `CARGO` env var if set, otherwise look for `cargo` in PATH.
         let cargo = env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
@@ -189,15 +157,14 @@ impl Cargo {
     }
 }
 
-pub fn clean_sysroot_dir() {
-    let sysroot = get_target_sysroot_dir();
-    if sysroot.exists() {
-        std::fs::remove_dir_all(&sysroot).unwrap();
+pub fn clean_sysroot_dir(sysroot: &Sysroot) {
+    if sysroot.root.exists() {
+        std::fs::remove_dir_all(&sysroot.root).unwrap();
     }
 }
 
 pub fn clean_target_dir() {
-    let target_dir = get_target_dir(&Cargo::metadata());
+    let target_dir = Cargo::get_target_dir();
     if target_dir.exists() {
         std::fs::remove_dir_all(&target_dir).unwrap();
     }
@@ -229,30 +196,70 @@ pub fn rustc() -> Command {
     Command::new(rustc_path())
 }
 
-pub fn try_get_host_binary(binary: &str, verbose: usize) -> Option<PathBuf> {
-    try_get_host_sysroot_binary(binary, verbose).or_else(|| which::which(binary).ok())
+pub fn try_get_host_binary(sysroot: &Sysroot, binary: &str) -> Option<PathBuf> {
+    sysroot.binary(binary).or_else(|| which::which(binary).ok())
 }
 
-pub fn try_get_host_sysroot_binary(binary: &str, verbose: usize) -> Option<PathBuf> {
-    let bsan_sysroot = get_host_sysroot_dir(verbose);
-    let sysroot_bindir = Path::new(&bsan_sysroot).join("bin");
-    let symbolizer_path = sysroot_bindir.join(binary);
-    symbolizer_path.exists().then_some(symbolizer_path)
-}
-
-pub fn assert_host_binary(binary: &str, verbose: usize) -> PathBuf {
-    try_get_host_binary(binary, verbose)
+pub fn assert_host_binary(sysroot: &Sysroot, binary: &str) -> PathBuf {
+    try_get_host_binary(sysroot, binary)
         .unwrap_or_else(|| show_error!("failed to find `{}`", binary))
 }
 
-pub fn get_sysroot_target_dir(version_meta: &VersionMeta, verbose: usize) -> PathBuf {
-    let mut sysroot_target_dir = get_host_sysroot_dir(verbose);
-    sysroot_target_dir.push("lib");
-    sysroot_target_dir.push("rustlib");
-    sysroot_target_dir.push(&version_meta.host);
-    if sysroot_target_dir.exists() {
-        sysroot_target_dir
-    } else {
-        panic!("Target sysroot directory does not exist: {:?}", sysroot_target_dir);
+pub struct Sysroot {
+    root: PathBuf,
+}
+
+impl Sysroot {
+    pub fn host(verbose: usize) -> Self {
+        let mut cmd = rustc();
+        cmd.args(["--print", "sysroot"]);
+        debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
+        let libdir = exec_stdout(cmd);
+        Self { root: PathBuf::from(libdir.trim()) }
+    }
+
+    pub fn target() -> Self {
+        let root = match std::env::var_os("BSAN_SYSROOT") {
+            Some(dir) => PathBuf::from(dir),
+            None => {
+                let user_dirs =
+                    directories::ProjectDirs::from("org", "borrowsanitizer", "bsan").unwrap();
+                user_dirs.cache_dir().to_owned()
+            }
+        };
+        Self { root }
+    }
+
+    pub fn bin(&self) -> PathBuf {
+        self.root.join("bin")
+    }
+
+    pub fn binary(&self, binary: &str) -> Option<PathBuf> {
+        let path = self.bin().join(binary);
+        path.exists().then_some(path)
+    }
+
+    pub fn target_dir(&self, version_meta: &VersionMeta) -> PathBuf {
+        let mut target_dir = self.root.clone();
+        target_dir.push("lib");
+        target_dir.push("rustlib");
+        target_dir.push(&version_meta.host);
+        if target_dir.exists() {
+            target_dir
+        } else {
+            panic!(
+                "The host sysroot `{}` does not contain a target directory for target `{}`.",
+                self.root.display(),
+                version_meta.host
+            );
+        }
+    }
+}
+
+impl Deref for Sysroot {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.root
     }
 }

--- a/cargo-bsan/src/util.rs
+++ b/cargo-bsan/src/util.rs
@@ -9,6 +9,7 @@ use cargo_metadata::{Metadata, MetadataCommand};
 use rustc_version::VersionMeta;
 
 use crate::arg::*;
+use crate::setup::EnvConfig;
 
 #[derive(Clone, Debug)]
 pub enum BsanCommand {
@@ -42,8 +43,8 @@ macro_rules! show_error {
 pub(crate) use show_error;
 
 /// Debug-print a command that is going to be run.
-pub fn debug_cmd(prefix: &str, verbose: usize, cmd: &Command) {
-    if verbose != 0 {
+pub fn debug_cmd(prefix: &str, verbose: bool, cmd: &Command) {
+    if verbose {
         eprintln!("{prefix} running command: {cmd:?}");
     }
 }
@@ -220,20 +221,22 @@ pub struct Sysroot {
 }
 
 impl Sysroot {
-    pub fn host(verbose: usize) -> Self {
+    pub fn host(env: &EnvConfig) -> Self {
         let mut cmd = rustc();
         cmd.args(["--print", "sysroot"]);
-        debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
+        debug_cmd("[cargo-bsan rustc]", env.verbose, &cmd);
         let libdir = exec_stdout(cmd);
         Self { root: PathBuf::from(libdir.trim()) }
     }
 
-    pub fn target() -> Self {
+    pub fn target(config: &EnvConfig) -> Self {
         let root = match std::env::var_os("BSAN_SYSROOT") {
             Some(dir) => PathBuf::from(dir),
             None => {
+                let target_prefix = if config.lto { "bsan-lto" } else { "bsan" };
                 let user_dirs =
-                    directories::ProjectDirs::from("org", "borrowsanitizer", "bsan").unwrap();
+                    directories::ProjectDirs::from("org", "borrowsanitizer", target_prefix)
+                        .unwrap();
                 user_dirs.cache_dir().to_owned()
             }
         };

--- a/cargo-bsan/src/util.rs
+++ b/cargo-bsan/src/util.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use cargo_metadata::{Metadata, MetadataCommand};
-use path_macro::path;
+use rustc_version::VersionMeta;
 
 use crate::arg::*;
 
@@ -45,22 +45,6 @@ pub fn debug_cmd(prefix: &str, verbose: usize, cmd: &Command) {
         eprintln!("{prefix} running command: {cmd:?}");
     }
 }
-
-pub fn cargo() -> Command {
-    Command::new(env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo")))
-}
-
-pub fn find_library(default: &str, sysroot: &Path, libname: &str) -> Option<PathBuf> {
-    env::var_os(default).map(|o| o.into()).or_else(|| {
-        let plugin: PathBuf = path!(sysroot / "lib" / libname);
-        if plugin.exists() {
-            Some(plugin)
-        } else {
-            None
-        }
-    })
-}
-
 /// Execute the `Command`, where possible by replacing the current process with a new process
 /// described by the `Command`. Then exit this process with the exit code of the new process.
 pub fn exec(mut cmd: Command) -> ! {
@@ -123,17 +107,6 @@ pub fn get_target_sysroot_dir() -> PathBuf {
     }
 }
 
-pub fn get_host_sysroot_binary(binary: &str, verbose: usize) -> PathBuf {
-    let bsan_sysroot = get_host_sysroot_dir(verbose);
-    let sysroot_bindir = Path::new(&bsan_sysroot).join("bin");
-    let symbolizer_path = sysroot_bindir.join(binary);
-    if symbolizer_path.exists() {
-        symbolizer_path
-    } else {
-        show_error!("Unable to locate `{binary}` within the host sysroot ({sysroot_bindir:?}).");
-    }
-}
-
 pub fn ask_to_run(mut cmd: Command, ask: bool, text: &str) {
     // Disable interactive prompts in CI (GitHub Actions, Travis, AppVeyor, etc).
     // Azure doesn't set `CI` though (nothing to see here, just Microsoft being Microsoft),
@@ -171,39 +144,49 @@ pub fn get_target_dir(meta: &Metadata) -> PathBuf {
     output
 }
 
-// Computes the extra flags that need to be passed to cargo to make it behave like the current
-// cargo invocation.
-fn cargo_extra_flags() -> Vec<String> {
-    let mut flags = Vec::new();
-    // Forward `--config` flags.
-    let config_flag = "--config";
-    for arg in get_arg_flag_values(config_flag) {
-        flags.push(config_flag.to_string());
-        flags.push(arg);
+pub struct Cargo;
+
+impl Cargo {
+    pub fn cmd() -> Command {
+        // Honor the `CARGO` env var if set, otherwise look for `cargo` in PATH.
+        let cargo = env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+        Command::new(cargo)
     }
 
-    // Forward `--manifest-path`.
-    let manifest_flag = "--manifest-path";
-    if let Some(manifest) = get_arg_flag_value(manifest_flag) {
-        flags.push(manifest_flag.to_string());
-        flags.push(manifest);
+    pub fn metadata() -> Metadata {
+        // This will honor the `CARGO` env var the same way our `cargo()` does.
+        MetadataCommand::new().no_deps().other_options(Self::extra_flags()).exec().unwrap_or_else(
+            |err| {
+                if let cargo_metadata::Error::CargoMetadata { stderr } = err {
+                    show_error!("{stderr}")
+                } else {
+                    show_error!("{err}")
+                }
+            },
+        )
     }
 
-    // Forwarding `--target-dir` would make sense, but `cargo metadata` does not support that flag.
-    flags
-}
+    // Computes the extra flags that need to be passed to cargo to make it behave like the current
+    // cargo invocation.
+    fn extra_flags() -> Vec<String> {
+        let mut flags = Vec::new();
+        // Forward `--config` flags.
+        let config_flag = "--config";
+        for arg in get_arg_flag_values(config_flag) {
+            flags.push(config_flag.to_string());
+            flags.push(arg);
+        }
 
-pub fn get_cargo_metadata() -> Metadata {
-    // This will honor the `CARGO` env var the same way our `cargo()` does.
-    MetadataCommand::new().no_deps().other_options(cargo_extra_flags()).exec().unwrap_or_else(
-        |err| {
-            if let cargo_metadata::Error::CargoMetadata { stderr } = err {
-                show_error!("{stderr}")
-            } else {
-                show_error!("{err}")
-            }
-        },
-    )
+        // Forward `--manifest-path`.
+        let manifest_flag = "--manifest-path";
+        if let Some(manifest) = get_arg_flag_value(manifest_flag) {
+            flags.push(manifest_flag.to_string());
+            flags.push(manifest);
+        }
+
+        // Forwarding `--target-dir` would make sense, but `cargo metadata` does not support that flag.
+        flags
+    }
 }
 
 pub fn clean_sysroot_dir() {
@@ -214,7 +197,7 @@ pub fn clean_sysroot_dir() {
 }
 
 pub fn clean_target_dir() {
-    let target_dir = get_target_dir(&get_cargo_metadata());
+    let target_dir = get_target_dir(&Cargo::metadata());
     if target_dir.exists() {
         std::fs::remove_dir_all(&target_dir).unwrap();
     }
@@ -244,4 +227,32 @@ pub fn rustc_path() -> PathBuf {
 
 pub fn rustc() -> Command {
     Command::new(rustc_path())
+}
+
+pub fn try_get_host_binary(binary: &str, verbose: usize) -> Option<PathBuf> {
+    try_get_host_sysroot_binary(binary, verbose).or_else(|| which::which(binary).ok())
+}
+
+pub fn try_get_host_sysroot_binary(binary: &str, verbose: usize) -> Option<PathBuf> {
+    let bsan_sysroot = get_host_sysroot_dir(verbose);
+    let sysroot_bindir = Path::new(&bsan_sysroot).join("bin");
+    let symbolizer_path = sysroot_bindir.join(binary);
+    symbolizer_path.exists().then_some(symbolizer_path)
+}
+
+pub fn assert_host_binary(binary: &str, verbose: usize) -> PathBuf {
+    try_get_host_binary(binary, verbose)
+        .unwrap_or_else(|| show_error!("failed to find `{}`", binary))
+}
+
+pub fn get_sysroot_target_dir(version_meta: &VersionMeta, verbose: usize) -> PathBuf {
+    let mut sysroot_target_dir = get_host_sysroot_dir(verbose);
+    sysroot_target_dir.push("lib");
+    sysroot_target_dir.push("rustlib");
+    sysroot_target_dir.push(&version_meta.host);
+    if sysroot_target_dir.exists() {
+        sysroot_target_dir
+    } else {
+        panic!("Target sysroot directory does not exist: {:?}", sysroot_target_dir);
+    }
 }

--- a/cargo-bsan/src/util.rs
+++ b/cargo-bsan/src/util.rs
@@ -26,6 +26,8 @@ pub enum RustcPhase {
     Setup,
     /// Regular build
     Build,
+    /// Rustdoc build
+    Rustdoc,
 }
 
 pub fn show_error_(msg: &impl std::fmt::Display) -> ! {
@@ -194,6 +196,14 @@ pub fn rustc_path() -> PathBuf {
 
 pub fn rustc() -> Command {
     Command::new(rustc_path())
+}
+
+pub fn rustdoc_path() -> PathBuf {
+    env_or_host("BSAN_ORIG_RUSTDOC", "rustdoc")
+}
+
+pub fn rustdoc() -> Command {
+    Command::new(rustdoc_path())
 }
 
 pub fn try_get_host_binary(sysroot: &Sysroot, binary: &str) -> Option<PathBuf> {

--- a/cargo-bsan/src/util.rs
+++ b/cargo-bsan/src/util.rs
@@ -87,40 +87,6 @@ pub fn exec_with_pipe(mut cmd: Command) -> ! {
     std::process::exit(exit_status.code().unwrap_or(-1))
 }
 
-/// Determines where the host sysroot of this execution is
-pub fn get_host_sysroot_dir(verbose: usize) -> PathBuf {
-    let mut cmd = rustc();
-    cmd.args(["--print", "sysroot"]);
-    debug_cmd("[cargo-bsan rustc]", verbose, &cmd);
-    let libdir = exec_stdout(cmd);
-    PathBuf::from(libdir.trim())
-}
-
-/// Determines where the sysroot of this execution is
-///
-/// Either in a user-specified spot by an envar, or in a default cache location.
-pub fn get_target_sysroot_dir() -> PathBuf {
-    match std::env::var_os("BSAN_SYSROOT") {
-        Some(dir) => PathBuf::from(dir),
-        None => {
-            let user_dirs =
-                directories::ProjectDirs::from("org", "borrowsanitizer", "bsan").unwrap();
-            user_dirs.cache_dir().to_owned()
-        }
-    }
-}
-
-pub fn get_host_sysroot_binary(binary: &str, verbose: usize) -> PathBuf {
-    let bsan_sysroot = get_host_sysroot_dir(verbose);
-    let sysroot_bindir = Path::new(&bsan_sysroot).join("bin");
-    let binary_path = sysroot_bindir.join(binary);
-    if binary_path.exists() {
-        binary_path
-    } else {
-        show_error!("Unable to locate `{binary}` within the host sysroot ({sysroot_bindir:?}).");
-    }
-}
-
 pub fn ask_to_run(mut cmd: Command, ask: bool, text: &str) {
     // Disable interactive prompts in CI (GitHub Actions, Travis, AppVeyor, etc).
     // Azure doesn't set `CI` though (nothing to see here, just Microsoft being Microsoft),

--- a/tests/test-cargo-bsan/src/lib.rs
+++ b/tests/test-cargo-bsan/src/lib.rs
@@ -1,0 +1,33 @@
+/// Doc-test test
+///
+/// ```rust
+/// assert!(cargo_bsan_test::make_true());
+/// ```
+///
+/// `no_run` test:
+///
+/// ```rust,no_run
+/// assert!(!cargo_bsan_test::make_true());
+/// ```
+///
+/// `compile_fail` test:
+///
+/// ```rust,compile_fail
+/// assert!(cargo_bsan_test::make_true() == 5);
+/// ```
+///
+/// Post-monomorphization error in `compile_fail` test:
+///
+/// ```rust,compile_fail
+/// struct Fail<T>(T);
+/// impl<T> Fail<T> {
+///     const C: () = panic!();
+/// }
+///
+/// let _val = Fail::<i32>::C;
+/// ```
+// This is imported in `main.rs`.
+#[unsafe(no_mangle)]
+pub fn make_true() -> bool {
+    true
+}

--- a/tests/test-cargo-bsan/test.stdout.ref
+++ b/tests/test-cargo-bsan/test.stdout.ref
@@ -1,5 +1,21 @@
 
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+
 running 1 test
 .
 test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
 
+
+running 2 tests
+..
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+
+running 2 tests
+..
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+all doctests ran in $TIME; merged doctests compilation took $TIME


### PR DESCRIPTION
This fixes the ongoing bug with doctests (#130) by ensuring that the `rustdoc` harness is instrumented.

It also enforces a common LLVM version between `clang`, `lld`, and `rustc` on the user's system. This is provided by default in our development environment, and it is necessary to ensure compatibility for cross-language instrumentation. We now use `clang` and `lld` for linking.

An experimental `--lto` flag has been added to `cargo-bsan`. This create a sysroot in a distinct directory and runs our instrumentation pass using `-Clinker-plugin-lto`.