### PR TITLE
Init/deinit local ctx

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -249,6 +249,10 @@ SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_init() {}
 
 SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_deinit() {}
 
+SANITIZER_WEAK_ATTRIBUTE void __bsan_local_init(Provenance **prov) {}
+
+SANITIZER_WEAK_ATTRIBUTE void __bsan_local_deinit() {}
+
 // Weak tagging operations
 SANITIZER_WEAK_ATTRIBUTE BorTag __bsan_new_bor_tag() { return 0; }
 

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -94,6 +94,10 @@ SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_init();
 
 SANITIZER_WEAK_ATTRIBUTE void __bsan_internal_deinit();
 
+SANITIZER_WEAK_ATTRIBUTE void __bsan_local_init(Provenance **prov);
+
+SANITIZER_WEAK_ATTRIBUTE void __bsan_local_deinit();
+
 SANITIZER_WEAK_ATTRIBUTE BorTag __bsan_new_bor_tag();
 
 SANITIZER_INTERFACE_ATTRIBUTE void

--- a/bsan-rt/llvm-wrapper/bsan_thread.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_thread.cpp
@@ -26,6 +26,7 @@ void BsanThread::Init() {
   prov_stack_size_ = stack_top_ - stack_bottom_;
   prov_stack_ = MmapOrDie(prov_stack_size_, __func__);
   __BSAN_PROV_STACK = (Provenance *)(((u8 *)prov_stack_) + prov_stack_size_);
+  __bsan_local_init(&__BSAN_PROV_STACK);
 }
 
 void BsanThread::TSDDtor(void *tsd) {

--- a/bsan-rt/llvm-wrapper/bsan_thread.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_thread.cpp
@@ -38,6 +38,7 @@ void BsanThread::Destroy() {
   UnmapOrDie(prov_stack_, prov_stack_size_);
   uptr size = RoundUpTo(sizeof(BsanThread), GetPageSizeCached());
   UnmapOrDie(this, size);
+  __bsan_local_deinit();
 }
 
 thread_return_t BsanThread::ThreadStart() {

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -9,6 +9,7 @@ use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::errors::{ErrorFormatContext, UBInfo};
 use crate::helpers::FxHashMap;
+use crate::local::{self, LocalCtx};
 use crate::memory::{Heap, ShadowHeap};
 use crate::*;
 
@@ -76,6 +77,7 @@ pub struct GlobalCtx {
     shadow_heap: ShadowHeap<Provenance>,
     alloc_metadata_map: Heap<AllocInfo>,
     snapshots: RwLock<FxHashMap<AllocId, Tree>>,
+    threads: RwLock<FxHashMap<ThreadId, NonNull<LocalCtx>>>,
 }
 
 impl GlobalCtx {
@@ -85,6 +87,7 @@ impl GlobalCtx {
             alloc_metadata_map: Heap::new(),
             shadow_heap: ShadowHeap::new(&raw const __BSAN_WILDCARD_PROVENANCE),
             snapshots: RwLock::new(FxHashMap::default()),
+            threads: RwLock::new(FxHashMap::default()),
         }
     }
 
@@ -94,6 +97,10 @@ impl GlobalCtx {
 
     pub(crate) unsafe fn destroy_alloc_info(&self, ptr: NonNull<AllocInfo>) {
         unsafe { self.alloc_metadata_map.dealloc(ptr) }
+    }
+
+    pub(crate) fn register_thread(&self, local_ctx_ptr: NonNull<LocalCtx>) {
+        self.threads.write().insert(ThreadId::default(), local_ctx_ptr);
     }
 
     pub fn shadow_heap(&self) -> &ShadowHeap<Provenance> {

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -9,7 +9,7 @@ use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::errors::{ErrorFormatContext, UBInfo};
 use crate::helpers::FxHashMap;
-use crate::local::{self, LocalCtx};
+use crate::local::LocalCtx;
 use crate::memory::{Heap, ShadowHeap};
 use crate::*;
 
@@ -99,8 +99,12 @@ impl GlobalCtx {
         unsafe { self.alloc_metadata_map.dealloc(ptr) }
     }
 
-    pub(crate) fn register_thread(&self, local_ctx_ptr: NonNull<LocalCtx>) {
-        self.threads.write().insert(ThreadId::default(), local_ctx_ptr);
+    pub(crate) fn register_thread(&self, thread_id: ThreadId, local_ctx_ptr: NonNull<LocalCtx>) {
+        self.threads.write().insert(thread_id, local_ctx_ptr);
+    }
+
+    pub(crate) fn deregister_thread(&self, thread: ThreadId) {
+        self.threads.write().remove(&thread);
     }
 
     pub fn shadow_heap(&self) -> &ShadowHeap<Provenance> {

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -339,6 +339,14 @@ unsafe extern "C-unwind" fn __bsan_local_init(prov: *mut NonNull<Provenance>) {
 }
 
 #[unsafe(no_mangle)]
+unsafe extern "C-unwind" fn __bsan_local_deinit() {
+    unsafe {
+        let ctx = global_ctx();
+        deinit_local_ctx(ctx);
+    }
+}
+
+#[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn __bsan_new_bor_tag() -> BorTag {
     BorTag::default()
 }

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -28,11 +28,13 @@ mod borrow_tracker;
 use borrow_tracker::*;
 
 mod diagnostics;
+mod local;
 
 mod errors;
 mod memory;
 
 use crate::borrow_tracker::tree::Tree;
+use crate::local::*;
 use crate::sanitizer_common::Span;
 
 #[thread_local]
@@ -127,6 +129,36 @@ impl fmt::Debug for AllocId {
             write!(f, "a{}", self.0)
         } else {
             write!(f, "alloc{}", self.0)
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub static __BSAN_THREAD_ID_CTR: AtomicUsize = AtomicUsize::new(3);
+
+/// Unique identifier for a thread
+#[repr(transparent)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ThreadId(usize);
+
+impl ThreadId {
+    pub fn get(&self) -> usize {
+        self.0
+    }
+}
+
+impl Default for ThreadId {
+    fn default() -> Self {
+        ThreadId(__BSAN_THREAD_ID_CTR.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl fmt::Debug for ThreadId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if f.alternate() {
+            write!(f, "t{}", self.0)
+        } else {
+            write!(f, "thread{}", self.0)
         }
     }
 }
@@ -295,6 +327,14 @@ unsafe extern "C-unwind" fn __bsan_internal_init() {
 unsafe extern "C-unwind" fn __bsan_internal_deinit() {
     unsafe {
         deinit_global_ctx();
+    }
+}
+
+#[unsafe(no_mangle)]
+unsafe extern "C-unwind" fn __bsan_local_init(prov: *mut NonNull<Provenance>) {
+    unsafe {
+        let ctx = global_ctx();
+        init_local_ctx(ctx, prov);
     }
 }
 

--- a/bsan-rt/src/local.rs
+++ b/bsan-rt/src/local.rs
@@ -17,6 +17,7 @@ pub(crate) static LOCAL_CTX: LocalCtxWrapper =
 /// The LocalCtx should contain a pointer to the shadow stack,
 /// the length of the shadow stack allocation,
 /// and a pointer to where the thread's __BSAN_PROV_STACK is stored.
+#[allow(unused)]
 #[derive(Debug)]
 pub struct LocalCtx {
     thread_id: ThreadId,
@@ -43,8 +44,7 @@ pub unsafe fn init_local_ctx(global_ctx: &GlobalCtx, stack_ptr: *mut NonNull<Pro
     let local_ctx_ptr = LOCAL_CTX.0.get().cast::<LocalCtx>();
     let thread_id = ThreadId::default();
     unsafe {
-        let local_ctx = LocalCtx::new(thread_id, stack_ptr);
-        local_ctx_ptr.write(local_ctx);
+        local_ctx_ptr.write(LocalCtx::new(thread_id, stack_ptr));
         global_ctx.register_thread(thread_id, NonNull::new_unchecked(local_ctx_ptr));
     }
 }
@@ -62,18 +62,3 @@ pub unsafe fn deinit_local_ctx(global_ctx: &GlobalCtx) {
     unsafe { ptr::replace(LOCAL_CTX.0.get(), MaybeUninit::uninit()).assume_init() };
     global_ctx.deregister_thread(thread_id);
 }
-
-// /// # Safety
-// /// The user needs to ensure that the context is initialized.
-// #[inline]
-// pub unsafe fn local_ctx<'a>() -> &'a LocalCtx {
-//     unsafe { &*local_ctx_mut() }
-// }
-
-// /// # Safety
-// /// The user needs to ensure that the context is initialized.
-// #[inline]
-// pub unsafe fn local_ctx_mut<'a>() -> &'a mut LocalCtx {
-//     let ctx = LOCAL_CTX.0.get();
-//     unsafe { &mut *ctx.cast::<LocalCtx>() }
-// }

--- a/bsan-rt/src/local.rs
+++ b/bsan-rt/src/local.rs
@@ -1,0 +1,71 @@
+use core::cell::UnsafeCell;
+use core::mem::MaybeUninit;
+use core::num::NonZero;
+use core::ops::Deref;
+use core::ptr;
+use core::ptr::NonNull;
+
+use crate::{GlobalCtx, Provenance};
+
+struct LocalCtxWrapper(UnsafeCell<MaybeUninit<LocalCtx>>);
+
+unsafe impl Send for LocalCtxWrapper {}
+unsafe impl Sync for LocalCtxWrapper {}
+
+#[thread_local]
+pub static LOCAL_CTX: LocalCtxWrapper = LocalCtxWrapper(UnsafeCell::new(MaybeUninit::uninit()));
+
+/// The LocalCtx should contain a pointer to the shadow stack,
+/// the length of the shadow stack allocation,
+/// and a pointer to where the thread's __BSAN_PROV_STACK is stored.
+#[derive(Debug)]
+pub struct LocalCtx {
+    stack_top: NonNull<Provenance>,
+    stack_ptr: *mut NonNull<Provenance>,
+}
+
+impl LocalCtx {
+    pub unsafe fn new(stack_ptr: *mut NonNull<Provenance>) -> Self {
+        unsafe { LocalCtx { stack_top: stack_ptr.read(), stack_ptr } }
+    }
+}
+
+/// Initializes the local context object.
+///
+/// # Safety
+/// This function should only be called once, when a thread is initialized.
+#[inline]
+pub unsafe fn init_local_ctx(global_ctx: &GlobalCtx, stack_ptr: *mut NonNull<Provenance>) {
+    unsafe {
+        let local_ctx_ptr = LOCAL_CTX.0.get().cast::<LocalCtx>();
+        local_ctx_ptr.write(LocalCtx::new(stack_ptr));
+        global_ctx.register_thread(NonNull::new_unchecked(local_ctx_ptr));
+    }
+}
+
+/// Deinitializes the local context object.
+///
+/// # Safety
+///
+/// This function must only be called once: when a thread is terminating.
+/// It is marked as `unsafe`, since multiple other API functions rely
+/// on the assumption that the current thread remains initialized.
+#[inline]
+pub unsafe fn deinit_local_ctx() {
+    unsafe { drop(ptr::replace(LOCAL_CTX.0.get(), MaybeUninit::uninit()).assume_init()) };
+}
+
+// /// # Safety
+// /// The user needs to ensure that the context is initialized.
+// #[inline]
+// pub unsafe fn local_ctx<'a>() -> &'a LocalCtx {
+//     unsafe { &*local_ctx_mut() }
+// }
+
+// /// # Safety
+// /// The user needs to ensure that the context is initialized.
+// #[inline]
+// pub unsafe fn local_ctx_mut<'a>() -> &'a mut LocalCtx {
+//     let ctx = LOCAL_CTX.0.get();
+//     unsafe { &mut *ctx.cast::<LocalCtx>() }
+// }

--- a/bsan-rt/src/local.rs
+++ b/bsan-rt/src/local.rs
@@ -1,32 +1,36 @@
 use core::cell::UnsafeCell;
 use core::mem::MaybeUninit;
-use core::num::NonZero;
-use core::ops::Deref;
 use core::ptr;
 use core::ptr::NonNull;
 
-use crate::{GlobalCtx, Provenance};
+use crate::{GlobalCtx, Provenance, ThreadId};
 
-struct LocalCtxWrapper(UnsafeCell<MaybeUninit<LocalCtx>>);
+pub(crate) struct LocalCtxWrapper(UnsafeCell<MaybeUninit<LocalCtx>>);
 
 unsafe impl Send for LocalCtxWrapper {}
 unsafe impl Sync for LocalCtxWrapper {}
 
 #[thread_local]
-pub static LOCAL_CTX: LocalCtxWrapper = LocalCtxWrapper(UnsafeCell::new(MaybeUninit::uninit()));
+pub(crate) static LOCAL_CTX: LocalCtxWrapper =
+    LocalCtxWrapper(UnsafeCell::new(MaybeUninit::uninit()));
 
 /// The LocalCtx should contain a pointer to the shadow stack,
 /// the length of the shadow stack allocation,
 /// and a pointer to where the thread's __BSAN_PROV_STACK is stored.
 #[derive(Debug)]
 pub struct LocalCtx {
+    thread_id: ThreadId,
     stack_top: NonNull<Provenance>,
     stack_ptr: *mut NonNull<Provenance>,
 }
 
 impl LocalCtx {
-    pub unsafe fn new(stack_ptr: *mut NonNull<Provenance>) -> Self {
-        unsafe { LocalCtx { stack_top: stack_ptr.read(), stack_ptr } }
+    pub unsafe fn new(thread_id: ThreadId, stack_ptr: *mut NonNull<Provenance>) -> Self {
+        unsafe { LocalCtx { thread_id, stack_top: stack_ptr.read(), stack_ptr } }
+    }
+
+    pub fn thread_id(&self) -> ThreadId {
+        self.thread_id
     }
 }
 
@@ -36,10 +40,12 @@ impl LocalCtx {
 /// This function should only be called once, when a thread is initialized.
 #[inline]
 pub unsafe fn init_local_ctx(global_ctx: &GlobalCtx, stack_ptr: *mut NonNull<Provenance>) {
+    let local_ctx_ptr = LOCAL_CTX.0.get().cast::<LocalCtx>();
+    let thread_id = ThreadId::default();
     unsafe {
-        let local_ctx_ptr = LOCAL_CTX.0.get().cast::<LocalCtx>();
-        local_ctx_ptr.write(LocalCtx::new(stack_ptr));
-        global_ctx.register_thread(NonNull::new_unchecked(local_ctx_ptr));
+        let local_ctx = LocalCtx::new(thread_id, stack_ptr);
+        local_ctx_ptr.write(local_ctx);
+        global_ctx.register_thread(thread_id, NonNull::new_unchecked(local_ctx_ptr));
     }
 }
 
@@ -51,8 +57,10 @@ pub unsafe fn init_local_ctx(global_ctx: &GlobalCtx, stack_ptr: *mut NonNull<Pro
 /// It is marked as `unsafe`, since multiple other API functions rely
 /// on the assumption that the current thread remains initialized.
 #[inline]
-pub unsafe fn deinit_local_ctx() {
-    unsafe { drop(ptr::replace(LOCAL_CTX.0.get(), MaybeUninit::uninit()).assume_init()) };
+pub unsafe fn deinit_local_ctx(global_ctx: &GlobalCtx) {
+    let thread_id = unsafe { (*LOCAL_CTX.0.get()).assume_init_ref().thread_id() };
+    unsafe { ptr::replace(LOCAL_CTX.0.get(), MaybeUninit::uninit()).assume_init() };
+    global_ctx.deregister_thread(thread_id);
 }
 
 // /// # Safety


### PR DESCRIPTION
This PR adds back in a modified `local.rs` to the runtime to initialize and deinitialize local contexts, from `BsanThread::Init` in the runtime which calls `lib::__bsan_local_init` which calls `local::init_local_ctx` and finally `global::register_thread`. We deinit by following the same path through modules starting with `BsanThread::Destroy`.

We also add a new `ThreadId` type to distinguish `LocalCtx`s in the `GlobalCtx`, which is initialized with a global counter similar to `AllocId` and `BorTag`.

So far, `stack_top` and `stack_ptr` are unused:
```rust
pub struct LocalCtx {
    thread_id: ThreadId,
    stack_top: NonNull<Provenance>,
    stack_ptr: *mut NonNull<Provenance>,
}
```

Closes #165 