### PR TITLE
Add a nop mode for testing the LLVM wrapper.

### DIFF
--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -410,6 +410,12 @@ impl Buildable for CompilerRt {
         let target = path!(target_dir / self.artifact(env));
         Ok(Some(target))
     }
+    fn install(&self, env: &mut BsanEnv, args: &[String]) -> Result<()> {
+        env.in_mode(Mode::Release, |env| {
+            let built = self.build(env, args)?.expect("Compiler-rt was not built.");
+            env.copy_to_sysroot_libdir(&built)
+        })
+    }
 }
 
 struct BsanRtCore;

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -110,7 +110,7 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     }
 
     let llvm_tools = LlvmTools::new(&rustc_version, &host_sysroot);
-    let deps = Dependencies::setup(&host_sysroot);
+    let deps = Dependencies::setup(&rustc_version, &host_sysroot);
 
     setup_sysroot(&subcommand, &rustc_version, &deps, &llvm_tools, &target_sysroot, &env);
 

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -13,6 +13,10 @@ use crate::arg::*;
 use crate::llvm::LlvmTools;
 use crate::util::*;
 
+const RUST_RT: &str = "libbsan_rt";
+const LLVM_RT: &str = "libclang_rt.bsan";
+const LLVM_PLUGIN: &str = "libbsan_plugin";
+
 pub struct EnvConfig {
     pub verbose: bool,
     pub quiet: bool,
@@ -53,7 +57,7 @@ pub struct Dependencies {
 }
 
 impl Dependencies {
-    pub fn setup(host_sysroot: &Sysroot) -> Self {
+    pub fn setup(version: &VersionMeta, host_sysroot: &Sysroot) -> Self {
         let ensure_library_var = |var: &str, sysroot: &Sysroot, libname: &str| {
             env::var_os(var).map(|o| o.into()).or_else(|| {
                 let plugin: PathBuf = (*sysroot).join("lib").join(libname).to_path_buf();
@@ -65,7 +69,8 @@ impl Dependencies {
             })
         };
 
-        let Some(llvm_pass) = ensure_library_var("BSAN_PLUGIN", host_sysroot, "libbsan_plugin.so")
+        let Some(llvm_pass) =
+            ensure_library_var("BSAN_PLUGIN", host_sysroot, &format!("{LLVM_PLUGIN}.so"))
         else {
             show_error!(
                 "failed to locate the BorrowSanitizer LLVM plugin (libbsan_plugin.so) within the host sysroot: {}",
@@ -73,9 +78,25 @@ impl Dependencies {
             );
         };
 
-        let Some(runtime) = ensure_library_var("BSAN_RT", host_sysroot, "libbsan_rt.a") else {
+        let nop = env::var_os("BSAN_NOP").is_some();
+
+        let runtime_libname = if nop {
+            let host = &version.host;
+            let components: Vec<&str> = host.split("-").collect();
+            if let Some(arch) = components.first() {
+                format!("{LLVM_RT}-{arch}.a")
+            } else {
+                show_error!(
+                    "Failed to resolve the host architecture from the target triple: {host}"
+                );
+            }
+        } else {
+            format!("{RUST_RT}.a")
+        };
+
+        let Some(runtime) = ensure_library_var("BSAN_RT", host_sysroot, &runtime_libname) else {
             show_error!(
-                "failed to locate the BorrowSanitizer runtime (libbsan_rt.a) within the host sysroot."
+                "failed to locate the BorrowSanitizer runtime ({runtime_libname}) within the host sysroot."
             );
         };
 

--- a/tests/test-cargo-bsan/run_test.py
+++ b/tests/test-cargo-bsan/run_test.py
@@ -15,7 +15,7 @@ def fail(msg):
     sys.exit(1)
 
 
-def cargo_bsan(cmd, quiet=True):
+def cargo_bsan(cmd, quiet=True, nop=False):
     args = ["cargo", "bsan", cmd] + CARGO_EXTRA_FLAGS
     if quiet:
         args += ["-q"]
@@ -145,11 +145,16 @@ def test_cargo_bsan_run():
         cargo_bsan("run"),
         stdout_ref="run.stdout.ref",
     )
+    test(
+        "`cargo bsan run` (nop)",
+        cargo_bsan("run"),
+        stdout_ref="run.stdout.ref",
+        env={"BSAN_NOP": "1"},
+    )
     test_no_rebuild(
         "`cargo bsan run` (no rebuild)",
         cargo_bsan("run", quiet=False),
     )
-
 
 def test_cargo_bsan_test():
     test(
@@ -157,7 +162,12 @@ def test_cargo_bsan_test():
         cargo_bsan("test"),
         stdout_ref="test.stdout.ref",
     )
-
+    test(
+        "`cargo bsan test` (nop)",
+        cargo_bsan("test"),
+        stdout_ref="test.stdout.ref",
+        env={"BSAN_NOP": "1"},
+    )
 
 args_parser = argparse.ArgumentParser(description="`cargo bsan` testing")
 args_parser.add_argument(


### PR DESCRIPTION
Setting `BSAN_NOP` will now configure `cargo bsan` to use just the LLVM runtime component, without the Rust core. This will be useful for testing the wrapper and isolating bugs to specific components of the runtime.