### PR TITLE
Remove images that are more than one month old

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -133,3 +133,28 @@ jobs:
           run: |
             docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
               $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+
+    # we remove all images that are more than one month old
+    cleanup:
+      runs-on: ubuntu-latest
+      needs: merge
+      steps:
+        - name: Login
+          uses: docker/login-action@v3.0.0
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Fetch multi-platform package version SHAs
+          id: multi-arch-digests
+          run: |
+            package=$(docker manifest inspect ghcr.io/borrowsanitizer/bsan | jq -r '.manifests.[] | .digest' | paste -s -d ' ' -)
+            echo "multi-arch-digests=$package" >> $GITHUB_OUTPUT
+        - uses: snok/container-retention-policy@v3.0.1
+          with:
+            account: borrowsanitizer
+            token: ${{ secrets.GITHUB_TOKEN }}
+            image-names: bsan
+            cut-off: 1months
+            skip-shas: ${{ steps.multi-arch-digests.outputs.multi-arch-digests }}
+            tag-selection: both


### PR DESCRIPTION
Adds a final `cleanup` step to building our Docker image, which removes any images that are more than one month old.