### PR TITLE
Handle debug shims in runtime

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -727,8 +727,6 @@ private:
       Callee = BS.BsanFuncAssertProvenanceNull;
     } else if (Name == kBsanFuncAssertProvenanceWildcard) {
       Callee = BS.BsanFuncAssertProvenanceWildcard;
-    } else if (Name == kBsanFuncDebugSnapshot) {
-      Callee = BS.BsanFuncDebugSnapshot;
     } else {
       // report_fatal_error("Unknown debug function: " + Twine(Name) + "\n");
       return false;
@@ -1613,9 +1611,6 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
 
   BsanFuncAssertProvenanceInvalid = M.getOrInsertFunction(
       kBsanFuncAssertProvenanceInvalid, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncDebugSnapshot = M.getOrInsertFunction(
-      kBsanFuncDebugSnapshot, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   EHPersonality Pers = getDefaultEHPersonality(TargetTriple);
   DefaultPersonalityFn =

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -712,32 +712,6 @@ private:
             !BS.getAllocaSizeInBytes(AI).isZero());
   }
 
-  bool handleDebugFunction(CallBase &CB, Function *F) {
-    IRBuilder<> IRB(&CB);
-    auto Name = F->getName();
-
-    FunctionCallee Callee;
-    ProvenanceScalar Prov = assertProvenanceScalar(CB.getArgOperand(0));
-
-    if (Name == kBsanFuncAssertProvenanceInvalid) {
-      Callee = BS.BsanFuncAssertProvenanceInvalid;
-    } else if (Name == kBsanFuncAssertProvenanceValid) {
-      Callee = BS.BsanFuncAssertProvenanceValid;
-    } else if (Name == kBsanFuncAssertProvenanceNull) {
-      Callee = BS.BsanFuncAssertProvenanceNull;
-    } else if (Name == kBsanFuncAssertProvenanceWildcard) {
-      Callee = BS.BsanFuncAssertProvenanceWildcard;
-    } else {
-      // report_fatal_error("Unknown debug function: " + Twine(Name) + "\n");
-      return false;
-    }
-
-    IRB.CreateCall(Callee, {Prov.Tag, Prov.Info});
-    CB.eraseFromParent();
-
-    return true;
-  }
-
   void instrumentRetagMem(CallBase &CB) {
     IRBuilder<> IRB(&CB);
     Value *Operand = CB.getOperand(0);
@@ -829,10 +803,6 @@ private:
 
     Function *Callee = CB.getCalledFunction();
     if (Callee) {
-      if (Callee->getName().starts_with(kBsanDebugPrefix)) {
-        if (handleDebugFunction(CB, Callee))
-          return;
-      }
       if (isRetag(&CB)) {
         if (CB.getType() == BS.PtrTy) {
           return instrumentRetagReg(CB);
@@ -1599,18 +1569,6 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
 
   BsanFuncDestroyStackSlot = M.getOrInsertFunction(
       kBsanFuncDestroyStackSlotName, AL, IRB.getVoidTy(), PtrTy);
-
-  BsanFuncAssertProvenanceNull = M.getOrInsertFunction(
-      kBsanFuncAssertProvenanceNull, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncAssertProvenanceWildcard = M.getOrInsertFunction(
-      kBsanFuncAssertProvenanceWildcard, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncAssertProvenanceValid = M.getOrInsertFunction(
-      kBsanFuncAssertProvenanceValid, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncAssertProvenanceInvalid = M.getOrInsertFunction(
-      kBsanFuncAssertProvenanceInvalid, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   EHPersonality Pers = getDefaultEHPersonality(TargetTriple);
   DefaultPersonalityFn =

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -712,7 +712,7 @@ private:
             !BS.getAllocaSizeInBytes(AI).isZero());
   }
 
-  void handleDebugFunction(CallBase &CB, Function *F) {
+  bool handleDebugFunction(CallBase &CB, Function *F) {
     IRBuilder<> IRB(&CB);
     auto Name = F->getName();
 
@@ -727,22 +727,17 @@ private:
       Callee = BS.BsanFuncAssertProvenanceNull;
     } else if (Name == kBsanFuncAssertProvenanceWildcard) {
       Callee = BS.BsanFuncAssertProvenanceWildcard;
-    } else if (Name == kBsanFuncDebugPrint) {
-      Callee = BS.BsanFuncDebugPrint;
-    } else if (Name == kBsanFuncDebugPrintBorrowState) {
-      Callee = BS.BsanFuncDebugPrintBorrowState;
-    } else if (Name == kBsanFuncDebugTreeSize) {
-      Callee = BS.BsanFuncDebugTreeSize;
     } else if (Name == kBsanFuncDebugSnapshot) {
       Callee = BS.BsanFuncDebugSnapshot;
-    } else if (Name == kBsanFuncDebugPrintDiff) {
-      Callee = BS.BsanFuncDebugPrintDiff;
     } else {
-      report_fatal_error("Unknown debug function: " + Twine(Name) + "\n");
+      // report_fatal_error("Unknown debug function: " + Twine(Name) + "\n");
+      return false;
     }
 
     IRB.CreateCall(Callee, {Prov.Tag, Prov.Info});
     CB.eraseFromParent();
+
+    return true;
   }
 
   void instrumentRetagMem(CallBase &CB) {
@@ -807,6 +802,7 @@ private:
   }
 
   bool shouldTrustFunction(Value *V) {
+
     if (isAllocationFn(V, TLI)) {
       return true;
     }
@@ -816,6 +812,9 @@ private:
     }
 
     if (Function *F = dyn_cast<Function>(V)) {
+      if (F->getName().starts_with(kBsanPrefix)) {
+        return true;
+      }
       LibFunc LibFn;
       TLI->getLibFunc(*F, LibFn);
       return isLibFreeFunction(F, LibFn);
@@ -833,10 +832,8 @@ private:
     Function *Callee = CB.getCalledFunction();
     if (Callee) {
       if (Callee->getName().starts_with(kBsanDebugPrefix)) {
-        return handleDebugFunction(CB, Callee);
-      }
-      if (Callee->getName().starts_with(kBsanPrefix)) {
-        return;
+        if (handleDebugFunction(CB, Callee))
+          return;
       }
       if (isRetag(&CB)) {
         if (CB.getType() == BS.PtrTy) {
@@ -1617,20 +1614,8 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   BsanFuncAssertProvenanceInvalid = M.getOrInsertFunction(
       kBsanFuncAssertProvenanceInvalid, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
-  BsanFuncDebugPrint = M.getOrInsertFunction(kBsanFuncDebugPrint, AL,
-                                             IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncDebugPrintBorrowState = M.getOrInsertFunction(
-      kBsanFuncDebugPrintBorrowState, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncDebugTreeSize = M.getOrInsertFunction(
-      kBsanFuncDebugTreeSize, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
   BsanFuncDebugSnapshot = M.getOrInsertFunction(
       kBsanFuncDebugSnapshot, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
-
-  BsanFuncDebugPrintDiff = M.getOrInsertFunction(
-      kBsanFuncDebugPrintDiff, AL, IRB.getVoidTy(), IntptrTy, PtrTy);
 
   EHPersonality Pers = getDefaultEHPersonality(TargetTriple);
   DefaultPersonalityFn =

--- a/bsan-pass/BorrowSanitizer.h
+++ b/bsan-pass/BorrowSanitizer.h
@@ -109,8 +109,6 @@ public:
   FunctionCallee BsanFuncAssertProvenanceValid;
   FunctionCallee BsanFuncAssertProvenanceInvalid;
 
-  FunctionCallee BsanFuncDebugSnapshot;
-
   FunctionCallee DefaultPersonalityFn;
 
   ProvenanceScalar WildcardProvenance;

--- a/bsan-pass/BorrowSanitizer.h
+++ b/bsan-pass/BorrowSanitizer.h
@@ -109,11 +109,7 @@ public:
   FunctionCallee BsanFuncAssertProvenanceValid;
   FunctionCallee BsanFuncAssertProvenanceInvalid;
 
-  FunctionCallee BsanFuncDebugPrint;
-  FunctionCallee BsanFuncDebugPrintBorrowState;
-  FunctionCallee BsanFuncDebugTreeSize;
   FunctionCallee BsanFuncDebugSnapshot;
-  FunctionCallee BsanFuncDebugPrintDiff;
 
   FunctionCallee DefaultPersonalityFn;
 

--- a/bsan-pass/BorrowSanitizer.h
+++ b/bsan-pass/BorrowSanitizer.h
@@ -104,11 +104,6 @@ public:
   FunctionCallee BsanFuncReserveStackSlot;
   FunctionCallee BsanFuncDestroyStackSlot;
 
-  FunctionCallee BsanFuncAssertProvenanceNull;
-  FunctionCallee BsanFuncAssertProvenanceWildcard;
-  FunctionCallee BsanFuncAssertProvenanceValid;
-  FunctionCallee BsanFuncAssertProvenanceInvalid;
-
   FunctionCallee DefaultPersonalityFn;
 
   ProvenanceScalar WildcardProvenance;

--- a/bsan-pass/Declarations.h
+++ b/bsan-pass/Declarations.h
@@ -56,13 +56,8 @@ const char kBsanFuncAssertProvenanceWildcard[] =
     BSAN_DEBUG_FN("assert_wildcard");
 const char kBsanFuncAssertProvenanceValid[] = BSAN_DEBUG_FN("assert_valid");
 const char kBsanFuncAssertProvenanceInvalid[] = BSAN_DEBUG_FN("assert_invalid");
-const char kBsanFuncDebugPrint[] = BSAN_DEBUG_FN("print");
-const char kBsanFuncDebugPrintBorrowState[] =
-    BSAN_DEBUG_FN("print_borrow_state");
 const char kBsanFuncDebugGC[] = BSAN_DEBUG_FN("gc");
-const char kBsanFuncDebugTreeSize[] = BSAN_DEBUG_FN("tree_size");
 const char kBsanFuncDebugSnapshot[] = BSAN_DEBUG_FN("snapshot");
-const char kBsanFuncDebugPrintDiff[] = BSAN_DEBUG_FN("print_diff");
 const char kBsanFuncDebugParamTLS[] = BSAN_DEBUG_FN("param_tls");
 const char kBsanFuncDebugRetvalTLS[] = BSAN_DEBUG_FN("retval_tls");
 

--- a/bsan-pass/Declarations.h
+++ b/bsan-pass/Declarations.h
@@ -51,15 +51,6 @@ const char kBsanFuncMarkTLSName[] = BSAN_FN("mark_tls");
 
 const char kBsanDebugPrefix[] = BSAN_DEBUG_FN();
 
-const char kBsanFuncAssertProvenanceNull[] = BSAN_DEBUG_FN("assert_null");
-const char kBsanFuncAssertProvenanceWildcard[] =
-    BSAN_DEBUG_FN("assert_wildcard");
-const char kBsanFuncAssertProvenanceValid[] = BSAN_DEBUG_FN("assert_valid");
-const char kBsanFuncAssertProvenanceInvalid[] = BSAN_DEBUG_FN("assert_invalid");
-const char kBsanFuncDebugGC[] = BSAN_DEBUG_FN("gc");
-const char kBsanFuncDebugParamTLS[] = BSAN_DEBUG_FN("param_tls");
-const char kBsanFuncDebugRetvalTLS[] = BSAN_DEBUG_FN("retval_tls");
-
 const char kBsanProvStackName[] = "__BSAN_PROV_STACK";
 const char kBsanParamTLSName[] = "__BSAN_PARAM_TLS";
 const char kBsanRetvalTLSName[] = "__BSAN_RETVAL_TLS";

--- a/bsan-pass/Declarations.h
+++ b/bsan-pass/Declarations.h
@@ -57,7 +57,6 @@ const char kBsanFuncAssertProvenanceWildcard[] =
 const char kBsanFuncAssertProvenanceValid[] = BSAN_DEBUG_FN("assert_valid");
 const char kBsanFuncAssertProvenanceInvalid[] = BSAN_DEBUG_FN("assert_invalid");
 const char kBsanFuncDebugGC[] = BSAN_DEBUG_FN("gc");
-const char kBsanFuncDebugSnapshot[] = BSAN_DEBUG_FN("snapshot");
 const char kBsanFuncDebugParamTLS[] = BSAN_DEBUG_FN("param_tls");
 const char kBsanFuncDebugRetvalTLS[] = BSAN_DEBUG_FN("retval_tls");
 

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -351,24 +351,32 @@ SANITIZER_WEAK_ATTRIBUTE void __bsan_dealloc_stack_impl(void *ptr,
                                                         BorTag bor_tag,
                                                         AllocInfo *alloc_info,
                                                         Span pc) {}
-// Weak Debugging
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_assert_null(BorTag bor_tag,
-                                                       AllocInfo *alloc_info) {}
-SANITIZER_WEAK_ATTRIBUTE void
-__bsan_debug_assert_wildcard(BorTag bor_tag, AllocInfo *alloc_info) {}
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_assert_valid(BorTag bor_tag,
+// Debugging
+SANITIZER_WEAK_ATTRIBUTE void __bsan_print(BorTag bor_tag,
+                                           AllocInfo *alloc_info) {}
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print(void *ptr) {
+  Provenance *Slot = GetArgSlot(0);
+  __bsan_print(Slot->Tag, Slot->Info);
+}
+SANITIZER_WEAK_ATTRIBUTE void __bsan_print_borrow_state(BorTag bor_tag,
                                                         AllocInfo *alloc_info) {
 }
-SANITIZER_WEAK_ATTRIBUTE void
-__bsan_debug_assert_invalid(BorTag bor_tag, AllocInfo *alloc_info) {}
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_print(BorTag bor_tag,
-                                                 AllocInfo *alloc_info) {}
-SANITIZER_WEAK_ATTRIBUTE void
-__bsan_debug_print_borrow_state(BorTag bor_tag, AllocInfo *alloc_info) {}
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_tree_size(BorTag bor_tag,
-                                                     AllocInfo *alloc_info) {}
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_print_diff(BorTag bor_tag,
-                                                      AllocInfo *alloc_info) {}
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_borrow_state(void *ptr) {
+  Provenance *Slot = GetArgSlot(0);
+  __bsan_print_borrow_state(Slot->Tag, Slot->Info);
+}
+SANITIZER_WEAK_ATTRIBUTE void __bsan_tree_size(BorTag bor_tag,
+                                               AllocInfo *alloc_info) {}
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_tree_size(void *ptr) {
+  Provenance *Slot = GetArgSlot(0);
+  __bsan_tree_size(Slot->Tag, Slot->Info);
+}
+SANITIZER_WEAK_ATTRIBUTE void __bsan_print_diff(BorTag bor_tag,
+                                                AllocInfo *alloc_info) {}
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_diff(void *ptr) {
+  Provenance *Slot = GetArgSlot(0);
+  __bsan_print_diff(Slot->Tag, Slot->Info);
+}
 
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_abort() {
   // Printf("BorrowSanitizer: aborting due to a fatal error.\n");

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -358,6 +358,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print(void *ptr) {
   Provenance *Slot = GetArgSlot(0);
   __bsan_print(Slot->Tag, Slot->Info);
 }
+
 SANITIZER_WEAK_ATTRIBUTE void __bsan_print_borrow_state(BorTag bor_tag,
                                                         AllocInfo *alloc_info) {
 }
@@ -365,12 +366,21 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_borrow_state(void *ptr) {
   Provenance *Slot = GetArgSlot(0);
   __bsan_print_borrow_state(Slot->Tag, Slot->Info);
 }
+
 SANITIZER_WEAK_ATTRIBUTE void __bsan_tree_size(BorTag bor_tag,
                                                AllocInfo *alloc_info) {}
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_tree_size(void *ptr) {
   Provenance *Slot = GetArgSlot(0);
   __bsan_tree_size(Slot->Tag, Slot->Info);
 }
+
+SANITIZER_WEAK_ATTRIBUTE void __bsan_snapshot(BorTag bor_tag,
+                                              AllocInfo *alloc_info) {}
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_snapshot(void *ptr) {
+  Provenance *Slot = GetArgSlot(0);
+  __bsan_snapshot(Slot->Tag, Slot->Info);
+}
+
 SANITIZER_WEAK_ATTRIBUTE void __bsan_print_diff(BorTag bor_tag,
                                                 AllocInfo *alloc_info) {}
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_diff(void *ptr) {

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -146,23 +146,10 @@ SANITIZER_WEAK_ATTRIBUTE AllocInfo *__bsan_reserve_stack_slot();
 
 SANITIZER_WEAK_ATTRIBUTE void __bsan_destroy_stack_slot(AllocInfo *slot);
 
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_assert_null(BorTag bor_tag,
-                                                       AllocInfo *alloc_info);
-SANITIZER_WEAK_ATTRIBUTE void
-__bsan_debug_assert_wildcard(BorTag bor_tag, AllocInfo *alloc_info);
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_assert_valid(BorTag bor_tag,
-                                                        AllocInfo *alloc_info);
-SANITIZER_WEAK_ATTRIBUTE void
-__bsan_debug_assert_invalid(BorTag bor_tag, AllocInfo *alloc_info);
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_print(BorTag bor_tag,
-                                                 AllocInfo *alloc_info);
-SANITIZER_WEAK_ATTRIBUTE void
-__bsan_debug_print_borrow_state(BorTag bor_tag, AllocInfo *alloc_info);
-
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_tree_size(BorTag bor_tag,
-                                                     AllocInfo *alloc_info);
-SANITIZER_WEAK_ATTRIBUTE void __bsan_debug_print_diff(BorTag bor_tag,
-                                                      AllocInfo *alloc_info);
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print(void *ptr);
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_borrow_state(void *ptr);
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_tree_size(void *ptr);
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_diff(void *ptr);
 
 } // extern "C"
 

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -150,6 +150,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print(void *ptr);
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_borrow_state(void *ptr);
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_tree_size(void *ptr);
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print_diff(void *ptr);
+SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_snapshot(void *ptr);
 
 } // extern "C"
 

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -96,12 +96,6 @@ impl GlobalCtx {
         &self.shadow_heap
     }
 
-    pub fn exit(&self, code: i32) -> ! {
-        unsafe {
-            libc::exit(code);
-        }
-    }
-
     pub fn protected_tags<'a>(&'a self) -> ProtectedTagsRef<'a> {
         ProtectedTagsRef(self.protected_tags.read())
     }

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -524,52 +524,14 @@ unsafe extern "C" fn __bsan_alloc_stack_impl(
     }
 }
 
-// Code is more readable with explicit return
-#[allow(clippy::needless_return)]
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_null(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
-    let global_ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
-    if prov != Provenance::null() {
-        crate::eprintln!("Expected null provenance, got {prov:?}");
-        global_ctx.exit(1);
-    }
-}
-
-#[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_wildcard(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
-    let global_ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
-    if prov != Provenance::wildcard() {
-        crate::eprintln!("Expected wildcard provenance, got {prov:?}");
-        global_ctx.exit(1);
-    }
-}
-
-#[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_valid(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
-    let prov = Provenance { bor_tag, alloc_info };
-    assert_ne!(prov, Provenance::null());
-    assert_ne!(prov, Provenance::wildcard());
-}
-
-#[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_assert_invalid(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
-    let global_ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
-    if !(prov == Provenance::null() || prov == Provenance::wildcard()) {
-        global_ctx.exit(1);
-    }
-}
-
-#[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_print(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_print(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let prov = Provenance { bor_tag, alloc_info };
     crate::println!("{prov:?}");
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_print_borrow_state(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_print_borrow_state(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {
@@ -579,7 +541,7 @@ extern "C" fn __bsan_debug_print_borrow_state(bor_tag: BorTag, alloc_info: *mut 
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_tree_size(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_tree_size(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {
         crate::println!("Tree size: {}", bt.debug_tree_size());
@@ -598,7 +560,7 @@ extern "C" fn __bsan_debug_snapshot(bor_tag: BorTag, alloc_info: *mut AllocInfo)
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_print_diff(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_print_diff(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -550,7 +550,7 @@ extern "C" fn __bsan_tree_size(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_debug_snapshot(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_snapshot(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
     let _ = BorrowTracker::for_alloc(prov, |bt| {


### PR DESCRIPTION
This PR moves debug handling out of the LLVM pass. Debug functions are treated as any other, removing the necessity for `handleDebugFunction` in `bsan-pass/BorrowSanitizer.cpp`.

We also removed the `__bsan_debug_assert_...` functions (unused in the testbench and in Ian's experience), but if YOU, the reader, regularly uses them then I can add them back.

I noticed `__bsan_debug_snapshot` was missing C++ shims in the runtime. I added it back in as well.

Fixes #149