### PR TITLE
Fixed nop retags by splitting up our runtime components.

### DIFF
--- a/bsan-rt/Cargo.toml
+++ b/bsan-rt/Cargo.toml
@@ -14,7 +14,7 @@ smallvec = "1.15.1"
 bitflags = "2.11.1"
 
 [lib]
-name = "bsan_rt_core"
+name = "bsan_rt"
 crate-type = ["staticlib"]
 
 [features]

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -30,6 +30,14 @@ THREADLOCAL void *__bsan_marker = nullptr;
 SANITIZER_INTERFACE_ATTRIBUTE
 THREADLOCAL Provenance *__bsan_shadow_stack = nullptr;
 
+// A flag set by the Rust core runtime to indicate to the LLVM
+// wrapper that an error has occurred.
+SANITIZER_INTERFACE_ATTRIBUTE
+THREADLOCAL uptr __bsan_had_error = 0;
+
+SANITIZER_INTERFACE_ATTRIBUTE
+atomic_uintptr_t __bsan_bor_tag_ctr{2};
+
 namespace __bsan {
 
 // Much like other MemorySanitizer, we use a thread-local flag to detect
@@ -51,6 +59,10 @@ bool bsan_deinit_running = false;
 
 // Every thread has a unique ID
 atomic_uintptr_t thread_id{0};
+
+BorTag NewBorTag() {
+  return atomic_fetch_add(&__bsan_bor_tag_ctr, 1, memory_order_relaxed);
+}
 
 // Returns the desired length for the current stack trace.
 // We add '1' to skip printing our runtime symbols in traces.
@@ -289,10 +301,6 @@ void __bsan_local_init(Provenance **prov) {}
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_local_deinit() {}
 
-// Weak tagging operations
-SANITIZER_WEAK_ATTRIBUTE
-BorTag __bsan_new_bor_tag() { return 0; }
-
 SANITIZER_WEAK_ATTRIBUTE
 BorTag __bsan_retag_impl(void *object_addr, uptr access_size, u8 flags,
                          const uptr im_data[2], uptr im_len,
@@ -337,11 +345,19 @@ void __bsan_write(void *ptr, uptr access_size, BorTag bor_tag,
   HANDLE_ERROR(pc, bp);
 }
 
+SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE Provenance *
+__bsan_shadow(void *addr) {
+  return GetSlot(0);
+}
+
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
 __bsan_shadow_transfer(void *dest, const void *src, uptr access_size) {}
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
 __bsan_shadow_clear(void *dest, uptr access_size) {}
+
+SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
+__bsan_rc_store(BorTag Tag, AllocInfo *Info, Provenance *Dest) {}
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE AllocInfo *
 __bsan_reserve_stack_slot() {
@@ -441,9 +457,6 @@ void __bsan_debug_print_diff(void *ptr) {
   __bsan_print_diff(Slot->Tag, Slot->Info);
 }
 
-void __bsan_abort() {
-  // Printf("BorrowSanitizer: aborting due to a fatal error.\n");
-  Die();
-}
+void __bsan_abort() { Die(); }
 
 } // extern "C"

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -11,8 +11,6 @@ using __sanitizer::u64;
 using __sanitizer::u8;
 using __sanitizer::uptr;
 
-extern THREADLOCAL uptr __BSAN_HAD_ERROR;
-
 typedef uptr Span;
 typedef uptr BorTag;
 typedef uptr ThreadId;
@@ -28,6 +26,10 @@ const Provenance WILDCARD = {0, nullptr};
 extern SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL Provenance
     *__bsan_shadow_stack;
 
+extern SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL uptr __bsan_had_error;
+
+extern SANITIZER_INTERFACE_ATTRIBUTE atomic_uintptr_t __bsan_bor_tag_ctr;
+
 namespace __bsan {
 
 extern THREADLOCAL void *bsan_thread;
@@ -35,6 +37,8 @@ extern bool bsan_inited;
 extern bool bsan_init_running;
 extern bool bsan_deinit_running;
 extern atomic_uintptr_t thread_id;
+
+BorTag NewBorTag();
 
 void InitializeGC();
 void DeinitializeGC();
@@ -57,7 +61,7 @@ bool CallerIsInstrumented(void *sym);
   uptr bp = GET_CURRENT_FRAME();
 
 #define HANDLE_ERROR(pc, bp)                                                   \
-  if (__BSAN_HAD_ERROR) {                                                      \
+  if (__bsan_had_error) {                                                      \
     UNINITIALIZED BufferedStackTrace stack;                                    \
     stack.Unwind(pc, bp, nullptr, true, __bsan::GetStackTraceLen());           \
     PrintStackTrace(stack);                                                    \

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -69,7 +69,7 @@ INTERCEPTOR(int, pthread_create, void *th, void *attr,
   return res;
 }
 
-extern "C" void *__crt_malloc(SIZE_T size) {
+extern "C" void *__bsan_crt_malloc(SIZE_T size) {
   if (DlsymAlloc::Use())
     return DlsymAlloc::Allocate(size);
   return REAL(malloc)(size);
@@ -82,13 +82,13 @@ INTERCEPTOR(void *, malloc, SIZE_T size) {
   void *ptr = REAL(malloc)(size);
   if (INST_CALLER(malloc)) {
     Provenance *RetSlot = GetSlot(0);
-    BorTag Tag = __bsan_new_bor_tag();
+    BorTag Tag = NewBorTag();
     *RetSlot = {Tag, __bsan_alloc(ptr, size, Tag, span)};
   }
   return ptr;
 }
 
-extern "C" void __crt_free(void *ptr) {
+extern "C" void __bsan_crt_free(void *ptr) {
   if (UNLIKELY(!ptr))
     return;
   if (DlsymAlloc::PointerIsMine(ptr))
@@ -117,7 +117,7 @@ INTERCEPTOR(void *, calloc, SIZE_T nmemb, SIZE_T size) {
   void *ptr = REAL(calloc)(nmemb, size);
   Provenance *RetSlot = GetSlot(0);
   if (INST_CALLER(calloc)) {
-    BorTag Tag = __bsan_new_bor_tag();
+    BorTag Tag = NewBorTag();
     *RetSlot = {Tag, __bsan_alloc(ptr, nmemb * size, Tag, span)};
   }
   return ptr;
@@ -136,7 +136,7 @@ INTERCEPTOR(void *, realloc, void *ptr, SIZE_T size) {
   void *nptr = REAL(realloc)(ptr, size);
   if (is_inst) {
     Provenance *RetSlot = GetSlot(0);
-    BorTag Tag = __bsan_new_bor_tag();
+    BorTag Tag = NewBorTag();
     *RetSlot = {Tag, __bsan_alloc(nptr, size, Tag, span)};
   }
   return nptr;

--- a/bsan-rt/llvm-wrapper/bsan_interface_internal.h
+++ b/bsan-rt/llvm-wrapper/bsan_interface_internal.h
@@ -43,9 +43,6 @@ void __bsan_local_init(Provenance **prov);
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_local_deinit();
 
-SANITIZER_WEAK_ATTRIBUTE
-BorTag __bsan_new_bor_tag();
-
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_read(void *ptr, uptr access_size, BorTag bor_tag,
                  AllocInfo *alloc_info);

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -123,7 +123,7 @@ impl GlobalCtx {
         let mut ctx = ErrorFormatContext::default();
         crate::eprint!("error: {}", ctx.display_ub(ub_info, pc));
         unsafe {
-            __BSAN_HAD_ERROR = 1;
+            crate::sanitizer_common::__bsan_had_error = 1;
         }
     }
 
@@ -148,8 +148,8 @@ mod global_alloc {
 
     #[cfg(not(test))]
     unsafe extern "C" {
-        fn __crt_malloc(size: usize) -> *mut core::ffi::c_void;
-        fn __crt_free(ptr: *mut core::ffi::c_void);
+        fn __bsan_crt_malloc(size: usize) -> *mut core::ffi::c_void;
+        fn __bsan_crt_free(ptr: *mut core::ffi::c_void);
     }
 
     use core::alloc::{GlobalAlloc, Layout};
@@ -165,7 +165,7 @@ mod global_alloc {
             }
             #[cfg(not(test))]
             unsafe {
-                __crt_malloc(layout.size()).cast::<u8>()
+                __bsan_crt_malloc(layout.size()).cast::<u8>()
             }
         }
         unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
@@ -175,7 +175,7 @@ mod global_alloc {
             }
             #[cfg(not(test))]
             unsafe {
-                __crt_free(ptr.cast::<c_void>());
+                __bsan_crt_free(ptr.cast::<c_void>());
             }
         }
     }

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -37,10 +37,6 @@ use crate::borrow_tracker::tree::Tree;
 use crate::local::*;
 use crate::sanitizer_common::Span;
 
-#[thread_local]
-#[unsafe(no_mangle)]
-pub static mut __BSAN_HAD_ERROR: usize = 0;
-
 /// A struct for summarizing debug information about memory operations
 #[cfg(feature = "debug")]
 struct DebugSummary {
@@ -70,7 +66,7 @@ impl fmt::Display for DebugSummary {
 }
 
 macro_rules! debug_bsan {
-    ($op:literal, $ptr:ident, $bor_tag:ident, $alloc_info:expr) => {
+    ($op:literal, $p:ident, $bor_tag:ident, $alloc_info:expr) => {
         #[cfg(feature = "debug")]
         {
             #[allow(unused_unsafe)]
@@ -79,7 +75,7 @@ macro_rules! debug_bsan {
                 1 => AllocInfoSummary::Null,
                 _ => unsafe { &*$alloc_info }.summarize(),
             };
-            let summary = DebugSummary { op: $op, ptr: $ptr.addr(), bor_tag: $bor_tag, info };
+            let summary = DebugSummary { op: $op, ptr: 0, bor_tag: $bor_tag, info };
             libc_print::std_name::println!("{}", summary);
         }
     };
@@ -163,8 +159,10 @@ impl fmt::Debug for ThreadId {
     }
 }
 
-#[unsafe(no_mangle)]
-pub static __bsan_bor_tag_ctr: AtomicUsize = AtomicUsize::new(2);
+unsafe extern "C" {
+    #[link_name = "__bsan_bor_tag_ctr"]
+    unsafe static __BSAN_BOR_TAG_CTR: AtomicUsize;
+}
 
 /// Unique identifier for a node within the tree
 #[repr(transparent)]
@@ -187,7 +185,7 @@ impl BorTag {
 
 impl Default for BorTag {
     fn default() -> Self {
-        BorTag(__bsan_bor_tag_ctr.fetch_add(1, Ordering::Relaxed))
+        BorTag(unsafe { __BSAN_BOR_TAG_CTR.fetch_add(1, Ordering::Relaxed) })
     }
 }
 
@@ -346,11 +344,6 @@ unsafe extern "C-unwind" fn __bsan_local_deinit() {
     }
 }
 
-#[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_new_bor_tag() -> BorTag {
-    BorTag::default()
-}
-
 bitflags::bitflags! {
     #[repr(C)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -391,7 +384,6 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
     debug_bsan!("retag", object_addr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
-
     let opt_slice = |ptr, len| -> Option<_> {
         (!im_data.is_null()).then(|| unsafe { slice::from_raw_parts(ptr, len) })
     };

--- a/bsan-rt/src/sanitizer_common.rs
+++ b/bsan-rt/src/sanitizer_common.rs
@@ -102,6 +102,9 @@ impl SanitizerCommon {
 }
 
 unsafe extern "C" {
+    #[thread_local]
+    pub unsafe static mut __bsan_had_error: usize;
+
     /// Symbolize a single PC into "file:line:column" and returns 1 on success.
     fn __bsan_symbolize_pc(
         pc: usize,

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -83,11 +83,15 @@ impl Command {
             let args = &[];
             let mut env_guards = vec![];
             let cargo_bsan = env.build_artifact(CargoBsan, args)?;
-            let runtime = env.build_artifact(BsanRt, args)?;
+            let rust_runtime = env.build_artifact(BsanRt, args)?;
+            let llvm_runtime = env.build_artifact(CompilerRt, args)?;
+
             let pass = env.build_artifact(BsanPass, args)?;
             let symbolizer = env.sysroot_binary("llvm-symbolizer");
 
-            env_guards.push(env.sh.push_env("BSAN_RT", &runtime));
+            env_guards.push(env.sh.push_env("BSAN_RT_RUST", &rust_runtime));
+            env_guards.push(env.sh.push_env("BSAN_RT_LLVM", &llvm_runtime));
+
             env_guards.push(env.sh.push_env("BSAN_PLUGIN", &pass));
             env_guards.push(env.sh.push_env("BSAN_SYMBOLIZER", &symbolizer));
             env_guards.push(env.sh.push_env("CARGO_BSAN", &cargo_bsan));
@@ -104,6 +108,9 @@ impl Command {
         })?;
 
         crate::all_components!().iter().try_for_each(|c| c.install(env, &[]))?;
+
+        let cargo_test_path = path!(env.build_dir / "bsan");
+        cmd!(env.sh, "rm -rf {cargo_test_path}").run()?;
         cmd!(env.sh, "python3 tests/test-cargo-bsan/run_test.py").run()?;
         Ok(())
     }
@@ -142,18 +149,20 @@ impl Command {
         env.in_mode(Mode::Release, |env| {
             let plugin = env.build_artifact(BsanPass, &[])?;
 
-            let runtime = if debug {
+            let rust_runtime = if debug {
                 env.build_artifact(BsanRt, &["--features".to_string(), "debug".to_string()])?
             } else {
                 env.build_artifact(BsanRt, &[])?
             };
 
+            let llvm_runtime = env.build_artifact(CompilerRt, &[])?;
             let cargo_bsan = env.build_artifact(CargoBsan, &[])?;
             let sysroot_dir = path!(&env.build_dir / "sysroot");
 
             let env_guards = vec![
                 env.sh.push_env("BSAN_PLUGIN", &plugin),
-                env.sh.push_env("BSAN_RT", &runtime),
+                env.sh.push_env("BSAN_RT_RUST", &rust_runtime),
+                env.sh.push_env("BSAN_RT_LLVM", &llvm_runtime),
                 env.sh.push_env("BSAN_SYSROOT", &sysroot_dir),
             ];
 
@@ -181,7 +190,6 @@ impl Command {
 pub enum Component {
     CargoBsan,
     BsanRt,
-    BsanRtCore,
     CompilerRt,
     BsanPass,
 }
@@ -189,13 +197,7 @@ pub enum Component {
 #[macro_export]
 macro_rules! all_components {
     () => {
-        [
-            Component::CargoBsan,
-            Component::BsanRt,
-            Component::BsanRtCore,
-            Component::CompilerRt,
-            Component::BsanPass,
-        ]
+        [Component::CargoBsan, Component::BsanRt, Component::CompilerRt, Component::BsanPass]
     };
 }
 
@@ -206,7 +208,6 @@ impl Deref for Component {
         match self {
             Component::CargoBsan => &CargoBsan,
             Component::BsanRt => &BsanRt,
-            Component::BsanRtCore => &BsanRtCore,
             Component::CompilerRt => &CompilerRt,
             Component::BsanPass => &BsanPass,
         }
@@ -308,58 +309,6 @@ static RT_FLAGS: &[&str] = &[
     "-Crelocation-model=pic",
 ];
 
-struct BsanRt;
-
-impl Buildable for BsanRt {
-    fn artifact(&self, _env: &BsanEnv) -> String {
-        "libbsan_rt.a".into()
-    }
-
-    fn doc(&self, env: &mut BsanEnv, args: &[String]) -> Result<()> {
-        env.doc("bsan-rt", args)
-    }
-
-    fn build(&self, env: &mut BsanEnv, args: &[String]) -> Result<Option<PathBuf>> {
-        let llvm_ar = env.target_binary("llvm-ar");
-        let llvm_wrapper = env.build_artifact(CompilerRt, &[])?;
-        let rust_runtime = env.build_artifact(BsanRtCore, args)?;
-
-        let dest_archive = path!(env.artifact_dir() / self.artifact(env));
-        cmd!(env.sh, "cp {llvm_wrapper} {dest_archive}").quiet().run()?;
-
-        let tmp_dir = env.sh.create_temp_dir()?;
-        env.cd(tmp_dir.path(), |env| {
-            cmd!(env.sh, "{llvm_ar} -x {rust_runtime}").quiet().run()?;
-
-            let file_names: Vec<String> = fs::read_dir(tmp_dir.path())
-                .unwrap()
-                .filter_map(|entry| {
-                    let path = entry.ok().unwrap().path();
-                    if path.is_file() {
-                        path.to_str().map(|s| s.to_owned())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            // Finally, add the objects into the static archive of C++ component.
-            cmd!(env.sh, "{llvm_ar} -r {dest_archive}").args(file_names).quiet().run()?;
-            Ok(())
-        })?;
-
-        Ok(Some(path!(env.artifact_dir() / dest_archive)))
-    }
-
-    fn install(&self, env: &mut BsanEnv, args: &[String]) -> Result<()> {
-        env.in_mode(Mode::Release, |env| {
-            self.build(env, args)?;
-            let runtime = env.assert_artifact(&self.artifact(env));
-            env.copy_to_sysroot_libdir(&runtime)
-        })
-    }
-}
-
 struct CompilerRt;
 impl CompilerRt {
     fn cmake(env: &mut BsanEnv) -> Result<Config> {
@@ -418,11 +367,11 @@ impl Buildable for CompilerRt {
     }
 }
 
-struct BsanRtCore;
+struct BsanRt;
 
-impl Buildable for BsanRtCore {
+impl Buildable for BsanRt {
     fn artifact(&self, _env: &BsanEnv) -> String {
-        "libbsan_rt_core.a".into()
+        "libbsan_rt.a".into()
     }
 
     fn doc(&self, env: &mut BsanEnv, args: &[String]) -> Result<()> {
@@ -436,10 +385,7 @@ impl Buildable for BsanRtCore {
             Ok(env.assert_artifact(&self.artifact(env)))
         })?;
 
-        cmd!(env.sh, "{llvm_objcopy} -w -G __bsan_* -G __BSAN_*")
-            .arg(&rust_runtime)
-            .quiet()
-            .run()?;
+        cmd!(env.sh, "{llvm_objcopy} -w -G __bsan_*").arg(&rust_runtime).quiet().run()?;
 
         Ok(Some(rust_runtime))
     }
@@ -462,6 +408,14 @@ impl Buildable for BsanRtCore {
             &["-Zmiri-permissive-provenance", "-Zmiri-disable-alignment-check"],
             |env| env.miri("bsan-rt", args),
         )
+    }
+
+    fn install(&self, env: &mut BsanEnv, args: &[String]) -> Result<()> {
+        env.in_mode(Mode::Release, |env| {
+            self.build(env, args)?;
+            let runtime = env.assert_artifact(&self.artifact(env));
+            env.copy_to_sysroot_libdir(&runtime)
+        })
     }
 }
 

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -156,7 +156,9 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
     for arg in
         ArgSplitFlagValue::from_string_iter(&mut args, "--target-dir").filter_map(Result::err)
     {
-        cmd.arg(arg);
+        if arg != "--nop" {
+            cmd.arg(arg);
+        }
     }
     cmd.args(args);
 
@@ -277,13 +279,22 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
 }
 
 fn bsan_rustflags(env: &EnvConfig, deps: &Dependencies, llvm_tools: &LlvmTools) -> Vec<String> {
-    let rt_dir = deps.runtime.parent().unwrap();
     let mut additional_args =
         BSAN_DEFAULT_RUSTFLAGS.iter().map(ToString::to_string).collect::<Vec<_>>();
-    additional_args.push(format!("-L{}", rt_dir.display()));
-    additional_args.push(String::from("-lstatic=bsan_rt"));
+
+    if !env.nop {
+        let (rust_include, rust_lib) = deps.rust_runtime();
+        additional_args.push(format!("-L{}", rust_include.display()));
+        additional_args.push(format!("-lstatic={rust_lib}"));
+    }
+
+    let (llvm_include, llvm_lib) = deps.llvm_runtime();
+    additional_args.push(format!("-L{}", llvm_include.display()));
+    additional_args.push(format!("-lstatic={llvm_lib}"));
+
     additional_args.push(format!("-Clinker={}", llvm_tools.clang.display()));
     additional_args.push(format!("-Clink-arg=-fuse-ld={}", llvm_tools.lld.display()));
+
     if env.lto {
         additional_args.push(String::from("-Clinker-plugin-lto"));
         additional_args

--- a/cargo-bsan/src/setup.rs
+++ b/cargo-bsan/src/setup.rs
@@ -3,7 +3,7 @@
 //! to comments and the names of environment variables.
 use std::env;
 use std::ffi::OsStr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 
 use rustc_build_sysroot::{BuildMode, SysrootBuilder, SysrootConfig, SysrootStatus};
@@ -21,6 +21,7 @@ pub struct EnvConfig {
     pub verbose: bool,
     pub quiet: bool,
     pub lto: bool,
+    pub nop: bool,
 }
 
 impl EnvConfig {
@@ -28,14 +29,16 @@ impl EnvConfig {
         let verbose = has_arg_flag("-v");
         let quiet = has_arg_flag("-q") || has_arg_flag("--quiet");
         let lto = has_arg_flag("--lto");
-        Self { verbose, quiet, lto }
+        let nop = has_arg_flag("--nop");
+        Self { verbose, quiet, lto, nop }
     }
 
     pub fn from_env() -> Self {
         let verbose = env::var_os("BSAN_VERBOSE").is_some();
         let quiet = env::var_os("BSAN_QUIET").is_some();
         let lto = env::var_os("BSAN_LTO").is_some();
-        Self { verbose, quiet, lto }
+        let nop: bool = env::var_os("BSAN_NOP").is_some();
+        Self { verbose, quiet, lto, nop }
     }
 
     pub fn populate_env(&self, cmd: &mut Command) {
@@ -48,11 +51,15 @@ impl EnvConfig {
         if self.lto {
             cmd.env("BSAN_LTO", "1");
         }
+        if self.nop {
+            cmd.env("BSAN_NOP", "1");
+        }
     }
 }
 
 pub struct Dependencies {
-    pub runtime: PathBuf,
+    pub rust_runtime: PathBuf,
+    pub llvm_runtime: PathBuf,
     pub llvm_pass: PathBuf,
 }
 
@@ -78,9 +85,16 @@ impl Dependencies {
             );
         };
 
-        let nop = env::var_os("BSAN_NOP").is_some();
+        let rust_runtime_name = format!("{RUST_RT}.a");
+        let Some(rust_runtime) =
+            ensure_library_var("BSAN_RT_RUST", host_sysroot, &rust_runtime_name)
+        else {
+            show_error!(
+                "failed to locate the BorrowSanitizer core runtime ({rust_runtime_name}) within the host sysroot."
+            );
+        };
 
-        let runtime_libname = if nop {
+        let llvm_runtime_name = {
             let host = &version.host;
             let components: Vec<&str> = host.split("-").collect();
             if let Some(arch) = components.first() {
@@ -90,28 +104,55 @@ impl Dependencies {
                     "Failed to resolve the host architecture from the target triple: {host}"
                 );
             }
-        } else {
-            format!("{RUST_RT}.a")
         };
-
-        let Some(runtime) = ensure_library_var("BSAN_RT", host_sysroot, &runtime_libname) else {
+        let Some(llvm_runtime) =
+            ensure_library_var("BSAN_RT_LLVM", host_sysroot, &llvm_runtime_name)
+        else {
             show_error!(
-                "failed to locate the BorrowSanitizer runtime ({runtime_libname}) within the host sysroot."
+                "failed to locate the BorrowSanitizer LLVM runtime ({llvm_runtime_name}) within the host sysroot."
             );
         };
 
-        Self { runtime, llvm_pass }
+        Self { rust_runtime, llvm_runtime, llvm_pass }
     }
 
     pub fn populate_env(&self, cmd: &mut Command) {
-        cmd.env("BSAN_RT", &self.runtime);
+        cmd.env("BSAN_RT_LLVM", &self.llvm_runtime);
+        cmd.env("BSAN_RT_RUST", &self.rust_runtime);
         cmd.env("BSAN_PLUGIN", &self.llvm_pass);
     }
 
     pub fn from_env() -> Self {
-        let runtime = expect_env_path("BSAN_RT");
+        let llvm_runtime = expect_env_path("BSAN_RT_LLVM");
+        let rust_runtime = expect_env_path("BSAN_RT_RUST");
         let llvm_pass = expect_env_path("BSAN_PLUGIN");
-        Self { runtime, llvm_pass }
+        Self { rust_runtime, llvm_runtime, llvm_pass }
+    }
+
+    pub fn llvm_runtime(&self) -> (PathBuf, String) {
+        Self::rt_include(&self.llvm_runtime).unwrap_or_else(|| {
+            show_error!(
+                "Invalid format for LLVM runtime (`BSAN_RT_LLVM`): {}",
+                self.llvm_runtime.display()
+            )
+        })
+    }
+
+    pub fn rust_runtime(&self) -> (PathBuf, String) {
+        Self::rt_include(&self.rust_runtime).unwrap_or_else(|| {
+            show_error!(
+                "Invalid format for LLVM runtime (`BSAN_RT_RUST`): {}",
+                self.llvm_runtime.display()
+            )
+        })
+    }
+
+    fn rt_include(runtime: &Path) -> Option<(PathBuf, String)> {
+        let parent_dir = runtime.parent().map(|p| p.to_path_buf())?;
+        let file_name = runtime.file_name().and_then(|n| n.to_str())?;
+        let stem = file_name.strip_suffix(".a")?;
+        let link_name = stem.strip_prefix("lib")?.to_string();
+        Some((parent_dir, link_name))
     }
 }
 

--- a/tests/test-cargo-bsan/Cargo.toml
+++ b/tests/test-cargo-bsan/Cargo.toml
@@ -4,3 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+
+
+[features]
+nop = []

--- a/tests/test-cargo-bsan/run_test.py
+++ b/tests/test-cargo-bsan/run_test.py
@@ -19,6 +19,8 @@ def cargo_bsan(cmd, quiet=True, nop=False):
     args = ["cargo", "bsan", cmd] + CARGO_EXTRA_FLAGS
     if quiet:
         args += ["-q"]
+    if nop:
+        args += ["--nop"]
     return args
 
 
@@ -147,9 +149,8 @@ def test_cargo_bsan_run():
     )
     test(
         "`cargo bsan run` (nop)",
-        cargo_bsan("run"),
+        cargo_bsan("run", nop=True),
         stdout_ref="run.stdout.ref",
-        env={"BSAN_NOP": "1"},
     )
     test_no_rebuild(
         "`cargo bsan run` (no rebuild)",
@@ -164,9 +165,8 @@ def test_cargo_bsan_test():
     )
     test(
         "`cargo bsan test` (nop)",
-        cargo_bsan("test"),
+        cargo_bsan("test", nop=True),
         stdout_ref="test.stdout.ref",
-        env={"BSAN_NOP": "1"},
     )
 
 args_parser = argparse.ArgumentParser(description="`cargo bsan` testing")
@@ -178,7 +178,9 @@ ARGS = args_parser.parse_args()
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))
 
-execute(["cargo", "clean"])
+# remove the target directory for the
+# current test crate
+execute(["rm", "-rf", "target"])
 test_cargo_bsan_setup()
 test_cargo_bsan_run()
 test_cargo_bsan_test()

--- a/tests/test-cargo-bsan/run_test.py
+++ b/tests/test-cargo-bsan/run_test.py
@@ -21,6 +21,7 @@ def cargo_bsan(cmd, quiet=True, nop=False):
         args += ["-q"]
     if nop:
         args += ["--nop"]
+        args += ["-F nop"]
     return args
 
 
@@ -166,7 +167,7 @@ def test_cargo_bsan_test():
     test(
         "`cargo bsan test` (nop)",
         cargo_bsan("test", nop=True),
-        stdout_ref="test.stdout.ref",
+        stdout_ref="test.nop.stdout.ref",
     )
 
 args_parser = argparse.ArgumentParser(description="`cargo bsan` testing")

--- a/tests/test-cargo-bsan/src/main.rs
+++ b/tests/test-cargo-bsan/src/main.rs
@@ -6,3 +6,19 @@ fn main() {
 fn default() {
     assert!(true)
 }
+
+
+// We add in UB that would otherwise
+// be detected.
+#[test]
+#[cfg(feature = "nop")]
+fn nop() {
+    let mut x = 1;
+    let rx = &mut x;
+    let ptr_x = rx as *mut i32;
+    let vx = &mut x;
+    *vx = 2;
+    unsafe {
+        *ptr_x = 1;
+    }
+}

--- a/tests/test-cargo-bsan/test.nop.stdout.ref
+++ b/tests/test-cargo-bsan/test.nop.stdout.ref
@@ -1,0 +1,21 @@
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+
+running 2 tests
+..
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+
+running 2 tests
+..
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+
+running 2 tests
+..
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in $TIME
+
+all doctests ran in $TIME; merged doctests compilation took $TIME


### PR DESCRIPTION
Our nop mode was not actually nop-ing. There were a few functions and statics (`__bsan_shadow`, `__bsan_rc_store`, `__BSAN_HAD_ERROR`, `__BSAN_BOR_TAG_CTR`) that did not have corresponding weak definitions in the LLVM wrapper.

This PR adds these definitions and fixes another, related problem. Originally, we combined the LLVM and the Rust runtimes into a single static archive, but this prevents strong symbols from overriding weak symbols. Up until now, we were able to accidentally avoid this problem due to the missing weak symbols. 

This PR solves this by linking our LLVM and Rust runtimes separately, with the Rust one coming first. Our `cargo-bsan` plugin uses two separate environment variables (`BSAN_RT_LLVM`, `BSAN_RT_RUST`) to record the paths to each static archive throughout the build process. This also removes the `BsanRtCore` step from our build script. When using `xb`, the keyword `bsan-rt` now only refers to the Rust component, while `compiler-rt` refers to the LLVM wrapper.