### PR TITLE
Remove unused/unneeded `Provenance` helpers.

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -91,94 +91,6 @@ bool BorrowSanitizer::shouldInstrumentAlloca(const DataLayout &DL,
           !AllocSize.value().isZero());
 }
 
-// Recursively populates a given vector with the list of descriptions of where
-// provenance values live within a type.
-static std::tuple<Value *, Value *>
-getProvenanceDesc(IRBuilder<> &IRB, const DataLayout *DL,
-                  SmallVector<ProvenanceDesc> &ProvDesc, Type *ParentTy,
-                  Type *CurrentTy, Value *ByteOffset, Value *ProvOffset) {
-  Value *TypeSize =
-      IRB.CreateTypeSize(IRB.getIntPtrTy(*DL), DL->getTypeAllocSize(CurrentTy));
-  Value *NextProvOffset = ProvOffset;
-  switch (CurrentTy->getTypeID()) {
-  case Type::PointerTyID: {
-    ProvenanceDesc Desc(ByteOffset, TypeSize, ElementCount::get(1, false));
-    ProvDesc.push_back(Desc);
-    Value *Elems = IRB.CreateElementCount(IRB.getIntPtrTy(*DL), Desc.Elems);
-    NextProvOffset = IRB.CreateAdd(ProvOffset, Elems);
-  } break;
-  case Type::StructTyID: {
-    StructType *ST = cast<StructType>(CurrentTy);
-    Value *CurrByteOffset = ByteOffset;
-    for (Type *ElemType : ST->elements()) {
-      auto [BOffset, POffset] =
-          getProvenanceDesc(IRB, DL, ProvDesc, ParentTy, ElemType,
-                            CurrByteOffset, NextProvOffset);
-      CurrByteOffset = BOffset;
-      NextProvOffset = POffset;
-    }
-  } break;
-  case Type::ArrayTyID: {
-    ArrayType *AT = cast<ArrayType>(CurrentTy);
-    Value *CurrByteOffset = ByteOffset;
-    for (unsigned Idx = 0; Idx < AT->getNumElements(); ++Idx) {
-      auto [BOffset, POffset] =
-          getProvenanceDesc(IRB, DL, ProvDesc, ParentTy, AT->getElementType(),
-                            CurrByteOffset, NextProvOffset);
-      CurrByteOffset = BOffset;
-      NextProvOffset = POffset;
-    }
-  } break;
-  default:
-    break;
-  }
-  Value *NextByteOffset = IRB.CreateAdd(ByteOffset, TypeSize);
-  return std::make_tuple(NextByteOffset, NextProvOffset);
-}
-
-// Returns the descriptions for where provenance values are stored for a type.
-static SmallVector<ProvenanceDesc>
-getProvenanceDesc(IRBuilder<> &IRB, const DataLayout *DL, Type *Ty) {
-  SmallVector<ProvenanceDesc> Desc;
-  ConstantInt *Zero = ConstantInt::get(IRB.getIntPtrTy(*DL), 0);
-  getProvenanceDesc(IRB, DL, Desc, Ty, Ty, Zero, Zero);
-  return Desc;
-}
-
-// Computes the offset in terms of provenance components for an index into an
-// aggregate or array value. Used for implementing `extractvalue` and
-// `insertvalue`.
-static std::tuple<Type *, uint64_t>
-offsetIntoProvenanceIndex(IRBuilder<> &IRB, const DataLayout *DL,
-                          Type *CurrentTy, uint64_t Idx,
-                          uint64_t PrevOffset = 0) {
-  switch (CurrentTy->getTypeID()) {
-  case Type::StructTyID: {
-    StructType *ST = cast<StructType>(CurrentTy);
-    assert(Idx < ST->getNumElements() &&
-           "Index out of bounds for struct type.");
-    uint64_t Offset = PrevOffset;
-    for (unsigned CurrIdx = 0; CurrIdx < Idx; ++CurrIdx) {
-      Type *ElemType = ST->getElementType(CurrIdx);
-      SmallVector<ProvenanceDesc> ProvDesc =
-          getProvenanceDesc(IRB, DL, ElemType);
-      Offset += ProvDesc.size();
-    }
-    return std::make_tuple(ST->getElementType(Idx), Offset);
-  } break;
-  case Type::ArrayTyID: {
-    ArrayType *AT = cast<ArrayType>(CurrentTy);
-    assert(Idx < AT->getNumElements() && "Index out of bounds for array type.");
-    SmallVector<ProvenanceDesc> ProvDesc =
-        getProvenanceDesc(IRB, DL, AT->getElementType());
-    return std::make_tuple(AT->getElementType(), PrevOffset + ProvDesc.size());
-  } break;
-  default: {
-    report_fatal_error("Cannot index into a non-struct or non-array type.");
-  }
-  }
-}
-
 static bool inSCC(DominatorTree &DT, LoopInfo &LI, BasicBlock *BB) {
   if (LI.getLoopFor(BB))
     return true;
@@ -417,7 +329,8 @@ class BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
   // provenance for an argument, we take its pointer from this array and then
   // insert the necessary instructions to load it from thread-local storage
   // within the prologue of the function.
-  SmallDenseMap<Argument *, SmallVector<ProvenancePtr>> ArgumentProvenance;
+  SmallDenseMap<Argument *, SmallVector<std::pair<Value *, ElementCount>>>
+      ArgumentProvenance;
 
   // With the exception of allocas, each value is associated with a unique
   // provenance value.
@@ -526,19 +439,17 @@ private:
   // Will fail with an error if anything other than a scalar provenance value is
   // present. If no provenance has been assigned yet, then return a wildcard
   // provenance value.
-  ProvenanceScalar assertProvenanceScalar(BasicBlock *BB, ProvenanceKey Key) {
+  Provenance assertProvenanceScalar(BasicBlock *BB, ProvenanceKey Key) {
     std::optional<Provenance> OptProv = getProvenance(BB, Key);
     if (OptProv.has_value()) {
       Provenance Prov = OptProv.value();
       if (Prov.Elems.isVector()) {
         report_fatal_error(
             "Expected scalar provenance, but found vector provenance!");
-      } else {
-        ProvenanceScalar Scalar = Prov.assertScalar();
-        return Scalar;
       }
+      return Prov;
     }
-    return BS.WildcardProvenance;
+    return Provenance::wildcard(BS.PL, ElementCount::getFixed(1));
   }
 
   Provenance assertProvenance(IRBuilder<> &IRB, ElementCount Elems,
@@ -562,7 +473,7 @@ private:
       }
       return Prov;
     }
-    return Provenance::wildcard(IRB, BS.PL, Elems);
+    return Provenance::wildcard(BS.PL, Elems);
   }
 
   // Asserts that there is either a provenance value at the given index, or that
@@ -586,9 +497,10 @@ private:
         if (Key.Offset >= ArgumentProvenance[Arg].size()) {
           report_fatal_error("Invalid argument provenance!");
         }
-        ProvenancePtr ArgProvenancePtr = ProvVec[Key.Offset];
+        Value *ArgProvenancePtr = ProvVec[Key.Offset].first;
+        ElementCount Elems = ProvVec[Key.Offset].second;
         Provenance ArgProvenance =
-            Provenance::load(EntryIRB, BS.PL, ArgProvenancePtr);
+            Provenance::load(EntryIRB, BS.PL, ArgProvenancePtr, Elems);
         setProvenance(Key, ArgProvenance);
         return ArgProvenance;
       }
@@ -605,13 +517,11 @@ private:
   // address.
   void storeProvenanceToShadow(IRBuilder<> &IRB, Value *ObjAddr,
                                Provenance Prov, AtomicOrdering Ordering) {
-    ProvenancePtr ProvPtr;
     if (Prov.Elems.isVector()) {
       report_fatal_error("Vectors are not supported.");
     } else {
-      ProvenanceScalar Scalar = Prov.assertScalar();
       Value *ShadowPointer = IRB.CreateCall(BS.BsanFuncShadowStore,
-                                            {Scalar.Tag, Scalar.Info, ObjAddr});
+                                            {Prov.Tag, Prov.Info, ObjAddr});
     }
   }
 
