### PR TITLE
Ensure that offsets created by `getProvenanceDesc` include struct padding

### DIFF
--- a/bsan-pass/Provenance.cpp
+++ b/bsan-pass/Provenance.cpp
@@ -10,52 +10,62 @@ ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB, Type *Ty) {
   SmallVector<ProvenanceDesc> Desc;
   if (Ty->isSized()) {
     Value *Zero = ConstantInt::get(IRB.getIntPtrTy(*DL), 0);
-    getProvenanceDesc(IRB, Desc, Ty, Zero, Zero);
+    getProvenanceDesc(IRB, Desc, Ty, Zero);
   }
   return Desc;
 }
 
 // Populates a vector with the list of locations of provenance
 // values within a type.
-std::tuple<Value *, Value *> ProvenanceLayout::getProvenanceDesc(
-    IRBuilder<> &IRB, SmallVector<ProvenanceDesc> &ProvDesc, Type *CurrentTy,
-    Value *ByteOffset, Value *ProvOffset) {
+Value *
+ProvenanceLayout::getProvenanceDesc(IRBuilder<> &IRB,
+                                    SmallVector<ProvenanceDesc> &ProvDesc,
+                                    Type *CurrentTy, Value *ByteOffset) {
   assert(CurrentTy->isSized() && "expected a sized type");
-  TypeSize AllocSize = DL->getTypeAllocSize(CurrentTy);
-  Value *TypeSize = IRB.CreateTypeSize(IRB.getIntPtrTy(*DL), AllocSize);
-  Value *NextProvOffset = ProvOffset;
+  Type *IntptrTy = IRB.getIntPtrTy(*DL);
+
   switch (CurrentTy->getTypeID()) {
   case Type::PointerTyID: {
-    ProvenanceDesc Desc(ByteOffset, TypeSize, ElementCount::get(1, false));
+    TypeSize AllocTySize = DL->getTypeAllocSize(CurrentTy);
+    Value *AllocSize = IRB.CreateTypeSize(IntptrTy, AllocTySize);
+    ProvenanceDesc Desc(ByteOffset, AllocSize, ElementCount::get(1, false));
     ProvDesc.push_back(Desc);
-    Value *Elems = IRB.CreateElementCount(IRB.getIntPtrTy(*DL), Desc.Elems);
-    NextProvOffset = IRB.CreateAdd(ProvOffset, Elems);
+    Value *Elems = IRB.CreateElementCount(IntptrTy, Desc.Elems);
+    return ConstantInt::get(IntptrTy, 1);
   } break;
   case Type::StructTyID: {
     StructType *ST = cast<StructType>(CurrentTy);
-    Value *CurrByteOffset = ByteOffset;
-    for (Type *ElemType : ST->elements()) {
-      auto [BOffset, POffset] = getProvenanceDesc(
-          IRB, ProvDesc, ElemType, CurrByteOffset, NextProvOffset);
-      CurrByteOffset = BOffset;
-      NextProvOffset = POffset;
+    const StructLayout *SL = DL->getStructLayout(ST);
+    Value *CurrProvOffset = ConstantInt::get(IntptrTy, 0);
+    for (auto [Idx, ElemTy] : llvm::enumerate(ST->elements())) {
+      Value *ElemOffset =
+          IRB.CreateTypeSize(IntptrTy, SL->getElementOffset(Idx));
+      Value *CurrByteOffset = IRB.CreateAdd(ByteOffset, ElemOffset);
+      auto *ProvOffset =
+          getProvenanceDesc(IRB, ProvDesc, ElemTy, CurrByteOffset);
+      CurrProvOffset = IRB.CreateAdd(CurrProvOffset, ProvOffset);
     }
+    return CurrProvOffset;
   } break;
   case Type::ArrayTyID: {
     ArrayType *AT = cast<ArrayType>(CurrentTy);
-    Value *CurrByteOffset = ByteOffset;
+    Value *CurrProvOffset = ConstantInt::get(IntptrTy, 0);
+    TypeSize ElemTySize = DL->getTypeAllocSize(AT->getElementType());
+    Value *ElemSize = IRB.CreateTypeSize(IntptrTy, ElemTySize);
     for (unsigned Idx = 0; Idx < AT->getNumElements(); ++Idx) {
-      auto [BOffset, POffset] = getProvenanceDesc(
-          IRB, ProvDesc, AT->getElementType(), CurrByteOffset, NextProvOffset);
-      CurrByteOffset = BOffset;
-      NextProvOffset = POffset;
+      Value *CurrByteOffset =
+          IRB.CreateMul(ConstantInt::get(IntptrTy, Idx), ElemSize);
+      CurrByteOffset = IRB.CreateAdd(ByteOffset, CurrByteOffset);
+      auto *ProvOffset = getProvenanceDesc(IRB, ProvDesc, AT->getElementType(),
+                                           CurrByteOffset);
+      CurrProvOffset = IRB.CreateAdd(CurrProvOffset, ProvOffset);
     }
+    return CurrProvOffset;
   } break;
-  default:
-    break;
+  default: {
+    return ConstantInt::get(IntptrTy, 0);
+  } break;
   }
-  Value *NextByteOffset = IRB.CreateAdd(ByteOffset, TypeSize);
-  return std::make_tuple(NextByteOffset, NextProvOffset);
 }
 
 void Provenance::addIncoming(BasicBlock *IncomingBlock,

--- a/bsan-pass/Provenance.h
+++ b/bsan-pass/Provenance.h
@@ -48,9 +48,8 @@ struct ProvenanceLayout {
   SmallVector<ProvenanceDesc> getProvenanceDesc(IRBuilder<> &IRB, Type *Ty);
 
 private:
-  std::tuple<Value *, Value *>
-  getProvenanceDesc(IRBuilder<> &IRB, SmallVector<ProvenanceDesc> &Dest,
-                    Type *CurrentTy, Value *ByteOffset, Value *ProvOffset);
+  Value *getProvenanceDesc(IRBuilder<> &IRB, SmallVector<ProvenanceDesc> &Dest,
+                           Type *CurrentTy, Value *ByteOffset);
 };
 
 class ProvenanceScalar;


### PR DESCRIPTION
We use the function `getProvenanceDesc` to determine where provenance values live within a value's type. This was calculating the offset of a struct's field as the sum of the size of previous fields. This is likely correct, but it's not robust. This PR defers to `StructLayout` to determine the offset of each field. 