### PR TITLE
Get repo stats and check for fixed tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,7 @@ name = "bsan"
 version = "0.1.0"
 dependencies = [
  "colored",
+ "libc",
  "regex",
  "rustc_version",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ ui_test = "0.30.2"
 rustc_version = "0.4"
 regex = "1.12.2"
 tempfile = "3"
+libc = "0.2.186"
 
 [[test]]
 name = "ui"

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -57,6 +57,7 @@ impl Command {
                 Ok(())
             }),
             Command::Inst { file, debug, args } => Self::inst(env, file, debug, &args),
+            Command::Fix => Self::fix(env),
             Command::Stats => Self::stats(env),
         }
     }
@@ -78,42 +79,14 @@ impl Command {
     }
 
     fn ui(env: &mut BsanEnv, bless: bool) -> Result<()> {
-        let sysroot_dir = path!(&env.build_dir / "sysroot");
-        env.sh.set_var("BSAN_SYSROOT", &sysroot_dir);
-
-        env.in_mode(Mode::Release, |env| {
-            let args = &[];
-            let mut env_guards = vec![];
-            let cargo_bsan = env.build_artifact(CargoBsan, args)?;
-            let rust_runtime = env.build_artifact(BsanRt, args)?;
-            let llvm_runtime = env.build_artifact(CompilerRt, args)?;
-
-            let pass = env.build_artifact(BsanPass, args)?;
-            let symbolizer = env.sysroot_binary("llvm-symbolizer");
-
-            env_guards.push(env.sh.push_env("BSAN_RT_RUST", &rust_runtime));
-            env_guards.push(env.sh.push_env("BSAN_RT_LLVM", &llvm_runtime));
-
-            env_guards.push(env.sh.push_env("BSAN_PLUGIN", &pass));
-            env_guards.push(env.sh.push_env("BSAN_SYMBOLIZER", &symbolizer));
-            env_guards.push(env.sh.push_env("CARGO_BSAN", &cargo_bsan));
-
-            cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;
-            let rustflags = cmd!(env.sh, "{cargo_bsan} bsan setup --print-rustflags").output()?;
-            let rustflags = String::from_utf8(rustflags.stdout)?;
-
-            env_guards.push(env.sh.push_env("BSAN_RUSTFLAGS", rustflags.trim()));
-
-            let add_bless = if bless { "--bless" } else { "" };
-            cmd!(env.sh, "cargo test -p bsan --test ui -- {add_bless}").run()?;
-            Ok(())
-        })?;
+        run_tests(env, bless, false)?;
 
         crate::all_components!().iter().try_for_each(|c| c.install(env, &[]))?;
 
         let cargo_test_path = path!(env.build_dir / "bsan");
         cmd!(env.sh, "rm -rf {cargo_test_path}").run()?;
         cmd!(env.sh, "python3 tests/test-cargo-bsan/run_test.py").run()?;
+        Self::stats(env)?;
         Ok(())
     }
 
@@ -236,6 +209,48 @@ impl Command {
 
         Ok(())
     }
+
+    fn fix(env: &mut BsanEnv) -> Result<()> {
+        run_tests(env, false, true)?;
+        Ok(())
+    }
+}
+
+fn run_tests(env: &mut BsanEnv, bless: bool, fix: bool) -> Result<(), anyhow::Error> {
+    let sysroot_dir = path!(&env.build_dir / "sysroot");
+    env.sh.set_var("BSAN_SYSROOT", &sysroot_dir);
+    env.in_mode(Mode::Release, |env| {
+        let args = &[];
+        let mut env_guards = vec![];
+        let cargo_bsan = env.build_artifact(CargoBsan, args)?;
+        let rust_runtime = env.build_artifact(BsanRt, args)?;
+        let llvm_runtime = env.build_artifact(CompilerRt, args)?;
+
+        let pass = env.build_artifact(BsanPass, args)?;
+        let symbolizer = env.sysroot_binary("llvm-symbolizer");
+
+        env_guards.push(env.sh.push_env("BSAN_RT_RUST", &rust_runtime));
+        env_guards.push(env.sh.push_env("BSAN_RT_LLVM", &llvm_runtime));
+
+        env_guards.push(env.sh.push_env("BSAN_PLUGIN", &pass));
+        env_guards.push(env.sh.push_env("BSAN_SYMBOLIZER", &symbolizer));
+        env_guards.push(env.sh.push_env("CARGO_BSAN", &cargo_bsan));
+
+        if fix {
+            env_guards.push(env.sh.push_env("BSAN_FIX", "true"));
+        }
+
+        cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;
+        let rustflags = cmd!(env.sh, "{cargo_bsan} bsan setup --print-rustflags").output()?;
+        let rustflags = String::from_utf8(rustflags.stdout)?;
+
+        env_guards.push(env.sh.push_env("BSAN_RUSTFLAGS", rustflags.trim()));
+
+        let add_bless = if bless { "--bless" } else { "" };
+        cmd!(env.sh, "cargo test -p bsan --test ui -- {add_bless}").run()?;
+        Ok(())
+    })?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -164,8 +164,10 @@ impl Command {
         let pass = count_rs(&path!(root / "tests" / "pass"))?
             + count_rs(&path!(root / "tests" / "pass-dep"))?;
         let miri_pass = count_rs(&path!(root / "tests" / "miri-tests" / "pass"))?;
-        let fail = count_rs(&path!(root / "tests" / "fail"))?;
+        let fail = count_rs(&path!(root / "tests" / "fail"))?
+            + count_rs(&path!(root / "tests" / "fail-dep"))?;
         let miri_fail = count_rs(&path!(root / "tests" / "miri-tests" / "fail"))?;
+        let mirilli_fail = count_rs(&path!(root / "tests" / "fail-dep" / "mirilli"))?;
         let miri_should_pass = count_rs(&path!(root / "tests" / "miri-tests" / "should-pass"))?;
         let miri_should_fail = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
         let total_pass = pass + miri_pass + miri_should_pass;
@@ -185,6 +187,7 @@ impl Command {
             fmt_percent(fail + miri_fail, total_fail)
         );
         println!("  ├─ original tests: {}", fail);
+        println!("  ├─ mirilli tests: {}", mirilli_fail);
         println!("  └─ miri tests: {}", miri_fail);
 
         println!(

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -237,15 +237,7 @@ fn run_tests(env: &mut BsanEnv, bless: bool, fix: bool) -> Result<(), anyhow::Er
         env_guards.push(env.sh.push_env("CARGO_BSAN", &cargo_bsan));
 
         if fix {
-            let root = &env.root_dir;
-            let miri_sp = count_rs(&path!(root / "tests" / "miri-tests" / "should-pass"))?;
-            let miri_sf = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
-            if miri_sp > 0 {
-                env_guards.push(env.sh.push_env("BSAN_SP", miri_sp.to_string()));
-            }
-            if miri_sf > 0 {
-                env_guards.push(env.sh.push_env("BSAN_SF", miri_sf.to_string()));
-            }
+            env_guards.push(env.sh.push_env("BSAN_FIX", "true"));
         }
 
         cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use clap::ValueEnum;
@@ -56,6 +56,7 @@ impl Command {
                 Ok(())
             }),
             Command::Inst { file, debug, args } => Self::inst(env, file, debug, &args),
+            Command::Metrics => Self::metrics(env),
         }
     }
 
@@ -182,6 +183,56 @@ impl Command {
 
             Ok(())
         })
