### PR TITLE
Update fork of Rust to add taint markers

### DIFF
--- a/bsan-pass/CMakeLists.txt
+++ b/bsan-pass/CMakeLists.txt
@@ -13,12 +13,14 @@ set(BSAN_SOURCES
   BorrowSanitizer.cpp
   BorrowSanitizerPass.cpp
   Provenance.cpp
+  TaintAnalysis.cpp
 )
 
 set(BSAN_HEADERS
   BorrowSanitizer.h
   BorrowSanitizerPass.h
   Provenance.h
+  TaintAnalysis.h
 )
 
 set(CMAKE_CXX_CLANG_TIDY clang-tidy;-warnings-as-errors=*)

--- a/bsan-pass/TaintAnalysis.cpp
+++ b/bsan-pass/TaintAnalysis.cpp
@@ -1,24 +1,26 @@
 // This file implements an interprocedural taint analysis to support
-// soundly removing runtime checks from safe components. 
+// soundly removing runtime checks from safe components.
 //
 // Our fork of rustc can be configured to emit function calls that mark when
-// pointers have been exposed to unsafety. This happens when a reference is 
-// cast into a raw pointer, or vice versa, and when any kind of transmutation 
+// pointers have been exposed to unsafety. This happens when a reference is
+// cast into a raw pointer, or vice versa, and when any kind of transmutation
 // happens. If a pointer is tainted, we need to instrument it from the point it
 // gained ownership to tthe end of the lifetime of its underlying object. If a
-// place is tainted, then any pointers that are loaded from it become tainted. We
-// use two forms of intrinsic functions (`__rust_taint_reg` and `__rust_taint_mem`)
-// to distinguish between each case.
+// place is tainted, then any pointers that are loaded from it become tainted.
+// We use two forms of intrinsic functions (`__rust_taint_reg` and
+// `__rust_taint_mem`) to distinguish between each case.
 //
-// Using this analysis, we can remove runtime checks for components that are exclusively
-// accessed via safe or unsafe operations, respectively. Only components that cross 
-// the "safe/unsafe boundary" are capable of having aliasing-related undefined behavior. 
+// Using this analysis, we can remove runtime checks for components that are
+// exclusively accessed via safe or unsafe operations, respectively. Only
+// components that cross the "safe/unsafe boundary" are capable of having
+// aliasing-related undefined behavior.
 //
-// We need to pessimistically assume that any external inputs to the current module
-// are tainted. This means that the "power" of the analysis to remove runtime checks
-// will increase if LTO is enabled. However, we still expect to be able to eliminate
-// a significant portion of runtime overhead in any case, even if we can only reason
-// about components that are isolated within the current module.
+// We need to pessimistically assume that any external inputs to the current
+// module are tainted. This means that the "power" of the analysis to remove
+// runtime checks will increase if LTO is enabled. However, we still expect to
+// be able to eliminate a significant portion of runtime overhead in any case,
+// even if we can only reason about components that are isolated within the
+// current module.
 
 #include "TaintAnalysis.h"
 #include "llvm/IR/Instructions.h"
@@ -30,11 +32,6 @@ using namespace llvm;
 
 #define TAINT_FN(name) "__rust_taint_"
 
+FunctionTaintAnalysis::FunctionTaintAnalysis(Function &F) : F(F) {}
 
-FunctionTaintAnalysis::FunctionTaintAnalysis(Function &F)
-    : F(F) {
-}
-
-void FunctionTaintAnalysis::run() {
-
-}
+void FunctionTaintAnalysis::run() {}

--- a/bsan-pass/TaintAnalysis.cpp
+++ b/bsan-pass/TaintAnalysis.cpp
@@ -6,9 +6,11 @@
 // cast into a raw pointer, or vice versa, and when any kind of transmutation 
 // happens. If a pointer is tainted, we need to instrument it from the point it
 // gained ownership to tthe end of the lifetime of its underlying object. If a
-// place is tainted, then any pointers that are loaded from it become tainted. 
+// place is tainted, then any pointers that are loaded from it become tainted. We
+// use two forms of intrinsic functions (`__rust_taint_reg` and `__rust_taint_mem`)
+// to distinguish between each case.
 //
-// As a result, we will remove runtime checks for components that are exclusively
+// Using this analysis, we can remove runtime checks for components that are exclusively
 // accessed via safe or unsafe operations, respectively. Only components that cross 
 // the "safe/unsafe boundary" are capable of having aliasing-related undefined behavior. 
 //