@@ -625,8 +535,7 @@ private:
     } else {
       Value *Slot = allocStackSlot(IRB, false);
       IRB.CreateCall(BS.BsanFuncShadowLoad, {ObjAddr, Slot});
-      ProvenancePtrScalar ProvPtr(IRB, BS.PL, Slot);
-      return Provenance::load(IRB, BS.PL, ProvPtr);
+      return Provenance::load(IRB, BS.PL, Slot);
     }
   }
 
@@ -644,12 +553,12 @@ private:
         Value *Tag = newBorrowTag(EntryIRB);
         Value *Info = EntryIRB.CreateCall(BS.BsanFuncReserveStackSlot, {});
         EntryIRB.CreateCall(BS.BsanFuncAllocStack, {&Arg, Size, Tag, Info});
-        setProvenance(&Arg, ProvenanceScalar(Tag, Info));
+        setProvenance(&Arg, Provenance(Tag, Info));
         ByValArgs.push_back(&Arg);
         NumParamProv = EntryIRB.CreateAdd(NumParamProv, BS.One);
       } else {
         SmallVector<ProvenanceDesc> ProvDesc =
-            getProvenanceDesc(EntryIRB, BS.DL, Arg.getType());
+            BS.PL.getProvenanceDesc(EntryIRB, Arg.getType());
         for (auto &Desc : ProvDesc) {
           Value *NumProv = EntryIRB.CreateElementCount(BS.IntptrTy, Desc.Elems);
           NumParamProv = EntryIRB.CreateAdd(NumParamProv, NumProv);
@@ -657,9 +566,8 @@ private:
               EntryIRB.CreateMul(NumParamProv, BS.PL.ProvenanceSize);
           Value *CurrentArraySlot =
               ptradd(EntryIRB, FrameTop, EntryIRB.CreateNeg(ByteOffset));
-          ProvenancePtr Ptr =
-              ProvenancePtr(EntryIRB, BS.PL, CurrentArraySlot, Desc.Elems);
-          ArgumentProvenance[&Arg].push_back(Ptr);
+          ArgumentProvenance[&Arg].push_back(
+              std::make_pair(CurrentArraySlot, Desc.Elems));
         }
       }
     }