+    }
+
+    fn metrics(env: &mut BsanEnv) -> Result<()> {
+        fn count_rs(path: &Path) -> Result<usize> {
+            if !path.exists() {
+                return Ok(0);
+            }
+            let mut cnt = 0usize;
+            for entry in fs::read_dir(path)? {
+                let entry = entry?;
+                let p = entry.path();
+                if p.is_dir() {
+                    cnt += count_rs(&p)?;
+                } else if p.extension().and_then(|s| s.to_str()) == Some("rs") {
+                    cnt += 1;
+                }
+            }
+            Ok(cnt)
+        }
+
+        let root = &env.root_dir;
+        let pass = count_rs(&path!(root / "tests" / "pass"))?;
+        let pass_dep = count_rs(&path!(root / "tests" / "pass-dep"))?;
+        let miri_pass = count_rs(&path!(root / "tests" / "miri-tests" / "pass"))?;
+        let fail = count_rs(&path!(root / "tests" / "fail"))?;
+        let miri_fail = count_rs(&path!(root / "tests" / "miri-tests" / "fail"))?;
+        let miri_should_pass = count_rs(&path!(root / "tests" / "miri-tests" / "should-pass"))?;
+        let miri_should_fail = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
+
+        let tn_regular = pass + pass_dep;
+        let tn_miri = miri_pass;
+        let tn_total = tn_regular + tn_miri;
+
+        let tp_regular = fail;
+        let tp_miri = miri_fail;
+        let tp_total = tp_regular + tp_miri;
+
+        println!();
+        println!("True negative (passing) tests: {}", tn_total);
+        println!("  - bsan tests: {}", tn_regular);
+        println!("  - miri tests: {}", tn_miri);
+
+        println!("True positive (failing) tests: {}", tp_total);
+        println!("  - bsan tests: {}", tp_regular);
+        println!("  - miri tests: {}", tp_miri);
+
+        println!("False positive (should pass) tests: {}", miri_should_pass);
+        println!("False negative (should fail) tests: {}", miri_should_fail);
+
+        Ok(())
     }
 }
 

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -188,29 +188,47 @@ impl Command {
 
     fn stats(env: &mut BsanEnv) -> Result<()> {
         let root = &env.root_dir;
-        let pass = count_rs(&path!(root / "tests" / "pass"))?;
-        let pass_dep = count_rs(&path!(root / "tests" / "pass-dep"))?;
+        let pass = count_rs(&path!(root / "tests" / "pass"))?
+            + count_rs(&path!(root / "tests" / "pass-dep"))?;
         let miri_pass = count_rs(&path!(root / "tests" / "miri-tests" / "pass"))?;
         let fail = count_rs(&path!(root / "tests" / "fail"))?;
         let miri_fail = count_rs(&path!(root / "tests" / "miri-tests" / "fail"))?;
         let miri_should_pass = count_rs(&path!(root / "tests" / "miri-tests" / "should-pass"))?;
         let miri_should_fail = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
+        let total_pass = pass + miri_pass + miri_should_pass;
+        let total_fail = fail + miri_fail + miri_should_fail;
 
         println!();
-        println!("True negative (pass) tests: {}", pass + pass_dep + miri_pass);
-        println!("  ├─ bsan tests: {}", pass + pass_dep);
+        println!(
+            "True negative (pass) tests: {} ({})",
+            pass + miri_pass,
+            fmt_percent(pass + miri_pass, total_pass)
+        );
+        println!("  ├─ original tests: {}", pass);
         println!("  └─ miri tests: {}", miri_pass);
-        println!("True positive (fail) tests: {}", fail + miri_fail);
-        println!("  ├─ bsan tests: {}", fail);
+        println!(
+            "True positive (fail) tests: {} ({})",
+            fail + miri_fail,
+            fmt_percent(fail + miri_fail, total_fail)
+        );
+        println!("  ├─ original tests: {}", fail);
         println!("  └─ miri tests: {}", miri_fail);
 
-        println!("False positive (should pass) tests: {}", miri_should_pass);
+        println!(
+            "False positive (should pass) tests: {} ({})",
+            miri_should_pass,
+            fmt_percent(miri_should_pass, total_pass)
+        );
         let should_pass_root = path!(root / "tests" / "miri-tests" / "should-pass");
         if should_pass_root.exists() {
             print_tree(&should_pass_root, "  ")?;
         }
 
-        println!("False negative (should fail) tests: {}", miri_should_fail);
+        println!(
+            "False negative (should fail) tests: {} ({})",
+            miri_should_fail,
+            fmt_percent(miri_should_fail, total_fail)
+        );
         let should_fail_root = path!(root / "tests" / "miri-tests" / "should-fail");
         if should_fail_root.exists() {
             print_tree(&should_fail_root, "  ")?;

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::ValueEnum;
@@ -9,6 +9,7 @@ use path_macro::path;
 use xshell::cmd;
 
 use crate::env::{BsanEnv, Mode};
+use crate::stats::*;
 use crate::utils::install_git_hooks;
 use crate::Command;
 
@@ -56,7 +57,7 @@ impl Command {
                 Ok(())
             }),
             Command::Inst { file, debug, args } => Self::inst(env, file, debug, &args),
-            Command::Metrics => Self::metrics(env),
+            Command::Stats => Self::stats(env),
         }
     }
 
@@ -185,24 +186,7 @@ impl Command {
         })
     }
 
-    fn metrics(env: &mut BsanEnv) -> Result<()> {
-        fn count_rs(path: &Path) -> Result<usize> {
-            if !path.exists() {
-                return Ok(0);
-            }
-            let mut cnt = 0usize;
-            for entry in fs::read_dir(path)? {
-                let entry = entry?;
-                let p = entry.path();
-                if p.is_dir() {
-                    cnt += count_rs(&p)?;
-                } else if p.extension().and_then(|s| s.to_str()) == Some("rs") {
-                    cnt += 1;
-                }
-            }
-            Ok(cnt)
-        }
-
+    fn stats(env: &mut BsanEnv) -> Result<()> {
         let root = &env.root_dir;
         let pass = count_rs(&path!(root / "tests" / "pass"))?;
         let pass_dep = count_rs(&path!(root / "tests" / "pass-dep"))?;
@@ -212,25 +196,25 @@ impl Command {
         let miri_should_pass = count_rs(&path!(root / "tests" / "miri-tests" / "should-pass"))?;
         let miri_should_fail = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
 
-        let tn_regular = pass + pass_dep;
-        let tn_miri = miri_pass;
-        let tn_total = tn_regular + tn_miri;
-
-        let tp_regular = fail;
-        let tp_miri = miri_fail;
-        let tp_total = tp_regular + tp_miri;
-
         println!();
-        println!("True negative (passing) tests: {}", tn_total);
-        println!("  - bsan tests: {}", tn_regular);
-        println!("  - miri tests: {}", tn_miri);
-
-        println!("True positive (failing) tests: {}", tp_total);
-        println!("  - bsan tests: {}", tp_regular);
-        println!("  - miri tests: {}", tp_miri);
+        println!("True negative (pass) tests: {}", pass + pass_dep + miri_pass);
+        println!("  ├─ bsan tests: {}", pass + pass_dep);
+        println!("  └─ miri tests: {}", miri_pass);
+        println!("True positive (fail) tests: {}", fail + miri_fail);
+        println!("  ├─ bsan tests: {}", fail);
+        println!("  └─ miri tests: {}", miri_fail);
 
         println!("False positive (should pass) tests: {}", miri_should_pass);
+        let should_pass_root = path!(root / "tests" / "miri-tests" / "should-pass");
+        if should_pass_root.exists() {
+            print_tree(&should_pass_root, "  ")?;
+        }
+
         println!("False negative (should fail) tests: {}", miri_should_fail);
+        let should_fail_root = path!(root / "tests" / "miri-tests" / "should-fail");
+        if should_fail_root.exists() {
+            print_tree(&should_fail_root, "  ")?;
+        }
 
         Ok(())
     }

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -237,7 +237,15 @@ fn run_tests(env: &mut BsanEnv, bless: bool, fix: bool) -> Result<(), anyhow::Er
         env_guards.push(env.sh.push_env("CARGO_BSAN", &cargo_bsan));
 
         if fix {
-            env_guards.push(env.sh.push_env("BSAN_FIX", "true"));
+            let root = &env.root_dir;
+            let miri_sp = count_rs(&path!(root / "tests" / "miri-tests" / "should-pass"))?;
+            let miri_sf = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
+            if miri_sp > 0 {
+                env_guards.push(env.sh.push_env("BSAN_SP", miri_sp.to_string()));
+            }
+            if miri_sf > 0 {
+                env_guards.push(env.sh.push_env("BSAN_SF", miri_sf.to_string()));
+            }
         }
 
         cmd!(env.sh, "{cargo_bsan} bsan setup").run()?;

--- a/bsan-script/src/main.rs
+++ b/bsan-script/src/main.rs
@@ -122,6 +122,8 @@ pub enum Command {
         #[arg(allow_hyphen_values(true), last(true))]
         args: Vec<String>,
     },
+    /// Try all `should-*` tests
+    Fix,
     /// Show repository test metrics (counts of passing/failing/false positives/negatives)
     Stats,
 }

--- a/bsan-script/src/main.rs
+++ b/bsan-script/src/main.rs
@@ -9,6 +9,7 @@ use commands::Component;
 mod commands;
 mod env;
 mod setup;
+mod stats;
 mod utils;
 
 static TOOLCHAIN_NAME: &str = "bsan";
@@ -122,7 +123,7 @@ pub enum Command {
         args: Vec<String>,
     },
     /// Show repository test metrics (counts of passing/failing/false positives/negatives)
-    Metrics,
+    Stats,
 }
 
 #[derive(Parser)]

--- a/bsan-script/src/main.rs
+++ b/bsan-script/src/main.rs
@@ -121,6 +121,8 @@ pub enum Command {
         #[arg(allow_hyphen_values(true), last(true))]
         args: Vec<String>,
     },
+    /// Show repository test metrics (counts of passing/failing/false positives/negatives)
+    Metrics,
 }
 
 #[derive(Parser)]

--- a/bsan-script/src/stats.rs
+++ b/bsan-script/src/stats.rs
@@ -1,0 +1,43 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+
+pub(crate) fn count_rs(path: &Path) -> Result<usize> {
+    if !path.exists() {
+        return Ok(0);
+    }
+    let mut cnt = 0;
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let p = entry.path();
+        if p.is_dir() {
+            cnt += count_rs(&p)?;
+        } else if p.extension().and_then(|s| s.to_str()) == Some("rs") {
+            cnt += 1;
+        }
+    }
+    Ok(cnt)
+}
+
+pub(crate) fn print_tree(dir: &Path, prefix: &str) -> Result<()> {
+    let mut dirs: Vec<_> = fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    dirs.sort();
+    for (i, p) in dirs.iter().enumerate() {
+        let name = p
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| p.to_string_lossy().into_owned());
+        let is_last = i + 1 == dirs.len();
+        let connector = if is_last { "└─" } else { "├─" };
+        println!("{}{} {}: {}", prefix, connector, name, count_rs(p)?);
+        let child_prefix =
+            if is_last { format!("{}   ", prefix) } else { format!("{}│  ", prefix) };
+        print_tree(p, &child_prefix)?;
+    }
+    Ok(())
+}

--- a/bsan-script/src/stats.rs
+++ b/bsan-script/src/stats.rs
@@ -41,3 +41,11 @@ pub(crate) fn print_tree(dir: &Path, prefix: &str) -> Result<()> {
     }
     Ok(())
 }
+
+pub(crate) fn fmt_percent(value: usize, total: usize) -> String {
+    if total == 0 {
+        "N/A".to_string()
+    } else {
+        format!("{:.2}%", value as f64 / total as f64 * 100.0)
+    }
+}

