### PR TITLE
Move thread IDs to LLVM.

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan_thread.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_thread.cpp
@@ -1,9 +1,12 @@
 #include "bsan_thread.h"
+#include "sanitizer_common/sanitizer_atomic.h"
 
 using namespace __sanitizer;
 using namespace __bsan;
 
 SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL void *__BSAN_PROV_STACK = nullptr;
+
+extern atomic_uintptr_t THREAD_ID_CTR;
 
 BsanThread *BsanThread::Create(thread_callback_t start_routine, void *arg) {
   uptr PageSize = GetPageSizeCached();
@@ -12,6 +15,7 @@ BsanThread *BsanThread::Create(thread_callback_t start_routine, void *arg) {
   thread->start_routine_ = start_routine;
   thread->arg_ = arg;
   thread->destructor_iterations_ = GetPthreadDestructorIterations();
+  thread->id = atomic_fetch_add(&THREAD_ID_CTR, 1, memory_order_relaxed);
   return thread;
 }
 

--- a/bsan-rt/llvm-wrapper/bsan_thread.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_thread.cpp
@@ -6,7 +6,7 @@ using namespace __bsan;
 
 SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL void *__BSAN_PROV_STACK = nullptr;
 
-extern atomic_uintptr_t THREAD_ID_CTR;
+atomic_uintptr_t THREAD_ID_CTR;
 
 BsanThread *BsanThread::Create(thread_callback_t start_routine, void *arg) {
   uptr PageSize = GetPageSizeCached();

--- a/bsan-rt/llvm-wrapper/bsan_thread.h
+++ b/bsan-rt/llvm-wrapper/bsan_thread.h
@@ -8,6 +8,8 @@
 using namespace __sanitizer;
 namespace __bsan {
 
+typedef uptr ThreadId;
+
 class BsanThread {
 public:
   static BsanThread *Create(thread_callback_t start_routine, void *arg);
@@ -18,7 +20,8 @@ public:
   bool IsMainThread() { return start_routine_ == nullptr; }
   uptr stack_top() { return stack_top_; }
   uptr stack_bottom() { return stack_bottom_; }
-  int destructor_iterations_;
+  int destructor_iterations_;  
+  ThreadId id;
   __sanitizer_sigset_t starting_sigset_;
 
 private:

--- a/bsan-rt/llvm-wrapper/bsan_thread.h
+++ b/bsan-rt/llvm-wrapper/bsan_thread.h
@@ -20,7 +20,7 @@ public:
   bool IsMainThread() { return start_routine_ == nullptr; }
   uptr stack_top() { return stack_top_; }
   uptr stack_bottom() { return stack_bottom_; }
-  int destructor_iterations_;  
+  int destructor_iterations_;
   ThreadId id;
   __sanitizer_sigset_t starting_sigset_;
 

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -38,10 +38,6 @@ use crate::sanitizer_common::{Location, Span};
 #[unsafe(no_mangle)]
 pub static mut __BSAN_HAD_ERROR: usize = 0;
 
-#[thread_local]
-#[unsafe(no_mangle)]
-pub static mut __BSAN_THREAD_ID: ThreadId = ThreadId(0);
-
 /// A struct for summarizing debug information about memory operations
 #[cfg(feature = "debug")]
 struct DebugSummary {
@@ -86,39 +82,6 @@ macro_rules! debug_bsan {
     };
 }
 
-#[unsafe(no_mangle)]
-pub static __BSAN_THREAD_ID_CTR: AtomicUsize = AtomicUsize::new(3);
-
-/// Unique identifier for an thread
-#[repr(transparent)]
-#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct ThreadId(pub usize);
-
-impl ThreadId {
-    pub fn get(&self) -> usize {
-        self.0
-    }
-
-    pub fn is_main(&self) -> bool {
-        self.0 == 1
-    }
-}
-
-impl Default for ThreadId {
-    fn default() -> Self {
-        ThreadId(__BSAN_THREAD_ID_CTR.fetch_add(1, Ordering::Relaxed))
-    }
-}
-
-impl fmt::Debug for ThreadId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            write!(f, "t{}", self.0)
-        } else {
-            write!(f, "thread{}", self.0)
-        }
-    }
-}
 
 #[unsafe(no_mangle)]
 pub static __BSAN_ALLOC_ID_CTR: AtomicUsize = AtomicUsize::new(3);

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -82,7 +82,6 @@ macro_rules! debug_bsan {
     };
 }
 
-
 #[unsafe(no_mangle)]
 pub static __BSAN_ALLOC_ID_CTR: AtomicUsize = AtomicUsize::new(3);
 


### PR DESCRIPTION
Our thread-local state mostly lives in the LLVM wrapper side, so we should create our Thread IDs there, too.