### PR TITLE
Only use a global array for interior mutable ranges when absolutely necessary

### DIFF
--- a/bsan-rt/src/borrow_tracker.rs
+++ b/bsan-rt/src/borrow_tracker.rs
@@ -11,7 +11,7 @@ use crate::tree_borrows::diagnostics::AccessCause;
 use crate::tree_borrows::perms::{AccessKind, Permission};
 use crate::tree_borrows::tree::LocationState;
 use crate::tree_borrows::{IdempotentForeignAccess, NewPermission};
-use crate::{AllocId, BorTag, GlobalCtx, Provenance, RetagInfo, Tree};
+use crate::{AllocId, BorTag, GlobalCtx, Provenance, RetagFlags, RetagInfo, Tree};
 
 #[derive(Debug)]
 pub struct BorrowTracker<'b> {
@@ -185,11 +185,18 @@ impl<'b> BorrowTracker<'b> {
                 }
                 cursor = offset + size
             }
-        }
-        if cursor < Size::from_bytes(retag_info.size) {
-            let width = Size::from_bytes(retag_info.size - cursor.bytes() as usize);
-            for (_loc_range, loc) in inside_perms.iter_mut(cursor, width) {
-                *loc = loc_state(true);
+            if cursor < Size::from_bytes(retag_info.size) {
+                let width = Size::from_bytes(retag_info.size - cursor.bytes() as usize);
+                for (_loc_range, loc) in inside_perms.iter_mut(cursor, width) {
+                    *loc = loc_state(true);
+                }
+            }
+        } else if retag_info.size > 0 {
+            let perm = loc_state(retag_info.flags.contains(RetagFlags::IS_FREEZE));
+            for (_loc_range, loc) in
+                inside_perms.iter_mut(Size::ZERO, Size::from_bytes(retag_info.size))
+            {
+                *loc = perm;
             }
         }
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.97.0-dev-b94c6b9"
-sha = "b94c6b9c7da24b03d567a859b05b90b16e690589"
+tag = "rolling-1.97.0-dev-be3e7c3"
+sha = "be3e7c375a3db751debedb11043116832adb408f"
 version = "1.97.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.97.0-dev-be3e7c3"
-sha = "be3e7c375a3db751debedb11043116832adb408f"
+tag = "rolling-1.97.0-dev-b94c6b9"
+sha = "b94c6b9c7da24b03d567a859b05b90b16e690589"
 version = "1.97.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.97.0-dev-1e214e7"
-sha = "1e214e7986bf2fa30f080d6931cb67538665a624"
+tag = "rolling-1.97.0-dev-be3e7c3"
+sha = "be3e7c375a3db751debedb11043116832adb408f"
 version = "1.97.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
Our retag intrinsics use a global static array to describe the layout of types that have interior mutability. However, each of these arrays has a run-time cost. Originally, we allocated an array for every single retag. This is not necessary for types that are entirely interior mutable.

This PR updates our fork of rust with a small tweak to our retag intrinsics: if a type is entirely interior mutable, we will not allocate an array to describe its layout. Instead, the parameter of the retag intrinsic that carries a pointer to the global array will be null, and we will use `RetagFlags::IS_FREEZE` to differentiate this case from types that do not have interior mutability.

In the future, we should keep in mind that setting `-Zcodegen-emit-retag` to contain the flags `no-precise-im` and `no-precise-pin` will reduce runtime overhead.