--- a/tests/fix_utils.rs
+++ b/tests/fix_utils.rs
@@ -1,0 +1,145 @@
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use ui_test::status_emitter::{RevisionStyle, StatusEmitter, Summary, TestStatus};
+
+type FailedOutput = (PathBuf, Vec<u8>);
+
+#[derive(Default)]
+pub struct FixResult {
+    pub failed: usize,
+    pub aborted: usize,
+    pub results: Vec<FailedOutput>,
+}
+
+pub struct FixEmitter {
+    inner: Box<dyn StatusEmitter>,
+    failed: Arc<AtomicUsize>,
+    aborted: Arc<AtomicUsize>,
+    last_progress: Arc<AtomicU64>,
+    start: Instant,
+}
+
+struct FixStatus {
+    inner: Box<dyn TestStatus>,
+    aborted: Arc<AtomicUsize>,
+    last_progress: Arc<AtomicU64>,
+    start: Instant,
+}
+
+impl FixEmitter {
+    pub fn new(
+        inner: Box<dyn StatusEmitter>,
+        failed: Arc<AtomicUsize>,
+        aborted: Arc<AtomicUsize>,
+        last_progress: Arc<AtomicU64>,
+        start: Instant,
+    ) -> Self {
+        Self { inner, failed, aborted, last_progress, start }
+    }
+}
+
+impl StatusEmitter for FixEmitter {
+    fn register_test(&self, name: PathBuf) -> Box<dyn TestStatus> {
+        let status = self.inner.register_test(name);
+        Box::new(FixStatus {
+            inner: status,
+            aborted: Arc::clone(&self.aborted),
+            last_progress: Arc::clone(&self.last_progress),
+            start: self.start,
+        })
+    }
+
+    fn finalize(
+        &self,
+        failed: usize,
+        succeeded: usize,
+        ignored: usize,
+        filtered: usize,
+        aborted: bool,
+    ) -> Box<dyn Summary> {
+        self.failed.store(failed, Ordering::SeqCst);
+        let _ = self.inner.finalize(failed, succeeded, ignored, filtered, aborted);
+        Box::new(())
+    }
+}
+
+impl TestStatus for FixStatus {
+    fn for_revision(&self, revision: &str, style: RevisionStyle) -> Box<dyn TestStatus> {
+        Box::new(FixStatus {
+            inner: self.inner.for_revision(revision, style),
+            aborted: Arc::clone(&self.aborted),
+            last_progress: Arc::clone(&self.last_progress),
+            start: self.start,
+        })
+    }
+
+    fn for_path(&self, path: &Path) -> Box<dyn TestStatus> {
+        Box::new(FixStatus {
+            inner: self.inner.for_path(path),
+            aborted: Arc::clone(&self.aborted),
+            last_progress: Arc::clone(&self.last_progress),
+            start: self.start,
+        })
+    }
+
+    fn failed_test<'a>(
+        &'a self,
+        cmd: &'a str,
+        stderr: &'a [u8],
+        stdout: &'a [u8],
+    ) -> Box<dyn std::fmt::Debug + 'a> {
+        self.inner.failed_test(cmd, stderr, stdout)
+    }
+
+    fn done(&self, result: &ui_test::test_result::TestResult, aborted: bool) {
+        if aborted {
+            self.aborted.fetch_add(1, Ordering::SeqCst);
+        }
+        self.last_progress.store(self.start.elapsed().as_secs(), Ordering::SeqCst);
+        self.inner.done(result, aborted);
+    }
+
+    fn path(&self) -> &Path {
+        self.inner.path()
+    }
+
+    fn revision(&self) -> &str {
+        self.inner.revision()
+    }
+}
+
+pub fn kill_descendants(root_pid: i32) {
+    let entries = match std::fs::read_dir("/proc") {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let pid: i32 = match entry.file_name().to_string_lossy().parse() {
+            Ok(pid) => pid,
+            Err(_) => continue,
+        };
+        let stat = match std::fs::read_to_string(entry.path().join("stat")) {
+            Ok(stat) => stat,
+            Err(_) => continue,
+        };
+        let rest = match stat.rsplit_once(")") {
+            Some((_, rest)) => rest.trim(),
+            None => continue,
+        };
+        let mut parts = rest.split_whitespace();
+        let _state = parts.next();
+        let ppid: i32 = match parts.next().and_then(|val| val.parse().ok()) {
+            Some(ppid) => ppid,
+            None => continue,
+        };
+        if ppid == root_pid && pid != root_pid {
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+    }
+}

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -3,7 +3,8 @@ use std::ffi::OsString;
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use colored::*;
@@ -13,7 +14,7 @@ use ui_test::color_eyre::eyre::{Context, Result};
 use ui_test::custom_flags::edition::Edition;
 use ui_test::dependencies::DependencyBuilder;
 use ui_test::spanned::Spanned;
-use ui_test::status_emitter::StatusEmitter;
+use ui_test::status_emitter::{StatusEmitter, Summary, TestStatus};
 use ui_test::{CommandBuilder, Config, Match};
 
 #[derive(Copy, Clone, Debug)]
@@ -30,6 +31,34 @@ pub fn flagsplit(flags: &str) -> Vec<String> {
 
 struct WithDependencies {
     bless: bool,
+}
+
+pub struct TestResult {
+    pub failed: usize,
+    pub aborted: bool,
+}
+
+struct FixEmitter {
+    inner: Box<dyn StatusEmitter>,
+    failed: Arc<AtomicUsize>,
+}
+
+impl StatusEmitter for FixEmitter {
+    fn register_test(&self, name: PathBuf) -> Box<dyn TestStatus> {
+        self.inner.register_test(name)
+    }
+
+    fn finalize(
+        &self,
+        failed: usize,
+        succeeded: usize,
+        ignored: usize,
+        filtered: usize,
+        aborted: bool,
+    ) -> Box<dyn Summary> {
+        self.failed.store(failed, Ordering::SeqCst);
+        self.inner.finalize(failed, succeeded, ignored, filtered, aborted)
+    }
 }
 
 fn bsan_config(
@@ -102,8 +131,8 @@ fn run_tests(
     with_dependencies: bool,
     tmpdir: &Path,
     timeout: Option<Duration>,
-) -> Result<()> {
-    // Handle command-line arguments.
+) -> Result<TestResult> {
+    // Handle/ command-line arguments.
     let mut args = ui_test::Args::test()?;
     args.bless |= env::var_os("RUSTC_BLESS").is_some_and(|v| v != "0");
 
@@ -135,22 +164,30 @@ fn run_tests(
 
     config.program.args.push("-Zui-testing".into());
 
+    let aborted = Arc::new(AtomicBool::new(false));
+
     if let Some(timeout) = timeout {
         // Capture our current pgid *before* spawning anything
         let original_pgid = unsafe { libc::getpgrp() };
-
+        let aborted = Arc::clone(&aborted);
         std::thread::spawn(move || {
             std::thread::sleep(timeout);
-
             // Still alive = something is stuck. Detach from the process
             // group so we survive the kill, then kill the stuck children.
             eprintln!("Killing stuck tests after timeout of {} seconds", timeout.as_secs());
+            aborted.store(true, Ordering::SeqCst);
             unsafe {
                 libc::setpgid(0, 0);
                 libc::kill(-original_pgid, libc::SIGKILL);
             }
         });
     }
+
+    let failed = Arc::new(AtomicUsize::new(0));
+    let emitter = FixEmitter {
+        inner: Box::<dyn StatusEmitter>::from(args.format),
+        failed: Arc::clone(&failed),
+    };
 
     eprintln!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
@@ -162,8 +199,11 @@ fn run_tests(
         // This could be used to overwrite the `Config` on a per-test basis.
         |_, _| {},
         // No GHA output as that would also show in the main rustc repo.
-        Box::<dyn StatusEmitter>::from(args.format),
-    )
+        Box::new(emitter),
+    )?;
+    let failed = failed.load(Ordering::SeqCst);
+    let aborted = aborted.load(Ordering::SeqCst);
+    Ok(TestResult { failed, aborted })
 }
 
 macro_rules! regexes {
@@ -246,7 +286,7 @@ fn ui(
     with_dependencies: Dependencies,
     tmpdir: &Path,
     timeout: Option<Duration>,
-) -> Result<()> {
+) -> Result<TestResult> {
     let msg = format!("## Running ui tests in {path} for {}", target.host);
     eprintln!("{}", msg.green().bold());
 
@@ -279,14 +319,14 @@ fn main() -> Result<()> {
     let tmpdir = tempfile::Builder::new().prefix("bsan-uitest-").tempdir()?;
 
     if env::var("BSAN_FIX").is_ok() {
-        let timeout = Some(Duration::from_secs(10));
+        let to = Some(Duration::from_secs(10));
         let should_pass = ui(
             Mode::Pass,
             "tests/miri-tests/should-pass",
             &target,
             WithoutDependencies,
             tmpdir.path(),
-            timeout,
+            to,
         );
         let should_fail = ui(
             Mode::Fail,
@@ -294,10 +334,24 @@ fn main() -> Result<()> {
             &target,
             WithoutDependencies,
             tmpdir.path(),
-            timeout,
+            to,
         );
-        should_pass?;
-        should_fail?;
+        for (name, result) in [("should-pass", should_pass), ("should-fail", should_fail)] {
+            match result {
+                Err(e) => {
+                    eprintln!("{name}: error running tests: {e}");
+                }
+                Ok(TestResult { failed, aborted }) => {
+                    if failed > 0 || aborted {}
+                    if failed > 0 {
+                        eprintln!("{name}: {failed} test(s) failed");
+                    }
+                    if aborted {
+                        eprintln!("{name}: test run was aborted (timeout)");
+                    }
+                }
+            }
+        }
         return Ok(());
     }
 

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -43,10 +43,12 @@ pub struct TestResult {
 struct FixEmitter {
     inner: Box<dyn StatusEmitter>,
     failed: Arc<AtomicUsize>,
+    registered: Arc<AtomicUsize>,
 }
 
 impl StatusEmitter for FixEmitter {
     fn register_test(&self, name: PathBuf) -> Box<dyn TestStatus> {
+        self.registered.fetch_add(1, Ordering::SeqCst);
         self.inner.register_test(name)
     }
 
@@ -169,30 +171,41 @@ fn run_tests(
     // Timeout enabled for fix mode
     if fix_mode {
         let original_pgid = unsafe { libc::getpgrp() };
-        std::thread::spawn(move || {
-            std::thread::sleep(TIMEOUT);
-            // Still alive = something is stuck. Detach from the process
-            // group so we survive the kill, then kill the stuck children.
-            unsafe {
-                libc::setpgid(0, 0);
-                libc::kill(-original_pgid, libc::SIGKILL);
-            }
-        });
-
         let failed = Arc::new(AtomicUsize::new(0));
+        let registered = Arc::new(AtomicUsize::new(0));
         let emitter = FixEmitter {
             inner: Box::<dyn StatusEmitter>::from(args.format),
             failed: Arc::clone(&failed),
+            registered: Arc::clone(&registered),
         };
 
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+
         eprintln!("   Compiler: {}", config.program.display());
-        // We don't care about this report, since we're generating our own with `TestResult`
-        let _ = ui_test::run_tests_generic(
-            vec![config],
-            ui_test::default_file_filter,
-            |_, _| {},
-            Box::new(emitter),
-        );
+        std::thread::spawn(move || {
+            let _ = ui_test::run_tests_generic(
+                vec![config],
+                ui_test::default_file_filter,
+                |_, _| {},
+                Box::new(emitter),
+            );
+            let _ = tx.send(());
+        });
+
+        match rx.recv_timeout(TIMEOUT) {
+            Ok(_) => {}
+            Err(_) => {
+                eprintln!(
+                    "warning: tests did not finish within {TIMEOUT:?}, killing stuck processes..."
+                );
+                unsafe {
+                    libc::setpgid(0, 0);
+                    libc::kill(-original_pgid, libc::SIGKILL);
+                }
+                failed.store(registered.load(Ordering::SeqCst), Ordering::SeqCst);
+            }
+        }
+
         let failed = failed.load(Ordering::SeqCst);
         return Ok(TestResult { failed });
     }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -3,8 +3,7 @@ use std::ffi::OsString;
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use colored::*;
@@ -14,7 +13,7 @@ use ui_test::color_eyre::eyre::{Context, Result};
 use ui_test::custom_flags::edition::Edition;
 use ui_test::dependencies::DependencyBuilder;
 use ui_test::spanned::Spanned;
-use ui_test::status_emitter::{StatusEmitter, Summary, TestStatus};
+use ui_test::status_emitter::StatusEmitter;
 use ui_test::{CommandBuilder, Config, Match};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -33,39 +32,6 @@ pub fn flagsplit(flags: &str) -> Vec<String> {
 
 struct WithDependencies {
     bless: bool,
-}
-
-#[derive(Default)]
-pub struct TestResult {
-    pub failed: usize,
-    pub passed: usize,
-}
-
-struct FixEmitter {
-    inner: Box<dyn StatusEmitter>,
-    failed: Arc<AtomicUsize>,
-    passed: Arc<AtomicUsize>,
-    registered: Arc<AtomicUsize>,
-}
-
-impl StatusEmitter for FixEmitter {
-    fn register_test(&self, name: PathBuf) -> Box<dyn TestStatus> {
-        self.registered.fetch_add(1, Ordering::SeqCst);
-        self.inner.register_test(name)
-    }
-
-    fn finalize(
-        &self,
-        failed: usize,
-        succeeded: usize,
-        ignored: usize,
-        filtered: usize,
-        aborted: bool,
-    ) -> Box<dyn Summary> {
-        self.failed.store(failed, Ordering::SeqCst);
-        self.passed.store(succeeded, Ordering::SeqCst);
-        self.inner.finalize(failed, succeeded, ignored, filtered, aborted)
-    }
 }
 
 fn bsan_config(
@@ -138,7 +104,7 @@ fn run_tests(
     with_dependencies: bool,
     tmpdir: &Path,
     fix_mode: bool,
-) -> Result<TestResult> {
+) -> Result<()> {
     // Handle/ command-line arguments.
     let mut args = ui_test::Args::test()?;
     args.bless |= env::var_os("RUSTC_BLESS").is_some_and(|v| v != "0");
@@ -173,50 +139,22 @@ fn run_tests(
 
     // Timeout enabled for fix mode
     if fix_mode {
+        // Capture our current pgid *before* spawning anything
         let original_pgid = unsafe { libc::getpgrp() };
-        let failed = Arc::new(AtomicUsize::new(0));
-        let passed = Arc::new(AtomicUsize::new(0));
-        let registered = Arc::new(AtomicUsize::new(0));
-        let emitter = FixEmitter {
-            inner: Box::<dyn StatusEmitter>::from(args.format),
-            failed: Arc::clone(&failed),
-            passed: Arc::clone(&passed),
-            registered: Arc::clone(&registered),
-        };
 
-        let (tx, rx) = std::sync::mpsc::channel::<()>();
-
-        eprintln!("   Compiler: {}", config.program.display());
         std::thread::spawn(move || {
-            let _ = ui_test::run_tests_generic(
-                vec![config],
-                ui_test::default_file_filter,
-                |_, _| {},
-                Box::new(emitter),
-            );
-            let _ = tx.send(());
-        });
+            std::thread::sleep(TIMEOUT);
 
-        match rx.recv_timeout(TIMEOUT) {
-            Ok(_) => {}
-            Err(_) => {
-                eprintln!(
-                    "warning: tests did not finish within {TIMEOUT:?}, killing stuck processes..."
-                );
-                unsafe {
-                    libc::setpgid(0, 0);
-                    libc::kill(-original_pgid, libc::SIGKILL);
-                }
-                failed.store(registered.load(Ordering::SeqCst), Ordering::SeqCst);
+            // Still alive = something is stuck. Detach from the process
+            // group so we survive the kill, then kill the stuck children.
+            eprintln!("Killing stuck tests after timeout of {} seconds", TIMEOUT.as_secs());
+            unsafe {
+                libc::setpgid(0, 0);
+                libc::kill(-original_pgid, libc::SIGKILL);
             }
-        }
-
-        let failed = failed.load(Ordering::SeqCst);
-        let passed = passed.load(Ordering::SeqCst);
-        return Ok(TestResult { failed, passed });
+        });
     }
 
-    // Regular UI tests without timeout
     eprintln!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
         // Only run one test suite. In the future we can add all test suites to one `Vec` and run
@@ -229,7 +167,7 @@ fn run_tests(
         // No GHA output as that would also show in the main rustc repo.
         Box::<dyn StatusEmitter>::from(args.format),
     )?;
-    Ok(TestResult::default())
+    Ok(())
 }
 
 macro_rules! regexes {
@@ -312,7 +250,7 @@ fn ui(
     with_dependencies: Dependencies,
     tmpdir: &Path,
     fix_mode: bool,
-) -> Result<TestResult> {
+) -> Result<()> {
     let msg = format!("## Running ui tests in {path} for {}", target.host);
     eprintln!("{}", msg.green().bold());
 
@@ -334,20 +272,12 @@ fn path_from_env(var: &str) -> PathBuf {
     path
 }
 
-fn parse_env_count(var: &str) -> Option<usize> {
-    env::var(var)
-        .ok()
-        .map(|val| val.trim().to_string())
-        .filter(|val| !val.is_empty())
-        .and_then(|val| val.parse::<usize>().ok())
-}
-
 fn get_version_info() -> VersionMeta {
     let cmd = Command::new("rustc");
     VersionMeta::for_command(cmd).expect("Failed to parse rustc version info")
 }
 
-fn check_for_fix(mode: Mode) -> Result<TestResult> {
+fn check_for_fix(mode: Mode) -> Result<()> {
     let target = get_version_info();
     let tmpdir = tempfile::Builder::new().prefix("bsan-uitest-").tempdir()?;
 
@@ -362,50 +292,11 @@ fn check_for_fix(mode: Mode) -> Result<TestResult> {
 fn main() -> Result<()> {
     ui_test::color_eyre::install()?;
 
-    if env::var("BSAN_SP").is_ok() || env::var("BSAN_SF").is_ok() {
-        let sp_count = parse_env_count("BSAN_SP");
-        let sf_count = parse_env_count("BSAN_SF");
-        let sp_run = sp_count.map(|count| (count, check_for_fix(Mode::Pass)));
-        let sf_run = sf_count.map(|count| (count, check_for_fix(Mode::Fail)));
-
-        if let Some((count, result)) = sp_run {
-            match result {
-                Ok(result) => {
-                    if result.passed > 0 {
-                        println!(
-                            "should-pass: {}/{} tests were fixed and now pass without errors!",
-                            result.passed, count
-                        )
-                    }
-                    if result.failed > 0 {
-                        println!(
-                            "should-pass: {}/{} tests did not pass without errors.",
-                            result.failed, count
-                        )
-                    }
-                }
-                Err(err) => eprintln!("should-pass: error running tests: {err}"),
-            }
-        }
-        if let Some((count, result)) = sf_run {
-            match result {
-                Ok(result) => {
-                    if result.passed > 0 {
-                        println!(
-                            "should-faild: {}/{} tests found an error with the correct output!",
-                            result.passed, count
-                        )
-                    }
-                    if result.failed > 0 {
-                        println!(
-                            "should-fail: {}/{} tests did not catch errors.",
-                            result.failed, count
-                        )
-                    }
-                }
-                Err(err) => eprintln!("should-fail: error running tests: {err}"),
-            }
-        }
+    if env::var("BSAN_FIX").is_ok() {
+        let should_pass = check_for_fix(Mode::Pass);
+        let should_fail = check_for_fix(Mode::Fail);
+        should_pass?;
+        should_fail?;
         return Ok(());
     }
 

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -4,7 +4,7 @@ use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use colored::*;
@@ -25,9 +25,12 @@ enum Mode {
     /// Requires annotations
     Fail,
 }
+
+type FailedOutput = (PathBuf, Vec<u8>);
 #[derive(Default)]
 pub struct FixResult {
     pub failed: usize,
+    pub results: Vec<FailedOutput>,
 }
 
 struct FixEmitter {
@@ -167,9 +170,9 @@ fn run_tests(
 
     config.program.args.push("-Zui-testing".into());
 
-    // Timeout enabled for fix mode
+    // Timeout and custom handler enabled for fix mode
     if fix_mode {
-        config.output_conflict_handling = |_path, _actual, _errors, _config| {};
+        static COLLECTED: OnceLock<Mutex<Vec<(PathBuf, Vec<u8>)>>> = OnceLock::new();
         let original_pgid = unsafe { libc::getpgrp() };
         std::thread::spawn(move || {
             std::thread::sleep(TIMEOUT);
@@ -181,6 +184,14 @@ fn run_tests(
             }
         });
 
+        COLLECTED.get_or_init(|| Mutex::new(Vec::new()));
+        // Clear in case of re-use
+        COLLECTED.get().unwrap().lock().unwrap().clear();
+
+        config.output_conflict_handling = |path, actual, _errors, _config| {
+            COLLECTED.get().unwrap().lock().unwrap().push((path.to_path_buf(), actual.to_vec()));
+        };
+
         let failed = Arc::new(AtomicUsize::new(0));
         let emitter = FixEmitter {
             inner: Box::<dyn StatusEmitter>::from(args.format),
@@ -188,7 +199,7 @@ fn run_tests(
         };
 
         eprintln!("   Compiler: {}", config.program.display());
-        // We don't care about this report, since we're generating our own with `TestResult`
+        // We don't care about this report, since we're generating our own with `FixResult`
         let _ = ui_test::run_tests_generic(
             vec![config],
             ui_test::default_file_filter,
@@ -196,7 +207,8 @@ fn run_tests(
             Box::new(emitter),
         );
         let failed = failed.load(Ordering::SeqCst);
-        return Ok(FixResult { failed });
+        let results = COLLECTED.get().unwrap().lock().unwrap().clone();
+        return Ok(FixResult { failed, results });
     }
 
     // Regular UI tests without timeout
@@ -341,6 +353,21 @@ fn check_for_fix(mode: Mode) -> Result<FixResult> {
     ui(mode, path, &target, WithoutDependencies, tmpdir.path(), true)
 }
 
+fn print_errors(result: FixResult) {
+    for (path, output) in result.results {
+        if output.is_empty() || !output.starts_with(b"error: Undefined Behavior:") {
+            continue;
+        }
+        let src = path.with_extension("").with_extension("").with_extension("rs");
+        eprintln!("  ✗ Test failed with output: {}", src.display());
+        let output = String::from_utf8_lossy(&output);
+        for line in output.lines() {
+            eprintln!("    {}", line);
+        }
+        eprintln!();
+    }
+}
+
 fn main() -> Result<()> {
     ui_test::color_eyre::install()?;
 
@@ -350,18 +377,20 @@ fn main() -> Result<()> {
         let sp_run = sp_count.map(|count| (count, check_for_fix(Mode::Pass)));
         let sf_run = sf_count.map(|count| (count, check_for_fix(Mode::Fail)));
         if let Some((count, Ok(result))) = sp_run {
-            println!(
-                "should-pass: {}/{} tests correctly passed with no errors",
+            eprintln!(
+                "SHOULD-PASS: {}/{} tests correctly passed with no errors.\n",
                 count - result.failed,
                 count
             );
+            print_errors(result);
         }
         if let Some((count, Ok(result))) = sf_run {
-            println!(
-                "should-fail: {}/{} tests failed with some bsan errors",
+            eprintln!(
+                "SHOULD-FAIL: {}/{} tests failed with bsan errors.\n",
                 count - result.failed,
                 count
             );
+            print_errors(result);
         }
         return Ok(());
     }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -38,11 +38,13 @@ struct WithDependencies {
 #[derive(Default)]
 pub struct TestResult {
     pub failed: usize,
+    pub passed: usize,
 }
 
 struct FixEmitter {
     inner: Box<dyn StatusEmitter>,
     failed: Arc<AtomicUsize>,
+    passed: Arc<AtomicUsize>,
     registered: Arc<AtomicUsize>,
 }
 
@@ -61,6 +63,7 @@ impl StatusEmitter for FixEmitter {
         aborted: bool,
     ) -> Box<dyn Summary> {
         self.failed.store(failed, Ordering::SeqCst);
+        self.passed.store(succeeded, Ordering::SeqCst);
         self.inner.finalize(failed, succeeded, ignored, filtered, aborted)
     }
 }
@@ -172,10 +175,12 @@ fn run_tests(
     if fix_mode {
         let original_pgid = unsafe { libc::getpgrp() };
         let failed = Arc::new(AtomicUsize::new(0));
+        let passed = Arc::new(AtomicUsize::new(0));
         let registered = Arc::new(AtomicUsize::new(0));
         let emitter = FixEmitter {
             inner: Box::<dyn StatusEmitter>::from(args.format),
             failed: Arc::clone(&failed),
+            passed: Arc::clone(&passed),
             registered: Arc::clone(&registered),
         };
 
@@ -207,7 +212,8 @@ fn run_tests(
         }
 
         let failed = failed.load(Ordering::SeqCst);
-        return Ok(TestResult { failed });
+        let passed = passed.load(Ordering::SeqCst);
+        return Ok(TestResult { failed, passed });
     }
 
     // Regular UI tests without timeout
@@ -364,17 +370,38 @@ fn main() -> Result<()> {
 
         if let Some((count, result)) = sp_run {
             match result {
-                Ok(result) => println!(
-                    "should-pass: {}/{} tests did not pass without errors.",
-                    result.failed, count
-                ),
+                Ok(result) => {
+                    if result.passed > 0 {
+                        println!(
+                            "should-pass: {}/{} tests were fixed and now pass without errors!",
+                            result.passed, count
+                        )
+                    }
+                    if result.failed > 0 {
+                        println!(
+                            "should-pass: {}/{} tests did not pass without errors.",
+                            result.failed, count
+                        )
+                    }
+                }
                 Err(err) => eprintln!("should-pass: error running tests: {err}"),
             }
         }
         if let Some((count, result)) = sf_run {
             match result {
                 Ok(result) => {
-                    println!("should-fail: {}/{} tests did not catch errors.", result.failed, count)
+                    if result.passed > 0 {
+                        println!(
+                            "should-faild: {}/{} tests found an error with the correct output!",
+                            result.passed, count
+                        )
+                    }
+                    if result.failed > 0 {
+                        println!(
+                            "should-fail: {}/{} tests did not catch errors.",
+                            result.failed, count
+                        )
+                    }
                 }
                 Err(err) => eprintln!("should-fail: error running tests: {err}"),
             }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -3,9 +3,9 @@ use std::ffi::OsString;
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use colored::*;
 use regex::bytes::Regex;
@@ -14,48 +14,20 @@ use ui_test::color_eyre::eyre::{Context, Result};
 use ui_test::custom_flags::edition::Edition;
 use ui_test::dependencies::DependencyBuilder;
 use ui_test::spanned::Spanned;
-use ui_test::status_emitter::{StatusEmitter, Summary, TestStatus};
+use ui_test::status_emitter::StatusEmitter;
 use ui_test::{CommandBuilder, Config, Match};
 
-const TIMEOUT: Duration = Duration::from_secs(10);
+mod fix_utils;
+
+use fix_utils::{kill_descendants, FixEmitter, FixResult};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Copy, Clone, Debug)]
 enum Mode {
     Pass,
     /// Requires annotations
     Fail,
-}
-
-type FailedOutput = (PathBuf, Vec<u8>);
-#[derive(Default)]
-pub struct FixResult {
-    pub failed: usize,
-    pub results: Vec<FailedOutput>,
-}
-
-struct FixEmitter {
-    inner: Box<dyn StatusEmitter>,
-    failed: Arc<AtomicUsize>,
-    // registered: Arc<AtomicUsize>,
-}
-
-impl StatusEmitter for FixEmitter {
-    fn register_test(&self, name: PathBuf) -> Box<dyn TestStatus> {
-        // self.registered.fetch_add(1, Ordering::SeqCst);
-        self.inner.register_test(name)
-    }
-
-    fn finalize(
-        &self,
-        failed: usize,
-        succeeded: usize,
-        ignored: usize,
-        filtered: usize,
-        aborted: bool,
-    ) -> Box<dyn Summary> {
-        self.failed.store(failed, Ordering::SeqCst);
-        self.inner.finalize(failed, succeeded, ignored, filtered, aborted)
-    }
 }
 
 pub fn flagsplit(flags: &str) -> Vec<String> {
@@ -173,30 +145,43 @@ fn run_tests(
     // Timeout and custom handler enabled for fix mode
     if fix_mode {
         static COLLECTED: OnceLock<Mutex<Vec<(PathBuf, Vec<u8>)>>> = OnceLock::new();
-        let original_pgid = unsafe { libc::getpgrp() };
-        std::thread::spawn(move || {
+        let finished = Arc::new(AtomicBool::new(false));
+        let last_progress = Arc::new(AtomicU64::new(0));
+        let start = Instant::now();
+        let abort_check = config.abort_check.clone();
+        let root_pid = unsafe { libc::getpid() };
+        let finished_guard = Arc::clone(&finished);
+        let last_progress_guard = Arc::clone(&last_progress);
+        std::thread::spawn(move || loop {
             std::thread::sleep(TIMEOUT);
-            // Still alive = something is stuck. Detach from the process
-            // group so we survive the kill, then kill the stuck children.
-            unsafe {
-                libc::setpgid(0, 0);
-                libc::kill(-original_pgid, libc::SIGKILL);
+            if finished_guard.load(Ordering::SeqCst) {
+                return;
+            }
+            let elapsed = start.elapsed().as_secs();
+            let last = last_progress_guard.load(Ordering::SeqCst);
+            if elapsed.saturating_sub(last) >= TIMEOUT.as_secs() {
+                abort_check.abort();
+                kill_descendants(root_pid);
+                return;
             }
         });
 
         COLLECTED.get_or_init(|| Mutex::new(Vec::new()));
         // Clear in case of re-use
         COLLECTED.get().unwrap().lock().unwrap().clear();
-
         config.output_conflict_handling = |path, actual, _errors, _config| {
             COLLECTED.get().unwrap().lock().unwrap().push((path.to_path_buf(), actual.to_vec()));
         };
 
         let failed = Arc::new(AtomicUsize::new(0));
-        let emitter = FixEmitter {
-            inner: Box::<dyn StatusEmitter>::from(args.format),
-            failed: Arc::clone(&failed),
-        };
+        let aborted = Arc::new(AtomicUsize::new(0));
+        let emitter = FixEmitter::new(
+            Box::<dyn StatusEmitter>::from(args.format),
+            Arc::clone(&failed),
+            Arc::clone(&aborted),
+            Arc::clone(&last_progress),
+            start,
+        );
 
         eprintln!("   Compiler: {}", config.program.display());
         // We don't care about this report, since we're generating our own with `FixResult`
@@ -206,9 +191,11 @@ fn run_tests(
             |_, _| {},
             Box::new(emitter),
         );
+        finished.store(true, Ordering::SeqCst);
         let failed = failed.load(Ordering::SeqCst);
+        let aborted = aborted.load(Ordering::SeqCst);
         let results = COLLECTED.get().unwrap().lock().unwrap().clone();
-        return Ok(FixResult { failed, results });
+        return Ok(FixResult { failed, aborted, results });
     }
 
     // Regular UI tests without timeout
@@ -377,18 +364,24 @@ fn main() -> Result<()> {
         let sp_run = sp_count.map(|count| (count, check_for_fix(Mode::Pass)));
         let sf_run = sf_count.map(|count| (count, check_for_fix(Mode::Fail)));
         if let Some((count, Ok(result))) = sp_run {
+            let ok = count.saturating_sub(result.failed + result.aborted);
             eprintln!(
-                "SHOULD-PASS: {}/{} tests correctly passed with no errors.\n",
-                count - result.failed,
-                count
+                "SHOULD-PASS: {}/{} tests correctly passed with no errors ({} aborted after {}s).\n",
+                ok,
+                count,
+                result.aborted,
+                TIMEOUT.as_secs()
             );
             print_errors(result);
         }
         if let Some((count, Ok(result))) = sf_run {
+            let ok = count.saturating_sub(result.failed + result.aborted);
             eprintln!(
-                "SHOULD-FAIL: {}/{} tests failed with bsan errors.\n",
-                count - result.failed,
-                count
+                "SHOULD-FAIL: {}/{} tests failed with bsan errors ({} aborted after {}s).\n",
+                ok,
+                count,
+                result.aborted,
+                TIMEOUT.as_secs()
             );
             print_errors(result);
         }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -4,6 +4,7 @@ use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use colored::*;
 use regex::bytes::Regex;
@@ -100,7 +101,7 @@ fn run_tests(
     target: &VersionMeta,
     with_dependencies: bool,
     tmpdir: &Path,
-    timeout: Option<u32>,
+    timeout: Option<Duration>,
 ) -> Result<()> {
     // Handle command-line arguments.
     let mut args = ui_test::Args::test()?;
@@ -135,16 +136,20 @@ fn run_tests(
     config.program.args.push("-Zui-testing".into());
 
     if let Some(timeout) = timeout {
-        let original_program = config.program.program.clone();
-        let wrapper = tmpdir.join("compile-timeout-wrapper.sh");
-        std::fs::write(
-            &wrapper,
-            format!("#!/bin/sh\nexec timeout {timeout} {} \"$@\"\n", original_program.display()),
-        )
-        .unwrap();
-        std::fs::set_permissions(&wrapper, std::os::unix::fs::PermissionsExt::from_mode(0o755))
-            .unwrap();
-        config.program.program = wrapper.into();
+        // Capture our current pgid *before* spawning anything
+        let original_pgid = unsafe { libc::getpgrp() };
+
+        std::thread::spawn(move || {
+            std::thread::sleep(timeout);
+
+            // Still alive = something is stuck. Detach from the process
+            // group so we survive the kill, then kill the stuck children.
+            eprintln!("Killing stuck tests after timeout of {} seconds", timeout.as_secs());
+            unsafe {
+                libc::setpgid(0, 0);
+                libc::kill(-original_pgid, libc::SIGKILL);
+            }
+        });
     }
 
     eprintln!("   Compiler: {}", config.program.display());
@@ -240,7 +245,7 @@ fn ui(
     target: &VersionMeta,
     with_dependencies: Dependencies,
     tmpdir: &Path,
-    timeout: Option<u32>,
+    timeout: Option<Duration>,
 ) -> Result<()> {
     let msg = format!("## Running ui tests in {path} for {}", target.host);
     eprintln!("{}", msg.green().bold());
@@ -274,7 +279,7 @@ fn main() -> Result<()> {
     let tmpdir = tempfile::Builder::new().prefix("bsan-uitest-").tempdir()?;
 
     if env::var("BSAN_FIX").is_ok() {
-        let timeout = Some(1);
+        let timeout = Some(Duration::from_secs(10));
         let should_pass = ui(
             Mode::Pass,
             "tests/miri-tests/should-pass",

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
@@ -16,6 +16,8 @@ use ui_test::dependencies::DependencyBuilder;
 use ui_test::spanned::Spanned;
 use ui_test::status_emitter::{StatusEmitter, Summary, TestStatus};
 use ui_test::{CommandBuilder, Config, Match};
+
+const TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Copy, Clone, Debug)]
 enum Mode {
@@ -33,9 +35,9 @@ struct WithDependencies {
     bless: bool,
 }
 
+#[derive(Default)]
 pub struct TestResult {
     pub failed: usize,
-    pub aborted: bool,
 }
 
 struct FixEmitter {
@@ -130,7 +132,7 @@ fn run_tests(
     target: &VersionMeta,
     with_dependencies: bool,
     tmpdir: &Path,
-    timeout: Option<Duration>,
+    fix_mode: bool,
 ) -> Result<TestResult> {
     // Handle/ command-line arguments.
     let mut args = ui_test::Args::test()?;
@@ -164,31 +166,38 @@ fn run_tests(
 
     config.program.args.push("-Zui-testing".into());
 
-    let aborted = Arc::new(AtomicBool::new(false));
-
-    if let Some(timeout) = timeout {
-        // Capture our current pgid *before* spawning anything
+    // Timeout enabled for fix mode
+    if fix_mode {
         let original_pgid = unsafe { libc::getpgrp() };
-        let aborted = Arc::clone(&aborted);
         std::thread::spawn(move || {
-            std::thread::sleep(timeout);
+            std::thread::sleep(TIMEOUT);
             // Still alive = something is stuck. Detach from the process
             // group so we survive the kill, then kill the stuck children.
-            eprintln!("Killing stuck tests after timeout of {} seconds", timeout.as_secs());
-            aborted.store(true, Ordering::SeqCst);
             unsafe {
                 libc::setpgid(0, 0);
                 libc::kill(-original_pgid, libc::SIGKILL);
             }
         });
+
+        let failed = Arc::new(AtomicUsize::new(0));
+        let emitter = FixEmitter {
+            inner: Box::<dyn StatusEmitter>::from(args.format),
+            failed: Arc::clone(&failed),
+        };
+
+        eprintln!("   Compiler: {}", config.program.display());
+        // We don't care about this report, since we're generating our own with `TestResult`
+        let _ = ui_test::run_tests_generic(
+            vec![config],
+            ui_test::default_file_filter,
+            |_, _| {},
+            Box::new(emitter),
+        );
+        let failed = failed.load(Ordering::SeqCst);
+        return Ok(TestResult { failed });
     }
 
-    let failed = Arc::new(AtomicUsize::new(0));
-    let emitter = FixEmitter {
-        inner: Box::<dyn StatusEmitter>::from(args.format),
-        failed: Arc::clone(&failed),
-    };
-
+    // Regular UI tests without timeout
     eprintln!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
         // Only run one test suite. In the future we can add all test suites to one `Vec` and run
@@ -199,11 +208,9 @@ fn run_tests(
         // This could be used to overwrite the `Config` on a per-test basis.
         |_, _| {},
         // No GHA output as that would also show in the main rustc repo.
-        Box::new(emitter),
+        Box::<dyn StatusEmitter>::from(args.format),
     )?;
-    let failed = failed.load(Ordering::SeqCst);
-    let aborted = aborted.load(Ordering::SeqCst);
-    Ok(TestResult { failed, aborted })
+    Ok(TestResult::default())
 }
 
 macro_rules! regexes {
@@ -285,7 +292,7 @@ fn ui(
     target: &VersionMeta,
     with_dependencies: Dependencies,
     tmpdir: &Path,
-    timeout: Option<Duration>,
+    fix_mode: bool,
 ) -> Result<TestResult> {
     let msg = format!("## Running ui tests in {path} for {}", target.host);
     eprintln!("{}", msg.green().bold());
@@ -294,7 +301,7 @@ fn ui(
         WithDependencies => true,
         WithoutDependencies => false,
     };
-    run_tests(mode, path, target, with_dependencies, tmpdir, timeout)
+    run_tests(mode, path, target, with_dependencies, tmpdir, fix_mode)
         .with_context(|| format!("ui tests in {path} for {} failed", target.host))
 }
 fn expect_env(var: &str) -> String {
@@ -308,58 +315,67 @@ fn path_from_env(var: &str) -> PathBuf {
     path
 }
 
+fn parse_env_count(var: &str) -> Option<usize> {
+    env::var(var)
+        .ok()
+        .map(|val| val.trim().to_string())
+        .filter(|val| !val.is_empty())
+        .and_then(|val| val.parse::<usize>().ok())
+}
+
 fn get_version_info() -> VersionMeta {
     let cmd = Command::new("rustc");
     VersionMeta::for_command(cmd).expect("Failed to parse rustc version info")
 }
 
-fn main() -> Result<()> {
-    ui_test::color_eyre::install()?;
+fn check_for_fix(mode: Mode) -> Result<TestResult> {
     let target = get_version_info();
     let tmpdir = tempfile::Builder::new().prefix("bsan-uitest-").tempdir()?;
 
-    if env::var("BSAN_FIX").is_ok() {
-        let to = Some(Duration::from_secs(10));
-        let should_pass = ui(
-            Mode::Pass,
-            "tests/miri-tests/should-pass",
-            &target,
-            WithoutDependencies,
-            tmpdir.path(),
-            to,
-        );
-        let should_fail = ui(
-            Mode::Fail,
-            "tests/miri-tests/should-fail",
-            &target,
-            WithoutDependencies,
-            tmpdir.path(),
-            to,
-        );
-        for (name, result) in [("should-pass", should_pass), ("should-fail", should_fail)] {
+    let path = match mode {
+        Mode::Pass => "tests/miri-tests/should-pass",
+        Mode::Fail => "tests/miri-tests/should-fail",
+    };
+
+    ui(mode, path, &target, WithoutDependencies, tmpdir.path(), true)
+}
+
+fn main() -> Result<()> {
+    ui_test::color_eyre::install()?;
+
+    if env::var("BSAN_SP").is_ok() || env::var("BSAN_SF").is_ok() {
+        let sp_count = parse_env_count("BSAN_SP");
+        let sf_count = parse_env_count("BSAN_SF");
+        let sp_run = sp_count.map(|count| (count, check_for_fix(Mode::Pass)));
+        let sf_run = sf_count.map(|count| (count, check_for_fix(Mode::Fail)));
+
+        if let Some((count, result)) = sp_run {
             match result {
-                Err(e) => {
-                    eprintln!("{name}: error running tests: {e}");
+                Ok(result) => println!(
+                    "should-pass: {}/{} tests did not pass without errors.",
+                    result.failed, count
+                ),
+                Err(err) => eprintln!("should-pass: error running tests: {err}"),
+            }
+        }
+        if let Some((count, result)) = sf_run {
+            match result {
+                Ok(result) => {
+                    println!("should-fail: {}/{} tests did not catch errors.", result.failed, count)
                 }
-                Ok(TestResult { failed, aborted }) => {
-                    if failed > 0 || aborted {}
-                    if failed > 0 {
-                        eprintln!("{name}: {failed} test(s) failed");
-                    }
-                    if aborted {
-                        eprintln!("{name}: test run was aborted (timeout)");
-                    }
-                }
+                Err(err) => eprintln!("should-fail: error running tests: {err}"),
             }
         }
         return Ok(());
     }
 
-    ui(Mode::Pass, "tests/pass", &target, WithoutDependencies, tmpdir.path(), None)?;
-    ui(Mode::Pass, "tests/pass-dep", &target, WithDependencies, tmpdir.path(), None)?;
-    ui(Mode::Pass, "tests/miri-tests/pass", &target, WithoutDependencies, tmpdir.path(), None)?;
-    ui(Mode::Fail, "tests/fail", &target, WithoutDependencies, tmpdir.path(), None)?;
-    ui(Mode::Fail, "tests/fail-dep", &target, WithDependencies, tmpdir.path(), None)?;
-    ui(Mode::Fail, "tests/miri-tests/fail", &target, WithoutDependencies, tmpdir.path(), None)?;
+    let target = get_version_info();
+    let tmpdir = tempfile::Builder::new().prefix("bsan-uitest-").tempdir()?;
+    ui(Mode::Pass, "tests/pass", &target, WithoutDependencies, tmpdir.path(), false)?;
+    ui(Mode::Pass, "tests/pass-dep", &target, WithDependencies, tmpdir.path(), false)?;
+    ui(Mode::Pass, "tests/miri-tests/pass", &target, WithoutDependencies, tmpdir.path(), false)?;
+    ui(Mode::Fail, "tests/fail", &target, WithoutDependencies, tmpdir.path(), false)?;
+    ui(Mode::Fail, "tests/fail-dep", &target, WithDependencies, tmpdir.path(), false)?;
+    ui(Mode::Fail, "tests/miri-tests/fail", &target, WithoutDependencies, tmpdir.path(), false)?;
     Ok(())
 }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -3,7 +3,8 @@ use std::ffi::OsString;
 use std::num::NonZero;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use colored::*;
@@ -13,7 +14,7 @@ use ui_test::color_eyre::eyre::{Context, Result};
 use ui_test::custom_flags::edition::Edition;
 use ui_test::dependencies::DependencyBuilder;
 use ui_test::spanned::Spanned;
-use ui_test::status_emitter::StatusEmitter;
+use ui_test::status_emitter::{StatusEmitter, Summary, TestStatus};
 use ui_test::{CommandBuilder, Config, Match};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -23,6 +24,35 @@ enum Mode {
     Pass,
     /// Requires annotations
     Fail,
+}
+#[derive(Default)]
+pub struct FixResult {
+    pub failed: usize,
+}
+
+struct FixEmitter {
+    inner: Box<dyn StatusEmitter>,
+    failed: Arc<AtomicUsize>,
+    // registered: Arc<AtomicUsize>,
+}
+
+impl StatusEmitter for FixEmitter {
+    fn register_test(&self, name: PathBuf) -> Box<dyn TestStatus> {
+        // self.registered.fetch_add(1, Ordering::SeqCst);
+        self.inner.register_test(name)
+    }
+
+    fn finalize(
+        &self,
+        failed: usize,
+        succeeded: usize,
+        ignored: usize,
+        filtered: usize,
+        aborted: bool,
+    ) -> Box<dyn Summary> {
+        self.failed.store(failed, Ordering::SeqCst);
+        self.inner.finalize(failed, succeeded, ignored, filtered, aborted)
+    }
 }
 
 pub fn flagsplit(flags: &str) -> Vec<String> {
@@ -104,7 +134,7 @@ fn run_tests(
     with_dependencies: bool,
     tmpdir: &Path,
     fix_mode: bool,
-) -> Result<()> {
+) -> Result<FixResult> {
     // Handle/ command-line arguments.
     let mut args = ui_test::Args::test()?;
     args.bless |= env::var_os("RUSTC_BLESS").is_some_and(|v| v != "0");
@@ -139,22 +169,37 @@ fn run_tests(
 
     // Timeout enabled for fix mode
     if fix_mode {
-        // Capture our current pgid *before* spawning anything
+        config.output_conflict_handling = |_path, _actual, _errors, _config| {};
         let original_pgid = unsafe { libc::getpgrp() };
-
         std::thread::spawn(move || {
             std::thread::sleep(TIMEOUT);
-
             // Still alive = something is stuck. Detach from the process
             // group so we survive the kill, then kill the stuck children.
-            eprintln!("Killing stuck tests after timeout of {} seconds", TIMEOUT.as_secs());
             unsafe {
                 libc::setpgid(0, 0);
                 libc::kill(-original_pgid, libc::SIGKILL);
             }
         });
+
+        let failed = Arc::new(AtomicUsize::new(0));
+        let emitter = FixEmitter {
+            inner: Box::<dyn StatusEmitter>::from(args.format),
+            failed: Arc::clone(&failed),
+        };
+
+        eprintln!("   Compiler: {}", config.program.display());
+        // We don't care about this report, since we're generating our own with `TestResult`
+        let _ = ui_test::run_tests_generic(
+            vec![config],
+            ui_test::default_file_filter,
+            |_, _| {},
+            Box::new(emitter),
+        );
+        let failed = failed.load(Ordering::SeqCst);
+        return Ok(FixResult { failed });
     }
 
+    // Regular UI tests without timeout
     eprintln!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
         // Only run one test suite. In the future we can add all test suites to one `Vec` and run
@@ -167,7 +212,7 @@ fn run_tests(
         // No GHA output as that would also show in the main rustc repo.
         Box::<dyn StatusEmitter>::from(args.format),
     )?;
-    Ok(())
+    Ok(FixResult::default())
 }
 
 macro_rules! regexes {
@@ -250,7 +295,7 @@ fn ui(
     with_dependencies: Dependencies,
     tmpdir: &Path,
     fix_mode: bool,
-) -> Result<()> {
+) -> Result<FixResult> {
     let msg = format!("## Running ui tests in {path} for {}", target.host);
     eprintln!("{}", msg.green().bold());
 
@@ -272,15 +317,22 @@ fn path_from_env(var: &str) -> PathBuf {
     path
 }
 
+fn parse_env_count(var: &str) -> Option<usize> {
+    env::var(var)
+        .ok()
+        .map(|val| val.trim().to_string())
+        .filter(|val| !val.is_empty())
+        .and_then(|val| val.parse::<usize>().ok())
+}
+
 fn get_version_info() -> VersionMeta {
     let cmd = Command::new("rustc");
     VersionMeta::for_command(cmd).expect("Failed to parse rustc version info")
 }
 
-fn check_for_fix(mode: Mode) -> Result<()> {
+fn check_for_fix(mode: Mode) -> Result<FixResult> {
     let target = get_version_info();
     let tmpdir = tempfile::Builder::new().prefix("bsan-uitest-").tempdir()?;
-
     let path = match mode {
         Mode::Pass => "tests/miri-tests/should-pass",
         Mode::Fail => "tests/miri-tests/should-fail",
@@ -292,11 +344,25 @@ fn check_for_fix(mode: Mode) -> Result<()> {
 fn main() -> Result<()> {
     ui_test::color_eyre::install()?;
 
-    if env::var("BSAN_FIX").is_ok() {
-        let should_pass = check_for_fix(Mode::Pass);
-        let should_fail = check_for_fix(Mode::Fail);
-        should_pass?;
-        should_fail?;
+    if env::var("BSAN_SP").is_ok() || env::var("BSAN_SF").is_ok() {
+        let sp_count = parse_env_count("BSAN_SP");
+        let sf_count = parse_env_count("BSAN_SF");
+        let sp_run = sp_count.map(|count| (count, check_for_fix(Mode::Pass)));
+        let sf_run = sf_count.map(|count| (count, check_for_fix(Mode::Fail)));
+        if let Some((count, Ok(result))) = sp_run {
+            println!(
+                "should-pass: {}/{} tests correctly passed with no errors",
+                count - result.failed,
+                count
+            );
+        }
+        if let Some((count, Ok(result))) = sf_run {
+            println!(
+                "should-fail: {}/{} tests failed with some bsan errors",
+                count - result.failed,
+                count
+            );
+        }
         return Ok(());
     }
 

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -100,6 +100,7 @@ fn run_tests(
     target: &VersionMeta,
     with_dependencies: bool,
     tmpdir: &Path,
+    timeout: Option<u32>,
 ) -> Result<()> {
     // Handle command-line arguments.
     let mut args = ui_test::Args::test()?;
@@ -132,6 +133,19 @@ fn run_tests(
     config.program.args.push("-Ainternal_features".into());
 
     config.program.args.push("-Zui-testing".into());
+
+    if let Some(timeout) = timeout {
+        let original_program = config.program.program.clone();
+        let wrapper = tmpdir.join("compile-timeout-wrapper.sh");
+        std::fs::write(
+            &wrapper,
+            format!("#!/bin/sh\nexec timeout {timeout} {} \"$@\"\n", original_program.display()),
+        )
+        .unwrap();
+        std::fs::set_permissions(&wrapper, std::os::unix::fs::PermissionsExt::from_mode(0o755))
+            .unwrap();
+        config.program.program = wrapper.into();
+    }
 
     eprintln!("   Compiler: {}", config.program.display());
     ui_test::run_tests_generic(
@@ -226,6 +240,7 @@ fn ui(
     target: &VersionMeta,
     with_dependencies: Dependencies,
     tmpdir: &Path,
+    timeout: Option<u32>,
 ) -> Result<()> {
     let msg = format!("## Running ui tests in {path} for {}", target.host);
     eprintln!("{}", msg.green().bold());
@@ -234,10 +249,9 @@ fn ui(
         WithDependencies => true,
         WithoutDependencies => false,
     };
-    run_tests(mode, path, target, with_dependencies, tmpdir)
+    run_tests(mode, path, target, with_dependencies, tmpdir, timeout)
         .with_context(|| format!("ui tests in {path} for {} failed", target.host))
 }
-
 fn expect_env(var: &str) -> String {
     env::var(var).expect(&format!("`{}` must be set to run BorrowSanitizer's ui tests.", var))
 }
@@ -258,11 +272,35 @@ fn main() -> Result<()> {
     ui_test::color_eyre::install()?;
     let target = get_version_info();
     let tmpdir = tempfile::Builder::new().prefix("bsan-uitest-").tempdir()?;
-    ui(Mode::Pass, "tests/pass", &target, WithoutDependencies, tmpdir.path())?;
-    ui(Mode::Pass, "tests/pass-dep", &target, WithDependencies, tmpdir.path())?;
-    ui(Mode::Pass, "tests/miri-tests/pass", &target, WithoutDependencies, tmpdir.path())?;
-    ui(Mode::Fail, "tests/fail", &target, WithoutDependencies, tmpdir.path())?;
-    ui(Mode::Fail, "tests/fail-dep", &target, WithDependencies, tmpdir.path())?;
-    ui(Mode::Fail, "tests/miri-tests/fail", &target, WithoutDependencies, tmpdir.path())?;
+
+    if env::var("BSAN_FIX").is_ok() {
+        let timeout = Some(1);
+        let should_pass = ui(
+            Mode::Pass,
+            "tests/miri-tests/should-pass",
+            &target,
+            WithoutDependencies,
+            tmpdir.path(),
+            timeout,
+        );
+        let should_fail = ui(
+            Mode::Fail,
+            "tests/miri-tests/should-fail",
+            &target,
+            WithoutDependencies,
+            tmpdir.path(),
+            timeout,
+        );
+        should_pass?;
+        should_fail?;
+        return Ok(());
+    }
+
+    ui(Mode::Pass, "tests/pass", &target, WithoutDependencies, tmpdir.path(), None)?;
+    ui(Mode::Pass, "tests/pass-dep", &target, WithDependencies, tmpdir.path(), None)?;
+    ui(Mode::Pass, "tests/miri-tests/pass", &target, WithoutDependencies, tmpdir.path(), None)?;
+    ui(Mode::Fail, "tests/fail", &target, WithoutDependencies, tmpdir.path(), None)?;
+    ui(Mode::Fail, "tests/fail-dep", &target, WithDependencies, tmpdir.path(), None)?;
+    ui(Mode::Fail, "tests/miri-tests/fail", &target, WithoutDependencies, tmpdir.path(), None)?;
     Ok(())
 }


### PR DESCRIPTION
Using `xb stats` you can now see how many true/false positive/negative tests we have. 

The terminology is "positive for bugs" vs "negative for bugs".

The current snapshot looks like:
```
True negative (pass) tests: 282 (99.30%)
  ├─ original tests: 10
  └─ miri tests: 272
True positive (fail) tests: 72 (59.50%)
  ├─ original tests: 8
  ├─ mirilli tests: 0
  └─ miri tests: 64
False positive (should pass) tests: 2 (0.70%)
False negative (should fail) tests: 49 (40.50%)
  ├─ aliasing: 32
  │  ├─ both_borrows: 4
  │  ├─ stacked_borrows: 1
  │  └─ tree_borrows: 27
  │     └─ wildcard: 27
  └─ baseline: 17
     ├─ dangling_pointers: 3
     ├─ intrinsics: 2
     ├─ provenance: 7
     └─ tls: 1
```

`xb fix` runs all tests in the `should-*` categories with a 10s timeout. The current snapshout outputs:

```

SHOULD-PASS: 0/2 tests correctly passed with no errors (0 aborted after 5s).

SHOULD-FAIL: 2/49 tests failed with bsan errors (3 aborted after 5s).

  ✗ Test failed with output: tests/miri-tests/should-fail/baseline/zst_local_oob.rs
    error: Undefined Behavior: an access of size 128b at offset 0xffffffffb1a02331 is out of bounds for alloc277 of size 1b.
       --> /root/.rustup/toolchains/bsan/lib/rustlib/src/rust/library/std/src/sys/pal/unix/stack_overflow.rs:107:35
        |
    107 | let fault_addr = unsafe { (*info).si_addr().addr() };
        |
    
    stack backtrace:

  ✗ Test failed with output: tests/miri-tests/should-fail/baseline/reading_half_a_pointer.rs
    error: Undefined Behavior: an access of size 128b at offset 0xffffffffa3466240 is out of bounds for alloc282 of size 24b.
       --> /root/.rustup/toolchains/bsan/lib/rustlib/src/rust/library/std/src/sys/pal/unix/stack_overflow.rs:107:35
        |
    107 | let fault_addr = unsafe { (*info).si_addr().addr() };
        |
    
    stack backtrace:
```

### TODO:
- [x] Add this summary to the end of `xb ui`
- [x] Add another command to test all the `should-*` cases
- [x] fix thread termination