--- a/bsan-pass/TaintAnalysis.cpp
+++ b/bsan-pass/TaintAnalysis.cpp
@@ -1,0 +1,38 @@
+// This file implements an interprocedural taint analysis to support
+// soundly removing runtime checks from safe components. 
+//
+// Our fork of rustc can be configured to emit function calls that mark when
+// pointers have been exposed to unsafety. This happens when a reference is 
+// cast into a raw pointer, or vice versa, and when any kind of transmutation 
+// happens. If a pointer is tainted, we need to instrument it from the point it
+// gained ownership to tthe end of the lifetime of its underlying object. If a
+// place is tainted, then any pointers that are loaded from it become tainted. 
+//
+// As a result, we will remove runtime checks for components that are exclusively
+// accessed via safe or unsafe operations, respectively. Only components that cross 
+// the "safe/unsafe boundary" are capable of having aliasing-related undefined behavior. 
+//
+// We need to pessimistically assume that any external inputs to the current module
+// are tainted. This means that the "power" of the analysis to remove runtime checks
+// will increase if LTO is enabled. However, we still expect to be able to eliminate
+// a significant portion of runtime overhead in any case, even if we can only reason
+// about components that are isolated within the current module.
+
+#include "TaintAnalysis.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Value.h"
+
+using namespace llvm;
+
+#define DEBUG_TYPE "borsan-taint"
+
+#define TAINT_FN(name) "__rust_taint_"
+
+
+FunctionTaintAnalysis::FunctionTaintAnalysis(Function &F)
+    : F(F) {
+}
+
+void FunctionTaintAnalysis::run() {
+
+}

--- a/bsan-pass/TaintAnalysis.h
+++ b/bsan-pass/TaintAnalysis.h
@@ -1,0 +1,44 @@
+#ifndef BORROWSANITIZER_TAINT_ANALYSIS_H
+#define BORROWSANITIZER_TAINT_ANALYSIS_H
+
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace llvm {
+
+class BasicBlock;
+class Function;
+class Instruction;
+class Value;
+
+class FunctionTaintAnalysis {
+  struct BlockInfo {
+    explicit BlockInfo(unsigned Size)
+        : Tainted(Size), TaintedIn(Size), TaintedOut(Size) {}
+    /// Which objects are tainted by this basic block.
+    BitVector Tainted;
+    /// Which objects are tainted on entry to this block.
+    BitVector TaintedIn;
+    /// Which objects are tainted after exiting this block.
+    BitVector TaintedOut;
+  };
+private:
+  Function &F;
+  using BlockInfoMap = DenseMap<const BasicBlock *, BlockInfo>;
+  BlockInfoMap BlockInfo;
+
+  SmallVector<const Value *> Objects;
+  unsigned NumObjects;
+  DenseMap<const Value *, unsigned> ObjectNumbering;
+
+public:
+  FunctionTaintAnalysis(Function &F);
+  void run();
+  /// Returns true if the alloca is alive after the instruction.
+  bool isTainted(const Value *V) const;
+};
+
+} // end namespace llvm
+
+#endif // BORROWSANITIZER_TAINT_ANALYSIS_H

--- a/bsan-pass/TaintAnalysis.h
+++ b/bsan-pass/TaintAnalysis.h
@@ -23,6 +23,7 @@ class FunctionTaintAnalysis {
     /// Which objects are tainted after exiting this block.
     BitVector TaintedOut;
   };
+
 private:
   Function &F;
   using BlockInfoMap = DenseMap<const BasicBlock *, BlockInfo>;

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -286,7 +286,7 @@ __bsan_protector_end_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc) {}
 SANITIZER_INTERFACE_ATTRIBUTE void
 __bsan_pop_frame(const Provenance *frame_start, uptr prot,
                  uptr alloca_vec_size) {
-  GET_SPAN_PC_BP;
+  GET_SPAN;
   for (uptr i = 0; i < prot + alloca_vec_size; i++) {
     const Provenance Prov = frame_start[i];
     if (i < prot) {

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -129,7 +129,6 @@ fn install_toolchain(
     };
 
     download_unpack_install("rust", true)?;
-    download_unpack_install("rustc-dev", true)?;
     download_unpack_install("rust-dev", true)?;
     download_unpack_install("rust-src", false)?;
 

--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,8 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.97.0-dev-f200f92"
-sha = "f200f929917ca91e8e98717cec4628d1c7c0eab2"
+tag = "rolling-1.97.0-dev-1e214e7"
+sha = "1e214e7986bf2fa30f080d6931cb67538665a624"
 version = "1.97.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
-llvm_branch = "rustc/22.1-2026-01-27"
+llvm_branch = "rustc/22.1-2026-03-22"
 llvm_url = "https://github.com/rust-lang/llvm-project.git"


### PR DESCRIPTION
This updates our Rust fork to [rolling-1.97.0-dev-1e214e7](https://github.com/BorrowSanitizer/rust/releases/tag/rolling-1.97.0-dev-1e214e7). It removes the component `rustc-dev`, which is no longer necessary. We used this when we had the `bsan-driver` compiler plugin.

This change adds a new flag `-Zcodgen-emit-taint`, which will emit function calls to mark when pointers and places become exposed to certain unsafe operations. 

When a reference is cast into a pointer, or vice versa, we "mark" it with the function `ptr __rust_taint_reg(ptr)`, creating a new alias. For example:
```Rust
let x = &0;
let y = x as *const _;
```
The code above would compile to:
```LLVM
%x = ...
&y = __rust_taint_reg(%x)
```
The same thing happens to pointers within a value that is transmuted. We treat `mem::transmute` as entirely opaque, except in cases where it becomes a nop, which we skip. When the type of a place is transmuted, we mark its contents as tainted using `void __rust_taint_mem(ptr)`. Any pointer that is loaded from a tainted place becomes tainted. This adds a stub implementation of a taint analysis pass.