### PR TITLE
Add runtime flags

### DIFF
--- a/bsan-rt/llvm-wrapper/CMakeLists.txt
+++ b/bsan-rt/llvm-wrapper/CMakeLists.txt
@@ -3,6 +3,7 @@ set(BSAN_SUPPORTED_ARCH ${SANITIZER_COMMON_SUPPORTED_ARCH})
 # Runtime library sources and build flags.
 set(BSAN_SOURCES
   bsan.cpp
+  bsan_flags.cpp
   bsan_interceptors.cpp
   bsan_linux.cpp
   bsan_thread.cpp
@@ -10,6 +11,7 @@ set(BSAN_SOURCES
 
 SET(BSAN_HEADERS
   bsan.h
+  bsan_flags.h
   bsan_thread.h
 )
 

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -1,4 +1,5 @@
 #include "bsan.h"
+#include "bsan_flags.h"
 #include "bsan_thread.h"
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_file.h"
@@ -78,19 +79,10 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_init() {
     return;
   BSAN_INIT_RUNNING = true;
   AvoidCVE_2016_2143();
+  InitializeFlags();
   __bsan_internal_init();
   InitializePlatformEarly();
   InitializeInterceptors();
-  SetCommonFlagsDefaults();
-  {
-    const char *symbolizer_path = GetEnv("BSAN_SYMBOLIZER");
-    if (symbolizer_path) {
-      CommonFlags cf;
-      cf.CopyFrom(*common_flags());
-      cf.external_symbolizer_path = symbolizer_path;
-      OverrideCommonFlags(cf);
-    }
-  }
   BsanTSDInit();
   BsanThread *main_thread = BsanThread::Create(nullptr, nullptr);
   SetCurrentThread(main_thread);

--- a/bsan-rt/llvm-wrapper/bsan_flags.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_flags.cpp
@@ -1,0 +1,143 @@
+//===-- bsan_flags.cpp ------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of BorrowSanitizer, an address sanity checker.
+//
+// BSan flag parsing logic.
+//===----------------------------------------------------------------------===//
+
+#include "bsan_flags.h"
+
+#include "bsan.h"
+#include "sanitizer_common/sanitizer_common.h"
+#include "sanitizer_common/sanitizer_flag_parser.h"
+#include "sanitizer_common/sanitizer_flags.h"
+#include "sanitizer_common/sanitizer_win_interception.h"
+
+using namespace __sanitizer;
+
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE
+const char *__bsan_default_options();
+
+namespace __bsan {
+
+Flags bsan_flags_dont_use_directly;  // use via flags().
+
+static const char *MaybeUseBsanDefaultOptionsCompileDefinition() {
+#ifdef BSAN_DEFAULT_OPTIONS
+  return SANITIZER_STRINGIFY(BSAN_DEFAULT_OPTIONS);
+#else
+  return "";
+#endif
+}
+
+void Flags::SetDefaults() {
+#define BSAN_FLAG(Type, Name, DefaultValue, Description) Name = DefaultValue;
+#include "bsan_flags.inc"
+#undef BSAN_FLAG
+}
+
+static void RegisterBsanFlags(FlagParser *parser, Flags *f) {
+#define BSAN_FLAG(Type, Name, DefaultValue, Description) \
+  RegisterFlag(parser, #Name, Description, &f->Name);
+#include "bsan_flags.inc"
+#undef BSAN_FLAG
+}
+
+static void DisplayHelpMessages(FlagParser *parser) {
+  if (Verbosity()) {
+    ReportUnrecognizedFlags();
+  }
+
+  if (common_flags()->help) {
+    parser->PrintFlagDescriptions();
+  }
+}
+
+static void InitializeDefaultFlags() {
+  Flags *f = flags();
+  FlagParser bsan_parser;
+
+  // Set the default values and prepare for parsing BSan and common flags.
+  SetCommonFlagsDefaults();
+  {
+    CommonFlags cf;
+    cf.CopyFrom(*common_flags());
+    if (const char *symbolizer_path = GetEnv("BSAN_SYMBOLIZER")) {
+      cf.external_symbolizer_path = symbolizer_path;
+    } else {
+      cf.external_symbolizer_path = GetEnv("BSAN_SYMBOLIZER_PATH");
+    }
+    cf.exitcode = 1;
+    OverrideCommonFlags(cf);
+  }
+  f->SetDefaults();
+
+  RegisterBsanFlags(&bsan_parser, f);
+  RegisterCommonFlags(&bsan_parser);
+
+  // Override from BSan compile definition.
+  const char *bsan_compile_def = MaybeUseBsanDefaultOptionsCompileDefinition();
+  bsan_parser.ParseString(bsan_compile_def);
+
+  // Override from user-specified string.
+  const char *bsan_default_options = __bsan_default_options();
+  bsan_parser.ParseString(bsan_default_options);
+
+  // Override from command line.
+  bsan_parser.ParseStringFromEnv("BSAN_OPTIONS");
+
+  InitializeCommonFlags();
+
+  DisplayHelpMessages(&bsan_parser);
+}
+
+// Validate flags and report incompatible configurations
+static void ProcessFlags() {
+  // Flags *f = flags();
+  // Flag validation goes here.
+}
+
+void InitializeFlags() {
+  InitializeDefaultFlags();
+  ProcessFlags();
+
+#if SANITIZER_WINDOWS
+  // On Windows, weak symbols (such as the `__bsan_default_options` function)
+  // are emulated by having the user program register which weak functions are
+  // defined. The BSAN DLL will initialize flags prior to user module
+  // initialization, so __bsan_default_options will not point to the user
+  // definition yet. We still want to ensure we capture when options are passed
+  // via
+  // __bsan_default_options, so we add a callback to be run
+  // when it is registered with the runtime.
+
+  AddRegisterWeakFunctionCallback(
+      reinterpret_cast<uptr>(__bsan_default_options), []() {
+        // We call `InitializeDefaultFlags` again, instead of just parsing
+        // `__bsan_default_options` directly, to ensure that flags set through
+        // `BSAN_OPTS` take precedence over those set through
+        // `__bsan_default_options`.
+        InitializeDefaultFlags();
+        ProcessFlags();
+        ApplyFlags();
+      });
+#endif
+}
+
+}  // namespace __bsan
+
+extern "C" {
+SANITIZER_INTERFACE_ATTRIBUTE bool __bsan_disable_node_debug_info() {
+  return __bsan::flags()->disable_node_debug_info;
+}
+}
+
+SANITIZER_INTERFACE_WEAK_DEF(const char*, __bsan_default_options, void) {
+  return "";
+}

--- a/bsan-rt/llvm-wrapper/bsan_flags.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_flags.cpp
@@ -21,12 +21,12 @@
 
 using namespace __sanitizer;
 
-extern "C" SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE
-const char *__bsan_default_options();
+extern "C" SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE const char *
+__bsan_default_options();
 
 namespace __bsan {
 
-Flags bsan_flags_dont_use_directly;  // use via flags().
+Flags bsan_flags_dont_use_directly; // use via flags().
 
 static const char *MaybeUseBsanDefaultOptionsCompileDefinition() {
 #ifdef BSAN_DEFAULT_OPTIONS
@@ -43,7 +43,7 @@ void Flags::SetDefaults() {
 }
 
 static void RegisterBsanFlags(FlagParser *parser, Flags *f) {
-#define BSAN_FLAG(Type, Name, DefaultValue, Description) \
+#define BSAN_FLAG(Type, Name, DefaultValue, Description)                       \
   RegisterFlag(parser, #Name, Description, &f->Name);
 #include "bsan_flags.inc"
 #undef BSAN_FLAG
@@ -130,7 +130,7 @@ void InitializeFlags() {
 #endif
 }
 
-}  // namespace __bsan
+} // namespace __bsan
 
 extern "C" {
 SANITIZER_INTERFACE_ATTRIBUTE bool __bsan_disable_node_debug_info() {
@@ -138,6 +138,6 @@ SANITIZER_INTERFACE_ATTRIBUTE bool __bsan_disable_node_debug_info() {
 }
 }
 
-SANITIZER_INTERFACE_WEAK_DEF(const char*, __bsan_default_options, void) {
+SANITIZER_INTERFACE_WEAK_DEF(const char *, __bsan_default_options, void) {
   return "";
 }

--- a/bsan-rt/llvm-wrapper/bsan_flags.h
+++ b/bsan-rt/llvm-wrapper/bsan_flags.h
@@ -1,0 +1,47 @@
+//===-- bsan_flags.h -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of BorrowSanitizer, an address sanity checker.
+//
+// BSan runtime flags.
+//===----------------------------------------------------------------------===//
+
+#ifndef BSAN_FLAGS_H
+#define BSAN_FLAGS_H
+
+#include "sanitizer_common/sanitizer_internal_defs.h"
+#include "sanitizer_common/sanitizer_flag_parser.h"
+
+// BSan flag values can be defined in four ways:
+// 1) initialized with default values at startup.
+// 2) overridden during compilation of BSan runtime by providing
+// compile definition BSAN_DEFAULT_OPTIONS.
+// 3) overridden from string returned by user-specified function
+// __bsan_default_options().
+// 4) overridden from env variable BSAN_OPTIONS.
+
+namespace __bsan {
+
+struct Flags {
+#define BSAN_FLAG(Type, Name, DefaultValue, Description) Type Name;
+#include "bsan_flags.inc"
+#undef BSAN_FLAG
+
+  void SetDefaults();
+};
+
+extern Flags bsan_flags_dont_use_directly;
+inline Flags *flags() {
+  return &bsan_flags_dont_use_directly;
+}
+
+void InitializeFlags();
+
+} // namespace __bsan
+
+#endif // BSAN_FLAGS_H

--- a/bsan-rt/llvm-wrapper/bsan_flags.h
+++ b/bsan-rt/llvm-wrapper/bsan_flags.h
@@ -14,8 +14,8 @@
 #ifndef BSAN_FLAGS_H
 #define BSAN_FLAGS_H
 
-#include "sanitizer_common/sanitizer_internal_defs.h"
 #include "sanitizer_common/sanitizer_flag_parser.h"
+#include "sanitizer_common/sanitizer_internal_defs.h"
 
 // BSan flag values can be defined in four ways:
 // 1) initialized with default values at startup.
@@ -36,9 +36,7 @@ struct Flags {
 };
 
 extern Flags bsan_flags_dont_use_directly;
-inline Flags *flags() {
-  return &bsan_flags_dont_use_directly;
-}
+inline Flags *flags() { return &bsan_flags_dont_use_directly; }
 
 void InitializeFlags();
 

--- a/bsan-rt/llvm-wrapper/bsan_flags.inc
+++ b/bsan-rt/llvm-wrapper/bsan_flags.inc
@@ -1,0 +1,20 @@
+//===-- bsan_flags.inc ------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// BSan runtime flags.
+//
+//===----------------------------------------------------------------------===//
+#ifndef BSAN_FLAG
+# error "Define BSAN_FLAG prior to including this file!"
+#endif
+
+// BSAN_FLAG(Type, Name, DefaultValue, Description)
+// See COMMON_FLAG in sanitizer_flags.inc for more details.
+
+BSAN_FLAG(bool, disable_node_debug_info, false,
+          "Disable NodeDebugInfo diagnostics from the tree.")

--- a/bsan-rt/src/diagnostics.rs
+++ b/bsan-rt/src/diagnostics.rs
@@ -110,6 +110,9 @@ pub struct HistoryData {
 impl History {
     /// Record an additional event to the history.
     pub fn push(&mut self, event: Event) {
+        if crate::global::DISABLE_NODE_DEBUG_INFO.load(core::sync::atomic::Ordering::Relaxed) {
+            return;
+        }
         self.events.push(event);
     }
 

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -2,6 +2,7 @@ use core::cell::UnsafeCell;
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use borrow_tracker::ProtectorKind;
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -10,8 +11,6 @@ use crate::errors::{ErrorFormatContext, UBInfo};
 use crate::helpers::FxHashMap;
 use crate::memory::{Heap, ShadowHeap};
 use crate::*;
-
-use core::sync::atomic::{AtomicBool, Ordering};
 
 pub static DISABLE_NODE_DEBUG_INFO: AtomicBool = AtomicBool::new(false);
 

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -11,8 +11,13 @@ use crate::helpers::FxHashMap;
 use crate::memory::{Heap, ShadowHeap};
 use crate::*;
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
+pub static DISABLE_NODE_DEBUG_INFO: AtomicBool = AtomicBool::new(false);
+
 unsafe extern "C" {
     fn __bsan_abort() -> !;
+    fn __bsan_disable_node_debug_info() -> bool;
 }
 
 #[derive(Default)]
@@ -193,6 +198,7 @@ static GLOBAL_CTX: GlobalCtxWrapper = GlobalCtxWrapper(UnsafeCell::new(MaybeUnin
 pub unsafe fn init_global_ctx() {
     unsafe {
         (*GLOBAL_CTX.0.get()).write(GlobalCtx::new());
+        DISABLE_NODE_DEBUG_INFO.store(__bsan_disable_node_debug_info(), Ordering::Relaxed);
     }
 }
 


### PR DESCRIPTION
## Notes

- Moved symbolizer flag defaults to `bsan_flags.cpp`
- Essentially a soft-port of `asan_flags.cpp` from compiler-rt

## TODO

- [x] Merge conflict with `main`


Closes #138 