@@ -678,7 +586,7 @@ private:
     if (StaticAllocaVec.size() > 0 || ByValArgs.size() > 0) {
       for (auto &Arg : ByValArgs) {
         BasicBlock *BB = EntryIRB.GetInsertBlock();
-        ProvenanceScalar Prov = assertProvenanceScalar(BB, Arg);
+        Provenance Prov = assertProvenanceScalar(BB, Arg);
         Value *SlotOffset = EntryIRB.CreateMul(ConstantInt::get(BS.IntptrTy, 1),
                                                BS.PL.ProvenanceSize);
         FrameHeaderBottom =
@@ -686,7 +594,7 @@ private:
         Prov.store(EntryIRB, BS.PL, FrameHeaderBottom);
       }
       for (auto [Idx, AI] : llvm::enumerate(StaticAllocaVec)) {
-        ProvenanceScalar Prov = createAllocaMetadata(EntryIRB, AI);
+        Provenance Prov = createAllocaMetadata(EntryIRB, AI);
         if (!HasLifetimeStart.contains(AI)) {
           NextNodeIRBuilder IRB(AI);
           initAllocaMetadata(IRB, AI, Prov);
@@ -739,26 +647,22 @@ private:
 
     Value *Slot = allocStackSlot(IRB, false);
     IRB.CreateCall(BS.BsanFuncShadowLoad, {Operand, Slot});
-    ProvenancePtrScalar SrcProvPtr(IRB, BS.PL, Slot);
-
-    ProvenanceScalar SrcProv = ProvenanceScalar::load(IRB, BS.PL, SrcProvPtr);
-    ProvenanceScalar RetaggedProv = instrumentRetag(IRB, CB, SrcAddr, SrcProv);
+    Provenance SrcProv = Provenance::load(IRB, BS.PL, Slot);
+    Provenance RetaggedProv = instrumentRetag(IRB, CB, SrcAddr, SrcProv);
     IRB.CreateCall(BS.BsanFuncShadowStore,
                    {RetaggedProv.Tag, RetaggedProv.Info, Operand});
   }
 
   void instrumentRetagReg(CallBase &CB) {
     IRBuilder<> IRB(&CB);
-    ProvenanceScalar Prov =
-        assertProvenanceScalar(CB.getParent(), CB.getOperand(0));
-    ProvenanceScalar Retagged =
-        instrumentRetag(IRB, CB, CB.getOperand(0), Prov);
+    Provenance Prov = assertProvenanceScalar(CB.getParent(), CB.getOperand(0));
+    Provenance Retagged = instrumentRetag(IRB, CB, CB.getOperand(0), Prov);
     setProvenance(&CB, Retagged);
   }
 
-  ProvenanceScalar instrumentRetag(IRBuilder<> &IRB, CallBase &CB,
-                                   Value *Target, ProvenanceScalar TargetProv) {
-    if (TargetProv != BS.WildcardProvenance) {
+  Provenance instrumentRetag(IRBuilder<> &IRB, CallBase &CB, Value *Target,
+                             Provenance TargetProv) {
+    if (!TargetProv.isWildcard()) {
       RetagInfo RI(&CB);
 
       Value *ImArrayLen = getLayoutArrayLength(RI.ImArray);
@@ -842,7 +746,7 @@ private:
     Value *NumParamProv = BS.Zero;
     for (const auto &[i, Arg] : llvm::enumerate(CB.args())) {
       SmallVector<ProvenanceDesc> ProvDesc =
-          getProvenanceDesc(Before, BS.DL, Arg->getType());
+          BS.PL.getProvenanceDesc(Before, Arg->getType());
       for (const auto &[Idx, Desc] : llvm::enumerate(ProvDesc)) {
         Value *NumProv = Before.CreateElementCount(BS.IntptrTy, Desc.Elems);
         NumParamProv = Before.CreateAdd(NumParamProv, NumProv);
@@ -852,8 +756,7 @@ private:
         Value *Slot = ptradd(Before, StackOffset, Before.CreateNeg(ByteOffset));
 
         Provenance ProvSrc = assertProvenance(Before, Desc.Elems, {Arg, Idx});
-        ProvenancePtr Dest = ProvenancePtr(Before, BS.PL, Slot, Desc.Elems);
-        ProvSrc.store(Before, BS.PL, Dest);
+        ProvSrc.store(Before, BS.PL, Slot);
       }
     }
 
@@ -879,12 +782,14 @@ private:
     After.SetCurrentDebugLocation(CB.getDebugLoc());
 
     Value *NumReturnProv = BS.Zero;
-    SmallVector<std::pair<unsigned, ProvenancePtr>> ProvenancePointers;
+    SmallVector<Value *> ProvenancePointers;
+
+    SmallVector<ProvenanceDesc> ReturnDesc =
+        BS.PL.getProvenanceDesc(Before, CB.getType());
+
     if (CB.getType()->isSized()) {
       // Unsized return types do not have provenance, so we can skip handling
       // the return array.
-      SmallVector<ProvenanceDesc> ReturnDesc =
-          getProvenanceDesc(Before, BS.DL, CB.getType());
 
       // Load each provenance component for the return type from the
       // thread-local return value array. Also, compute the byte-width of the
@@ -893,8 +798,7 @@ private:
       // array is populated with default values.
       for (const auto &[Idx, Desc] : llvm::enumerate(ReturnDesc)) {
         Value *Slot = allocStackSlot(Before, false, Desc.Elems);
-        ProvenancePtr Ptr = ProvenancePtr(Before, BS.PL, Slot, Desc.Elems);
-        ProvenancePointers.push_back({Idx, Ptr});
+        ProvenancePointers.push_back(Slot);
         Value *NumProv = Before.CreateElementCount(BS.IntptrTy, Desc.Elems);
         NumReturnProv = Before.CreateAdd(NumReturnProv, NumProv);
       }
@@ -930,8 +834,10 @@ private:
         UnwindIRB.CreateStore(ToRestore, BS.Marker);
       }
     }
-    for (auto &[Idx, Ptr] : ProvenancePointers) {
-      setProvenance({&CB, Idx}, Provenance::load(After, BS.PL, Ptr));
+    for (const auto &[Idx, Ptr] : llvm::enumerate(ProvenancePointers)) {
+      ElementCount Elems = ReturnDesc[Idx].Elems;
+      Provenance Prov = Provenance::load(After, BS.PL, Ptr, Elems);
+      setProvenance({&CB, Idx}, Prov);
     }
   }
 
@@ -959,27 +865,27 @@ private:
     for (int Idx = 0; Idx < NumOutputs; Idx++) {
       Value *Operand = CB.getOperand(Idx);
       SmallVector<ProvenanceDesc> Components =
-          getProvenanceDesc(IRB, BS.DL, Operand->getType());
+          BS.PL.getProvenanceDesc(IRB, Operand->getType());
       for (const auto &[Idx, Comp] : llvm::enumerate(Components)) {
-        setProvenance({Operand, Idx}, BS.WildcardProvenance);
+        setProvenance({Operand, Idx}, Provenance::wildcard(BS.PL));
       }
     }
   }
 
-  ProvenanceScalar
-  createScalarProvenancePHI(IRBuilder<> &IRB,
-                            iterator_range<pred_iterator> Blocks) {
+  Provenance createScalarProvenancePHI(IRBuilder<> &IRB,
+                                       iterator_range<pred_iterator> Blocks) {
     unsigned NumIncoming = std::distance(Blocks.begin(), Blocks.end());
     PHINode *TagNode = IRB.CreatePHI(BS.IntptrTy, NumIncoming, "_bsphi_tag");
     TagNode->dropDbgRecords();
     PHINode *InfoNode = IRB.CreatePHI(BS.PtrTy, NumIncoming, "_bsphi_info");
     InfoNode->dropDbgRecords();
 
+    Provenance Wildcard = Provenance::wildcard(BS.PL);
     for (BasicBlock *BB : Blocks) {
-      TagNode->addIncoming(BS.WildcardProvenance.Tag, BB);
-      InfoNode->addIncoming(BS.WildcardProvenance.Info, BB);
+      TagNode->addIncoming(Wildcard.Tag, BB);
+      InfoNode->addIncoming(Wildcard.Info, BB);
     }
-    return ProvenanceScalar(TagNode, InfoNode);
+    return Provenance(TagNode, InfoNode);
   }
 
   Provenance createProvenancePHI(IRBuilder<> &IRB, ProvenanceDesc Comp,
@@ -994,7 +900,7 @@ private:
     IRBuilder<> IRB(&PN);
     unsigned NumIncoming = PN.getNumIncomingValues();
     SmallVector<ProvenanceDesc> Components =
-        getProvenanceDesc(IRB, BS.DL, PN.getType());
+        BS.PL.getProvenanceDesc(IRB, PN.getType());
     for (auto [Idx, Comp] : llvm::enumerate(Components)) {
       Provenance Prov =
           createProvenancePHI(IRB, Comp, predecessors(PN.getParent()));
@@ -1017,24 +923,22 @@ private:
     }
   }
 
-  ProvenanceScalar createAllocaMetadata(IRBuilder<> &IRB, AllocaInst *AI) {
+  Provenance createAllocaMetadata(IRBuilder<> &IRB, AllocaInst *AI) {
     TypeSize TS = AI->getAllocationSize(*BS.DL).value();
     Value *Size = IRB.CreateTypeSize(BS.IntptrTy, TS);
     Value *Tag = newBorrowTag(IRB);
     Value *Info = IRB.CreateCall(BS.BsanFuncReserveStackSlot, {});
-    return ProvenanceScalar(Tag, Info);
+    return Provenance(Tag, Info);
   }
 
-  void initAllocaMetadata(IRBuilder<> &IRB, AllocaInst *AI,
-                          ProvenanceScalar Prov) {
+  void initAllocaMetadata(IRBuilder<> &IRB, AllocaInst *AI, Provenance Prov) {
     TypeSize TS = AI->getAllocationSize(*BS.DL).value();
     Value *Size = IRB.CreateTypeSize(BS.IntptrTy, TS);
     IRB.CreateCall(BS.BsanFuncAllocStack, {AI, Size, Prov.Tag, Prov.Info});
   }
 
-  ProvenanceScalar createAndInitAllocaMetadata(IRBuilder<> &IRB,
-                                               AllocaInst *AI) {
-    ProvenanceScalar Prov = createAllocaMetadata(IRB, AI);
+  Provenance createAndInitAllocaMetadata(IRBuilder<> &IRB, AllocaInst *AI) {
+    Provenance Prov = createAllocaMetadata(IRB, AI);
     initAllocaMetadata(IRB, AI, Prov);
     return Prov;
   }
@@ -1042,8 +946,8 @@ private:
   void instrumentLifetimeStart(IntrinsicInst &II) {
     AllocaInst *AI = findAllocaForValue(II.getArgOperand(0), true);
     IRBuilder<> IRB(&II);
-    ProvenanceScalar CurrentProv = assertProvenanceScalar(II.getParent(), AI);
-    if (CurrentProv != BS.WildcardProvenance) {
+    Provenance CurrentProv = assertProvenanceScalar(II.getParent(), AI);
+    if (!CurrentProv.isWildcard()) {
       IRB.CreateCall(BS.BsanFuncDeallocStack,
                      {AI, CurrentProv.Tag, CurrentProv.Info});
     }
@@ -1053,8 +957,8 @@ private:
   void instrumentLifetimeEnd(IntrinsicInst &II) {
     AllocaInst *AI = findAllocaForValue(II.getArgOperand(0), true);
     IRBuilder<> IRB(&II);
-    ProvenanceScalar Root = assertProvenanceScalar(II.getParent(), AI);
-    if (Root != BS.WildcardProvenance) {
+    Provenance Root = assertProvenanceScalar(II.getParent(), AI);
+    if (!Root.isWildcard()) {
       IRB.CreateCall(BS.BsanFuncDeallocStack, {AI, Root.Tag, Root.Info});
     }
   }
@@ -1087,15 +991,15 @@ private:
   }
 
   void insertReadCheck(IRBuilder<> &IRB, Value *Ptr, Value *Size) {
-    ProvenanceScalar Prov = assertProvenanceScalar(IRB.GetInsertBlock(), Ptr);
-    if (Prov != BS.WildcardProvenance) {
+    Provenance Prov = assertProvenanceScalar(IRB.GetInsertBlock(), Ptr);
+    if (!Prov.isWildcard()) {
       IRB.CreateCall(BS.BsanFuncRead, {Ptr, Size, Prov.Tag, Prov.Info});
     }
   }
 
   void insertWriteCheck(IRBuilder<> &IRB, Value *Ptr, Value *Size) {
-    ProvenanceScalar Prov = assertProvenanceScalar(IRB.GetInsertBlock(), Ptr);
-    if (Prov != BS.WildcardProvenance) {
+    Provenance Prov = assertProvenanceScalar(IRB.GetInsertBlock(), Ptr);
+    if (!Prov.isWildcard()) {
       IRB.CreateCall(BS.BsanFuncWrite, {Ptr, Size, Prov.Tag, Prov.Info});
     }
   }
@@ -1111,11 +1015,11 @@ private:
         IRB.CreateTypeSize(BS.IntptrTy, BS.DL->getTypeStoreSize(LI.getType()));
 
     SmallVector<ProvenanceDesc> Components =
-        getProvenanceDesc(IRB, BS.DL, LI.getType());
+        BS.PL.getProvenanceDesc(IRB, LI.getType());
 
     Value *Base = LI.getPointerOperand();
     for (const auto &[Idx, Comp] : llvm::enumerate(Components)) {
-      Value *ByteOffset = Comp.ByteOffset.getValue(IRB, BS.IntptrTy);
+      Value *ByteOffset = Comp.ByteOffset;
       Value *ObjAddr = ptradd(IRB, Base, ByteOffset);
       Provenance Prov =
           loadProvenanceFromShadow(IRB, Comp, ObjAddr, LI.getOrdering());
@@ -1145,20 +1049,20 @@ private:
 
     Value *Base = SI.getPointerOperand();
     SmallVector<ProvenanceDesc> ProvDesc =
-        getProvenanceDesc(IRB, BS.DL, Val->getType());
+        BS.PL.getProvenanceDesc(IRB, Val->getType());
 
-    DynSize Offset = DynSize(BS.Zero);
+    Value *Offset = BS.Zero;
 
     for (const auto &[Idx, Desc] : llvm::enumerate(ProvDesc)) {
-      Value *ByteOffset = Desc.ByteOffset.getValue(IRB, BS.IntptrTy);
+      Value *ByteOffset = Desc.ByteOffset;
       if (Clear) {
         if (Offset != Desc.ByteOffset) {
-          Value *CurrOffset = Offset.getValue(IRB, BS.IntptrTy);
+          Value *CurrOffset = Offset;
           Value *GapSize = IRB.CreateSub(ByteOffset, CurrOffset);
           Value *BaseAddr = ptradd(IRB, Base, CurrOffset);
           clearProvenance(IRB, BaseAddr, GapSize, SI.getOrdering());
         }
-        Offset = Desc.ByteOffset.add(Desc.ByteWidth);
+        Offset = IRB.CreateAdd(Desc.ByteOffset, Desc.ByteWidth);
       }
       Value *ObjAddr = ptradd(IRB, Base, ByteOffset);
       Provenance Prov =
@@ -1167,7 +1071,7 @@ private:
     }
 
     if (Clear) {
-      Value *OffsetVal = Offset.getValue(IRB, BS.IntptrTy);
+      Value *OffsetVal = Offset;
       Value *Remaining = IRB.CreateSub(EntireSize, OffsetVal);
       Value *RemainingAddr = ptradd(IRB, Base, OffsetVal);
       clearProvenance(IRB, RemainingAddr, Remaining, SI.getOrdering());
@@ -1189,19 +1093,45 @@ private:
   void visitGetElementPtrInst(GetElementPtrInst &I) {
     // Pointer arithmetic does not affect provenance, so we can propagage the
     // provenance of the input to the output value.
-    ProvenanceScalar Prov =
+    Provenance Prov =
         assertProvenanceScalar(I.getParent(), I.getPointerOperand());
     setProvenance(&I, Prov);
   }
 
-  void visitIntToPtrInst(IntToPtrInst &I) {
-    // Pointers converted from integers receive a wildcard provenance value.
-    // This is overly permissive, but certain certain Rust programs that do
-    // *not* use integer to pointer casts are still compiled to use `inttoptr`.
-    // Since these conversions are not present in MIR, Miri will not report an
-    // error in strict provenance mode, but we will have false positives unless
-    // we allow all accesses through these pointers.
-    setProvenance(&I, BS.WildcardProvenance);
+  // Computes the offset in terms of provenance components for an index into an
+  // aggregate or array value. Used for implementing `extractvalue` and
+  // `insertvalue`.
+  std::tuple<Type *, unsigned> offsetIntoProvenanceIndex(IRBuilder<> &IRB,
+                                                         Type *CurrentTy,
+                                                         unsigned Idx,
+                                                         unsigned PrevOffset) {
+    switch (CurrentTy->getTypeID()) {
+    case Type::StructTyID: {
+      StructType *ST = cast<StructType>(CurrentTy);
+      assert(Idx < ST->getNumElements() &&
+             "Index out of bounds for struct type.");
+      uint64_t Offset = PrevOffset;
+      for (unsigned CurrIdx = 0; CurrIdx < Idx; ++CurrIdx) {
+        Type *ElemType = ST->getElementType(CurrIdx);
+        SmallVector<ProvenanceDesc> ProvDesc =
+            BS.PL.getProvenanceDesc(IRB, ElemType);
+        Offset += ProvDesc.size();
+      }
+      return std::make_tuple(ST->getElementType(Idx), Offset);
+    } break;
+    case Type::ArrayTyID: {
+      ArrayType *AT = cast<ArrayType>(CurrentTy);
+      assert(Idx < AT->getNumElements() &&
+             "Index out of bounds for array type.");
+      SmallVector<ProvenanceDesc> ProvDesc =
+          BS.PL.getProvenanceDesc(IRB, AT->getElementType());
+      return std::make_tuple(AT->getElementType(),
+                             PrevOffset + ProvDesc.size());
+    } break;
+    default: {
+      report_fatal_error("Cannot index into a non-struct or non-array type.");
+    }
+    }
   }
 
   void visitExtractValueInst(ExtractValueInst &EI) {
@@ -1209,13 +1139,13 @@ private:
     Value *AggregateSrc = EI.getAggregateOperand();
 
     SmallVector<ProvenanceDesc> DestProvDesc =
-        getProvenanceDesc(IRB, BS.DL, EI.getType());
+        BS.PL.getProvenanceDesc(IRB, EI.getType());
 
     Type *CurrType = AggregateSrc->getType();
     uint64_t StartingIdx = 0;
     for (auto &Idx : EI.indices()) {
       std::tie(CurrType, StartingIdx) =
-          offsetIntoProvenanceIndex(IRB, BS.DL, CurrType, Idx, StartingIdx);
+          offsetIntoProvenanceIndex(IRB, CurrType, Idx, StartingIdx);
     }
 
     for (auto [Offset, Desc] : llvm::enumerate(DestProvDesc)) {
@@ -1230,13 +1160,13 @@ private:
     BaseProvMap.transfer(II.getAggregateOperand(), &II);
     Value *ToInsert = II.getInsertedValueOperand();
     SmallVector<ProvenanceDesc> SrcProvDesc =
-        getProvenanceDesc(IRB, BS.DL, ToInsert->getType());
+        BS.PL.getProvenanceDesc(IRB, ToInsert->getType());
 
     Type *CurrType = II.getType();
     uint64_t StartingIdx = 0;
     for (auto &Idx : II.indices()) {
       std::tie(CurrType, StartingIdx) =
-          offsetIntoProvenanceIndex(IRB, BS.DL, CurrType, Idx, StartingIdx);
+          offsetIntoProvenanceIndex(IRB, CurrType, Idx, StartingIdx);
     }
 
     for (auto [Offset, Desc] : llvm::enumerate(SrcProvDesc)) {
@@ -1248,22 +1178,21 @@ private:
   void visitSelectInst(SelectInst &SI) {
     IRBuilder<> IRB(&SI);
     SmallVector<ProvenanceDesc> ProvDesc =
-        getProvenanceDesc(IRB, BS.DL, SI.getType());
+        BS.PL.getProvenanceDesc(IRB, SI.getType());
 
     for (auto [Idx, Desc] : llvm::enumerate(ProvDesc)) {
       if (Desc.Elems.isVector()) {
         report_fatal_error("Vectors are not supported.");
       } else {
         BasicBlock *BB = SI.getParent();
-        ProvenanceScalar ProvL =
-            assertProvenanceScalar(BB, {SI.getTrueValue(), Idx});
-        ProvenanceScalar ProvR =
+        Provenance ProvL = assertProvenanceScalar(BB, {SI.getTrueValue(), Idx});
+        Provenance ProvR =
             assertProvenanceScalar(BB, {SI.getFalseValue(), Idx});
 
         Value *Tag = IRB.CreateSelect(SI.getCondition(), ProvL.Tag, ProvR.Tag);
         Value *Info =
             IRB.CreateSelect(SI.getCondition(), ProvL.Info, ProvR.Info);
-        setProvenance({&SI, Idx}, ProvenanceScalar(Tag, Info));
+        setProvenance({&SI, Idx}, Provenance(Tag, Info));
       }
     }
   }
@@ -1288,7 +1217,7 @@ private:
 
     if (RetVal) {
       SmallVector<ProvenanceDesc> ProvDesc =
-          getProvenanceDesc(IRB, BS.DL, RetVal->getType());
+          BS.PL.getProvenanceDesc(IRB, RetVal->getType());
 
       Value *NumReturnProv = BS.Zero;
       for (const auto &[Idx, Desc] : llvm::enumerate(ProvDesc)) {
@@ -1299,8 +1228,7 @@ private:
         Value *Slot = ptradd(IRB, FrameTop, IRB.CreateNeg(ByteWidth));
 
         Provenance Prov = assertProvenance(IRB, Desc.Elems, {RetVal, Idx});
-        ProvenancePtr Dest = ProvenancePtr(IRB, BS.PL, Slot, Desc.Elems);
-        Prov.store(IRB, BS.PL, Dest);
+        Prov.store(IRB, BS.PL, Slot);
       }
     }
   }
@@ -1428,6 +1356,9 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   IRBuilder<> IRB(*C);
 
   AttributeList AL;
+
+  Type *Int32Ty = Type::getInt32Ty(*C);
+  Type *Int8Ty = Type::getInt8Ty(*C);
 
   AL = AL.addFnAttribute(*C, Attribute::NoUnwind);
 

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1101,37 +1101,26 @@ private:
   // Computes the offset in terms of provenance components for an index into an
   // aggregate or array value. Used for implementing `extractvalue` and
   // `insertvalue`.
-  std::tuple<Type *, unsigned> offsetIntoProvenanceIndex(IRBuilder<> &IRB,
-                                                         Type *CurrentTy,
-                                                         unsigned Idx,
-                                                         unsigned PrevOffset) {
-    switch (CurrentTy->getTypeID()) {
-    case Type::StructTyID: {
-      StructType *ST = cast<StructType>(CurrentTy);
-      assert(Idx < ST->getNumElements() &&
-             "Index out of bounds for struct type.");
-      uint64_t Offset = PrevOffset;
+  std::pair<Type *, unsigned> getProvenanceOffset(IRBuilder<> &IRB, Type *Ty,
+                                                  unsigned Idx) {
+    if (auto *ST = dyn_cast<StructType>(Ty)) {
+      unsigned Offset = 0;
       for (unsigned CurrIdx = 0; CurrIdx < Idx; ++CurrIdx) {
         Type *ElemType = ST->getElementType(CurrIdx);
         SmallVector<ProvenanceDesc> ProvDesc =
             BS.PL.getProvenanceDesc(IRB, ElemType);
         Offset += ProvDesc.size();
       }
-      return std::make_tuple(ST->getElementType(Idx), Offset);
-    } break;
-    case Type::ArrayTyID: {
-      ArrayType *AT = cast<ArrayType>(CurrentTy);
-      assert(Idx < AT->getNumElements() &&
-             "Index out of bounds for array type.");
+      return {ST->getElementType(Idx), Offset};
+    }
+
+    if (auto *AT = dyn_cast<ArrayType>(Ty)) {
       SmallVector<ProvenanceDesc> ProvDesc =
           BS.PL.getProvenanceDesc(IRB, AT->getElementType());
-      return std::make_tuple(AT->getElementType(),
-                             PrevOffset + ProvDesc.size());
-    } break;
-    default: {
-      report_fatal_error("Cannot index into a non-struct or non-array type.");
+      return {AT->getElementType(), ProvDesc.size() * Idx};
     }
-    }
+
+    report_fatal_error("Cannot index into a non-struct or non-array type.");
   }
 
   void visitExtractValueInst(ExtractValueInst &EI) {
@@ -1142,15 +1131,16 @@ private:
         BS.PL.getProvenanceDesc(IRB, EI.getType());
 
     Type *CurrType = AggregateSrc->getType();
-    uint64_t StartingIdx = 0;
+    uint64_t StartIdx = 0;
     for (auto &Idx : EI.indices()) {
-      std::tie(CurrType, StartingIdx) =
-          offsetIntoProvenanceIndex(IRB, CurrType, Idx, StartingIdx);
+      unsigned IdxOffset = 0;
+      std::tie(CurrType, IdxOffset) = getProvenanceOffset(IRB, CurrType, Idx);
+      StartIdx += IdxOffset;
     }
 
     for (auto [Offset, Desc] : llvm::enumerate(DestProvDesc)) {
-      Provenance Prov = assertProvenance(IRB, Desc.Elems,
-                                         {AggregateSrc, StartingIdx + Offset});
+      Provenance Prov =
+          assertProvenance(IRB, Desc.Elems, {AggregateSrc, StartIdx + Offset});
       setProvenance({&EI, Offset}, Prov);
     }
   }
@@ -1163,15 +1153,16 @@ private:
         BS.PL.getProvenanceDesc(IRB, ToInsert->getType());
 
     Type *CurrType = II.getType();
-    uint64_t StartingIdx = 0;
+    uint64_t StartIdx = 0;
     for (auto &Idx : II.indices()) {
-      std::tie(CurrType, StartingIdx) =
-          offsetIntoProvenanceIndex(IRB, CurrType, Idx, StartingIdx);
+      unsigned IdxOffset = 0;
+      std::tie(CurrType, IdxOffset) = getProvenanceOffset(IRB, CurrType, Idx);
+      StartIdx += IdxOffset;
     }
 
     for (auto [Offset, Desc] : llvm::enumerate(SrcProvDesc)) {
       Provenance Prov = assertProvenance(IRB, Desc.Elems, {ToInsert, Offset});
-      setProvenance({&II, StartingIdx + Offset}, Prov);
+      setProvenance({&II, StartIdx + Offset}, Prov);
     }
   }
 

--- a/bsan-pass/BorrowSanitizer.h
+++ b/bsan-pass/BorrowSanitizer.h
@@ -2,7 +2,6 @@
 #define LLVM_TRANSFORMS_INSTRUMENTATION_BORROWSANITIZER_H
 
 #include "Provenance.h"
-#include "llvm/Analysis/StackSafetyAnalysis.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 
 namespace llvm {
@@ -15,26 +14,11 @@ public:
     TargetTriple = Triple(M.getTargetTriple());
 
     PL = ProvenanceLayout(C, DL);
-    unsigned PtrSizeBits = M.getDataLayout().getPointerSizeInBits();
-    PtrSize = PtrSizeBits / 8;
-    BoolTy = Type::getInt1Ty(*C);
-    Int8Ty = Type::getInt8Ty(*C);
-    Int16Ty = Type::getInt16Ty(*C);
-    Int32Ty = Type::getInt32Ty(*C);
-    Int64Ty = Type::getInt64Ty(*C);
     PtrTy = PointerType::getUnqual(*C);
-    IntptrTy = Type::getIntNTy(*C, PtrSizeBits);
-
+    unsigned PtrSize = M.getDataLayout().getPointerSize();
+    IntptrTy = Type::getIntNTy(*C, PtrSize * 8);
     Zero = ConstantInt::get(IntptrTy, 0);
     One = ConstantInt::get(IntptrTy, 1);
-
-    True = ConstantInt::get(Int8Ty, 1);
-    False = ConstantInt::get(Int8Ty, 0);
-
-    Constant *InvalidPtr = ConstantPointerNull::get(PtrTy);
-
-    WildcardProvenance = ProvenanceScalar(Zero, InvalidPtr);
-    InvalidProvenance = ProvenanceScalar(One, InvalidPtr);
   }
 
   bool instrumentModule(Module &M);
@@ -58,17 +42,9 @@ public:
   LLVMContext *C;
   const DataLayout *DL;
   ProvenanceLayout PL;
-  const StackSafetyGlobalInfo *const SSGI = nullptr;
 
-  unsigned PtrSize;
   Triple TargetTriple;
-  Type *BoolTy;
-  Type *Int8Ty;
-  Type *Int16Ty;
-  Type *Int32Ty;
-  Type *Int64Ty;
   PointerType *PtrTy;
-
   Type *IntptrTy;
   Align IntptrAlign;
 
@@ -102,9 +78,6 @@ public:
 
   FunctionCallee DefaultPersonalityFn;
 
-  ProvenanceScalar WildcardProvenance;
-  ProvenanceScalar InvalidProvenance;
-
   // Thread-local storage for paramters
   // and return values.
   Value *ProvStack = nullptr;
@@ -113,11 +86,6 @@ public:
 
   Constant *Zero = nullptr;
   Constant *One = nullptr;
-
-  Constant *True = nullptr;
-  Constant *False = nullptr;
-
-  DenseSet<Function *> ExternCalledFns;
 
   bool shouldTrustFunction(const TargetLibraryInfo *TLI, const Value *V);
   bool shouldInstrumentAlloca(const DataLayout &DL, const AllocaInst &AI);

--- a/bsan-pass/Provenance.cpp
+++ b/bsan-pass/Provenance.cpp
@@ -15,7 +15,6 @@ ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB, Type *Ty) {
   return Desc;
 }
 
-
 // Populates a vector with the list of locations of provenance
 // values within a type.
 std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
@@ -58,7 +57,6 @@ std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
   Value *NextByteOffset = IRB.CreateAdd(ByteOffset, TypeSize);
   return std::make_tuple(NextByteOffset, NextProvOffset);
 }
-
 
 void Provenance::addIncoming(BasicBlock *IncomingBlock,
                              Provenance &IncomingProv) {

--- a/bsan-pass/Provenance.cpp
+++ b/bsan-pass/Provenance.cpp
@@ -4,8 +4,8 @@
 
 using namespace llvm;
 
-// Recursively populates a given vector with the list of descriptions of where
-// provenance values live within a type.
+// Populates a vector with the list of locations of provenance
+// values within a type.
 std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
     IRBuilder<> &IRB, SmallVector<ProvenanceDesc> &ProvDesc, Type *CurrentTy,
     Value *ByteOffset, Value *ProvOffset) {
@@ -47,7 +47,7 @@ std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
   return std::make_tuple(NextByteOffset, NextProvOffset);
 }
 
-// Returns the descriptions for where provenance values are stored for a type.
+// Provides a list of the locations of provenance values inside a type.
 SmallVector<ProvenanceDesc>
 ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB, Type *Ty) {
   SmallVector<ProvenanceDesc> Desc;
@@ -60,7 +60,10 @@ ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB, Type *Ty) {
 
 void Provenance::addIncoming(BasicBlock *IncomingBlock,
                              Provenance &IncomingProv) {
+  assert(isa<PHINode>(this->Tag));
   PHINode *TagNode = cast<PHINode>(this->Tag);
+
+  assert(isa<PHINode>(this->Info));
   PHINode *InfoNode = cast<PHINode>(this->Info);
 
   TagNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Tag);

--- a/bsan-pass/Provenance.cpp
+++ b/bsan-pass/Provenance.cpp
@@ -4,6 +4,18 @@
 
 using namespace llvm;
 
+// Provides a list of the locations of provenance values inside a type.
+SmallVector<ProvenanceDesc>
+ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB, Type *Ty) {
+  SmallVector<ProvenanceDesc> Desc;
+  if (Ty->isSized()) {
+    Value *Zero = ConstantInt::get(IRB.getIntPtrTy(*DL), 0);
+    getProvenanceDesc(IRB, Desc, Ty, Zero, Zero);
+  }
+  return Desc;
+}
+
+
 // Populates a vector with the list of locations of provenance
 // values within a type.
 std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
@@ -47,16 +59,6 @@ std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
   return std::make_tuple(NextByteOffset, NextProvOffset);
 }
 
-// Provides a list of the locations of provenance values inside a type.
-SmallVector<ProvenanceDesc>
-ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB, Type *Ty) {
-  SmallVector<ProvenanceDesc> Desc;
-  if (Ty->isSized()) {
-    Value *Zero = ConstantInt::get(IRB.getIntPtrTy(*DL), 0);
-    getProvenanceDesc(IRB, Desc, Ty, Zero, Zero);
-  }
-  return Desc;
-}
 
 void Provenance::addIncoming(BasicBlock *IncomingBlock,
                              Provenance &IncomingProv) {

--- a/bsan-pass/Provenance.cpp
+++ b/bsan-pass/Provenance.cpp
@@ -1,74 +1,61 @@
 #include "Provenance.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/PatternMatch.h"
 
 using namespace llvm;
 
-Type *ProvenanceLayout::getPtrTy(ElementCount Elems) const {
-  if (Elems.isScalar()) {
-    return this->PtrTy;
+// Recursively populates a given vector with the list of descriptions of where
+// provenance values live within a type.
+std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
+    IRBuilder<> &IRB, SmallVector<ProvenanceDesc> &ProvDesc, Type *CurrentTy,
+    Value *ByteOffset, Value *ProvOffset) {
+  assert(CurrentTy->isSized() && "expected a sized type");
+  TypeSize AllocSize = DL->getTypeAllocSize(CurrentTy);
+  Value *TypeSize = IRB.CreateTypeSize(IRB.getIntPtrTy(*DL), AllocSize);
+  Value *NextProvOffset = ProvOffset;
+  switch (CurrentTy->getTypeID()) {
+  case Type::PointerTyID: {
+    ProvenanceDesc Desc(ByteOffset, TypeSize, ElementCount::get(1, false));
+    ProvDesc.push_back(Desc);
+    Value *Elems = IRB.CreateElementCount(IRB.getIntPtrTy(*DL), Desc.Elems);
+    NextProvOffset = IRB.CreateAdd(ProvOffset, Elems);
+  } break;
+  case Type::StructTyID: {
+    StructType *ST = cast<StructType>(CurrentTy);
+    Value *CurrByteOffset = ByteOffset;
+    for (Type *ElemType : ST->elements()) {
+      auto [BOffset, POffset] = getProvenanceDesc(
+          IRB, ProvDesc, ElemType, CurrByteOffset, NextProvOffset);
+      CurrByteOffset = BOffset;
+      NextProvOffset = POffset;
+    }
+  } break;
+  case Type::ArrayTyID: {
+    ArrayType *AT = cast<ArrayType>(CurrentTy);
+    Value *CurrByteOffset = ByteOffset;
+    for (unsigned Idx = 0; Idx < AT->getNumElements(); ++Idx) {
+      auto [BOffset, POffset] = getProvenanceDesc(
+          IRB, ProvDesc, AT->getElementType(), CurrByteOffset, NextProvOffset);
+      CurrByteOffset = BOffset;
+      NextProvOffset = POffset;
+    }
+  } break;
+  default:
+    break;
   }
-  return VectorType::get(this->PtrTy, Elems);
+  Value *NextByteOffset = IRB.CreateAdd(ByteOffset, TypeSize);
+  return std::make_tuple(NextByteOffset, NextProvOffset);
 }
 
-Type *ProvenanceLayout::getIntTy(ElementCount Elems) const {
-  if (Elems.isScalar()) {
-    return this->IntptrTy;
+// Returns the descriptions for where provenance values are stored for a type.
+SmallVector<ProvenanceDesc>
+ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB, Type *Ty) {
+  SmallVector<ProvenanceDesc> Desc;
+  if (Ty->isSized()) {
+    Value *Zero = ConstantInt::get(IRB.getIntPtrTy(*DL), 0);
+    getProvenanceDesc(IRB, Desc, Ty, Zero, Zero);
   }
-  return VectorType::get(this->IntptrTy, Elems);
-}
-
-std::optional<ProvenanceScalar> Provenance::getScalar() const {
-  if (Elems.isScalar()) {
-    return *static_cast<const ProvenanceScalar *>(this);
-  }
-  return std::nullopt;
-}
-
-ProvenanceScalar Provenance::assertScalar() const {
-  return this->getScalar().value();
-}
-
-std::optional<ProvenanceVector> Provenance::getVector() const {
-  if (Elems.isVector()) {
-    return *static_cast<const ProvenanceVector *>(this);
-  }
-  return std::nullopt;
-}
-
-ProvenanceVector Provenance::assertVector() const {
-  return this->getVector().value();
-}
-
-ProvenancePtr::ProvenancePtr(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                             Value *Base, ElementCount Elems) {
-  if (Elems.isScalar()) {
-    *this = ProvenancePtrScalar(IRB, PL, Base);
-  } else {
-    *this = ProvenancePtrVector(IRB, PL, Base, Elems);
-  }
-}
-
-ProvenancePtrScalar::ProvenancePtrScalar(IRBuilder<> &IRB,
-                                         const ProvenanceLayout &PL,
-                                         Value *Base) {
-
-  Value *ZeroIdx = ConstantInt::get(IRB.getInt64Ty(), 0);
-  this->TagPtr = Base;
-  this->InfoPtr = IRB.CreateGEP(
-      PL.ProvenanceTy, Base, {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 1)});
-}
-
-ProvenancePtrVector::ProvenancePtrVector(IRBuilder<> &IRB,
-                                         const ProvenanceLayout &PL,
-                                         Value *Base, ElementCount Elems) {
-  this->TagPtr = Base;
-  this->Elems = Elems;
-  Value *IntVecSize = IRB.CreateTypeSize(
-      PL.IntptrTy,
-      PL.DL->getTypeAllocSize(VectorType::get(PL.IntptrTy, Elems)));
-  Value *TagOffset = IRB.CreateAdd(Base, this->TagPtr);
-  this->InfoPtr =
-      IRB.CreateIntToPtr(IRB.CreateAdd(TagOffset, IntVecSize), PL.PtrTy);
+  return Desc;
 }
 
 void Provenance::addIncoming(BasicBlock *IncomingBlock,
@@ -80,61 +67,56 @@ void Provenance::addIncoming(BasicBlock *IncomingBlock,
   InfoNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Info);
 }
 
+bool Provenance::isWildcard() const {
+  if (this->Elems.isScalar()) {
+    if (auto *CI = dyn_cast<ConstantInt>(this->Tag)) {
+      return CI->isZero();
+    }
+    return false;
+  }
+  report_fatal_error("Vector provenance is not supported yet");
+}
+
 Provenance Provenance::load(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                            ProvenancePtr ProvPtr) {
+                            Value *Src, ElementCount Elems) {
+  if (Elems.isScalar()) {
+    Type *IntTy = PL.IntptrTy;
+    Type *PtrTy = PL.PtrTy;
 
-  Type *IntTy = PL.getIntTy(ProvPtr.Elems);
-  Type *PtrTy = PL.getPtrTy(ProvPtr.Elems);
+    Value *ZeroIdx = ConstantInt::get(IRB.getInt64Ty(), 0);
+    Value *TagPtr = Src;
+    Value *InfoPtr = IRB.CreateGEP(
+        PL.ProvenanceTy, Src, {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 1)});
 
-  LoadInst *Tag = IRB.CreateLoad(IntTy, ProvPtr.TagPtr);
-  LoadInst *Info = IRB.CreateLoad(PtrTy, ProvPtr.InfoPtr);
+    LoadInst *Tag = IRB.CreateLoad(IntTy, TagPtr);
+    LoadInst *Info = IRB.CreateLoad(PtrTy, InfoPtr);
 
-  return Provenance(Tag, Info, ProvPtr.Elems);
-}
-
-ProvenanceScalar ProvenanceScalar::load(IRBuilder<> &IRB,
-                                        const ProvenanceLayout &PL,
-                                        ProvenancePtrScalar ProvPtr) {
-  return Provenance::load(IRB, PL, ProvPtr).assertScalar();
-}
-ProvenanceVector ProvenanceVector::load(IRBuilder<> &IRB,
-                                        const ProvenanceLayout &PL,
-                                        ProvenancePtrVector ProvPtr) {
-  return Provenance::load(IRB, PL, ProvPtr).assertVector();
+    return Provenance(Tag, Info, ElementCount::getFixed(1));
+  }
+  report_fatal_error("Vector provenance is not supported yet");
 }
 
 void Provenance::store(IRBuilder<> &IRB, const ProvenanceLayout &PL,
                        Value *Base) {
-  this->store(IRB, PL, ProvenancePtr(IRB, PL, Base, this->Elems));
+  if (Elems.isScalar()) {
+    Value *ZeroIdx = ConstantInt::get(IRB.getInt64Ty(), 0);
+    Value *TagPtr = Base;
+    Value *InfoPtr =
+        IRB.CreateGEP(PL.ProvenanceTy, Base,
+                      {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 1)});
+    IRB.CreateStore(this->Tag, TagPtr);
+    IRB.CreateStore(this->Info, InfoPtr);
+  } else {
+    report_fatal_error("Vector provenance is not supported yet");
+  }
 }
 
-void Provenance::store(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                       ProvenancePtr Dest) {
-
-  StoreInst *Tag = IRB.CreateStore(this->Tag, Dest.TagPtr);
-  StoreInst *Info = IRB.CreateStore(this->Info, Dest.InfoPtr);
-}
-
-Provenance Provenance::wildcard(IRBuilder<> &IRB, const ProvenanceLayout &PL,
+Provenance Provenance::wildcard(const ProvenanceLayout &PL,
                                 ElementCount Elems) {
   if (Elems.isScalar()) {
-    return ProvenanceScalar::wildcard(PL);
+    Value *Zero = ConstantInt::get(PL.IntptrTy, 0);
+    Value *InvalidPtr = ConstantPointerNull::get(PL.PtrTy);
+    return Provenance(Zero, InvalidPtr, Elems);
   }
-  return ProvenanceVector::wildcard(IRB, PL, Elems);
-}
-
-ProvenanceScalar ProvenanceScalar::wildcard(const ProvenanceLayout &PL) {
-  Value *Zero = ConstantInt::get(PL.IntptrTy, 0);
-  Value *InvalidPtr = ConstantPointerNull::get(PL.PtrTy);
-  return ProvenanceScalar(Zero, InvalidPtr);
-}
-
-ProvenanceVector ProvenanceVector::wildcard(IRBuilder<> &IRB,
-                                            const ProvenanceLayout &PL,
-                                            ElementCount Elems) {
-  Constant *Zero = ConstantInt::get(PL.IntptrTy, 0);
-  Value *Tag = ConstantVector::getSplat(Elems, Zero);
-  Value *Info =
-      ConstantVector::getSplat(Elems, ConstantPointerNull::get(PL.PtrTy));
-  return ProvenanceVector(Tag, Info, Elems);
+  report_fatal_error("Vector provenance is not supported yet");
 }

--- a/bsan-pass/Provenance.h
+++ b/bsan-pass/Provenance.h
@@ -14,6 +14,21 @@ namespace llvm {
 // a pointer to an allocation metadata object.
 static const unsigned kProvenanceSize = 16;
 
+// A component of a type that carries provenance information.
+// This is either a pointer or a vector of pointers.
+struct ProvenanceDesc {
+  // The offset where this field is located.
+  Value *ByteOffset;
+  // The byte width of this field.
+  Value *ByteWidth;
+  // The number of provenance values in this field.
+  ElementCount Elems;
+
+public:
+  ProvenanceDesc(Value *ByteOffset, Value *ByteWidth, ElementCount Elems)
+      : ByteOffset(ByteOffset), ByteWidth(ByteWidth), Elems(Elems) {}
+};
+
 struct ProvenanceLayout {
   const DataLayout *DL;
   Type *IntptrTy = nullptr;
@@ -29,52 +44,18 @@ struct ProvenanceLayout {
     ProvenanceSize = ConstantInt::get(IntptrTy, kProvenanceSize);
     ProvenanceAlign = DL->getABITypeAlign(ProvenanceTy);
   }
-  Type *getPtrTy(ElementCount Elems) const;
-  Type *getIntTy(ElementCount Elems) const;
-};
 
-class ProvenancePtrScalar;
-class ProvenancePtrVector;
+  SmallVector<ProvenanceDesc> getProvenanceDesc(IRBuilder<> &IRB, Type *Ty);
 
-// A pointer to one or more adjacent provenance values in memory.
-// Represents a "provenancy-carrying-component" of a typed value,
-// offset from a given location in an array of provenance values.
-struct ProvenancePtr {
-  Value *TagPtr = nullptr;
-  Value *InfoPtr = nullptr;
-  ElementCount Elems = ElementCount::getFixed(1);
-  ProvenancePtr() {}
-  ProvenancePtr(Value *Tag, Value *Info, ElementCount Elems)
-      : TagPtr(Tag), InfoPtr(Info), Elems(Elems) {}
-
-  ProvenancePtr(IRBuilder<> &IRB, const ProvenanceLayout &PL, Value *Base,
-                ElementCount Elems);
-};
-
-class ProvenancePtrScalar : public ProvenancePtr {
-  using ProvenancePtr::ProvenancePtr;
-
-public:
-  ProvenancePtrScalar(Value *T, Value *F)
-      : ProvenancePtr(T, F, ElementCount::getFixed(1)) {}
-  ProvenancePtrScalar(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                      Value *Base);
-};
-
-class ProvenancePtrVector : public ProvenancePtr {
-  using ProvenancePtr::ProvenancePtr;
-
-public:
-  ProvenancePtrVector(Value *T, Value *F, ElementCount Elems)
-      : ProvenancePtr(T, F, Elems) {}
-  ProvenancePtrVector(IRBuilder<> &IRB, const ProvenanceLayout &PL, Value *Base,
-                      ElementCount Elems);
-  static ProvenancePtrVector alloc(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                                   ElementCount Elems);
+private:
+  std::tuple<Value *, Value *>
+  getProvenanceDesc(IRBuilder<> &IRB, SmallVector<ProvenanceDesc> &Dest,
+                    Type *CurrentTy, Value *ByteOffset, Value *ProvOffset);
 };
 
 class ProvenanceScalar;
 class ProvenanceVector;
+
 class Provenance {
 public:
   Value *Tag = nullptr;
@@ -82,6 +63,7 @@ public:
   ElementCount Elems = ElementCount::getFixed(1);
 
   Provenance() {}
+  Provenance(Value *Tag, Value *Info) : Tag(Tag), Info(Info) {}
   Provenance(Value *Tag, Value *Info, ElementCount Elems)
       : Tag(Tag), Info(Info), Elems(Elems) {}
   bool operator==(const Provenance &other) const {
@@ -91,129 +73,13 @@ public:
   bool operator!=(const Provenance &other) const { return !(*this == other); }
 
   void addIncoming(BasicBlock *IncomingBlock, Provenance &IncomingProv);
-  std::optional<ProvenanceScalar> getScalar() const;
-  ProvenanceScalar assertScalar() const;
-
-  std::optional<ProvenanceVector> getVector() const;
-  ProvenanceVector assertVector() const;
   void store(IRBuilder<> &IRB, const ProvenanceLayout &PL, Value *Dest);
-  void store(IRBuilder<> &IRB, const ProvenanceLayout &PL, ProvenancePtr Dest);
   static Provenance load(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                         ProvenancePtr ProvPtr);
-  static Provenance wildcard(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                             ElementCount Elems);
-};
-
-class ProvenanceScalar : public Provenance {
-  using Provenance::Provenance;
-
-public:
-  ProvenanceScalar(Value *Tag, Value *Info)
-      : Provenance(Tag, Info, ElementCount::getFixed(1)) {}
-  static ProvenanceScalar load(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                               ProvenancePtrScalar ProvPtr);
-  static ProvenanceScalar wildcard(const ProvenanceLayout &PL);
-};
-
-class ProvenanceVector : public Provenance {
-  using Provenance::Provenance;
-
-public:
-  ProvenanceVector(Value *Tag, Value *Info, ElementCount Elems)
-      : Provenance(Tag, Info, Elems) {}
-  static ProvenanceVector load(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                               ProvenancePtrVector ProvPtr);
-  static ProvenanceVector wildcard(IRBuilder<> &IRB, const ProvenanceLayout &PL,
-                                   ElementCount Elems);
-};
-
-// When loading and storing provenance, we need a way to
-// handle dynamically sized values, which can be placed at any
-// position within an aggregate type. The `DynSize` type makes
-// it far easier to reason about arithmetic and other operations
-// on values with both static and dynamic components.
-struct DynSize {
-  unsigned Static = 0;
-  SmallVector<Value *, 1> Dynamic;
-
-public:
-  DynSize() {}
-
-  DynSize(unsigned Off) : Static(Off) {}
-
-  DynSize(Value *Val) { this->append(Val); }
-
-  Value *getValue(IRBuilder<> &IRB, Type *Ty) {
-    Value *V = ConstantInt::get(Ty, Static);
-    for (Value *D : Dynamic) {
-      V = IRB.CreateAdd(V, D);
-    }
-    return V;
-  }
-
-  void append(Value *Val) {
-    if (ConstantInt *CI = dyn_cast<ConstantInt>(Val)) {
-      Static += CI->getZExtValue();
-    } else {
-      Dynamic.push_back(Val);
-    }
-  }
-
-  std::optional<unsigned> constant() {
-    if (Dynamic.empty()) {
-      return Static;
-    } else {
-      return std::nullopt;
-    }
-  }
-
-  DynSize add(DynSize RHS) {
-    DynSize Off;
-    Off.Static = this->Static + RHS.Static;
-    Off.Dynamic.append(this->Dynamic);
-    Off.Dynamic.append(RHS.Dynamic);
-    return Off;
-  }
-
-  DynSize sub(IRBuilder<> &IRB, Type *Ty, DynSize RHS) {
-    std::optional<unsigned> LConst = this->constant();
-    std::optional<unsigned> RConst = RHS.constant();
-    if (LConst.has_value() && RConst.has_value()) {
-      return DynSize(LConst.value() - RConst.value());
-    } else {
-      Value *LVal = this->getValue(IRB, Ty);
-      Value *RVal = RHS.getValue(IRB, Ty);
-      return IRB.CreateSub(LVal, RVal);
-    }
-  }
-
-  bool operator==(const DynSize &other) const {
-    if (this->Static != other.Static) {
-      return false;
-    }
-    if (this->Dynamic.size() != other.Dynamic.size()) {
-      return false;
-    }
-    return std::is_permutation(this->Dynamic.begin(), this->Dynamic.end(),
-                               other.Dynamic.begin());
-  }
-
-  bool operator!=(const DynSize &other) const { return !(*this == other); }
-};
-
-// A component of a type that carries provenance information.
-// This is either a pointer or a vector of pointers.
-struct ProvenanceDesc {
-  // The offset where this field is located.
-  DynSize ByteOffset;
-  // The byte width of this field.
-  DynSize ByteWidth;
-  // The number of provenance values in field.
-  ElementCount Elems;
-
-public:
-  ProvenanceDesc(Value *ByteOffset, Value *ByteWidth, ElementCount Elems)
-      : ByteOffset(ByteOffset), ByteWidth(ByteWidth), Elems(Elems) {}
+                         Value *Src,
+                         ElementCount Elems = ElementCount::getFixed(1));
+  static Provenance wildcard(const ProvenanceLayout &PL,
+                             ElementCount Elems = ElementCount::getFixed(1));
+  bool isWildcard() const;
 };
 
 struct ProvenanceKey {


### PR DESCRIPTION
This removes several helper classes for supporting scalable vectors of provenance values. This includes:
* `ProvenanceScalar` and `ProvenanceVector`
* `ProvenancePtr` and all of its subclasses
* `DynSize`

It also relocates `ProvenanceDesc` and related functions into the separate `Provenance.cpp` file. If in the future BorrowSanitizer needs to support scalable vectors, these might need to be added back in some form. However, at that point, our provenance metadata will likely have a different form, so these functions will need to be reimplemented anyway. At the moment, these components just tend to make development trickier.