### PR TITLE
Rely on branching to identify weak overrides

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -316,11 +316,11 @@ SANITIZER_INTERFACE_ATTRIBUTE
 BorTag __bsan_retag(void *object_addr, uptr access_size, u8 flags,
                     const uptr im_data[2], uptr im_len, const uptr pin_data[2],
                     uptr pin_len, BorTag bor_tag, AllocInfo *alloc_info) {
-  GET_SPAN_PC_BP;
+  GET_SPAN;
   BorTag tag =
       __bsan_retag_impl(object_addr, access_size, flags, im_data, im_len,
                         pin_data, pin_len, bor_tag, alloc_info, span);
-  HANDLE_ERROR(pc, bp);
+  HANDLE_ERROR;
   return tag;
 }
 
@@ -331,9 +331,9 @@ void __bsan_read_impl(void *ptr, uptr access_size, BorTag bor_tag,
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_read(void *ptr, uptr access_size, BorTag bor_tag,
                  AllocInfo *alloc_info) {
-  GET_SPAN_PC_BP;
+  GET_SPAN;
   __bsan_read_impl(ptr, access_size, bor_tag, alloc_info, span);
-  HANDLE_ERROR(pc, bp);
+  HANDLE_ERROR;
 }
 
 SANITIZER_WEAK_ATTRIBUTE
@@ -343,9 +343,9 @@ void __bsan_write_impl(void *ptr, uptr access_size, BorTag bor_tag,
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_write(void *ptr, uptr access_size, BorTag bor_tag,
                   AllocInfo *alloc_info) {
-  GET_SPAN_PC_BP;
+  GET_SPAN;
   __bsan_write_impl(ptr, access_size, bor_tag, alloc_info, span);
-  HANDLE_ERROR(pc, bp);
+  HANDLE_ERROR;
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE Provenance *
@@ -384,9 +384,9 @@ void __bsan_alloc_stack_impl(void *base_addr, uptr size, BorTag bor_tag,
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_alloc_stack(void *base_addr, uptr size, BorTag bor_tag,
                         AllocInfo *alloc_info) {
-  GET_SPAN_PC_BP;
+  GET_SPAN;
   __bsan_alloc_stack_impl(base_addr, size, bor_tag, alloc_info, span);
-  HANDLE_ERROR(pc, bp);
+  HANDLE_ERROR;
 }
 
 SANITIZER_WEAK_ATTRIBUTE
@@ -395,9 +395,9 @@ void __bsan_dealloc_stack_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc) {
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_dealloc_stack(void *ptr, BorTag bor_tag, AllocInfo *alloc_info) {
-  GET_SPAN_PC_BP;
+  GET_SPAN;
   __bsan_dealloc_stack_impl(bor_tag, alloc_info, span);
-  HANDLE_ERROR(pc, bp);
+  HANDLE_ERROR;
 }
 
 SANITIZER_WEAK_ATTRIBUTE

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -308,44 +308,49 @@ SANITIZER_WEAK_ATTRIBUTE
 BorTag __bsan_retag_impl(void *object_addr, uptr access_size, u8 flags,
                          const uptr im_data[2], uptr im_len,
                          const uptr pin_data[2], uptr pin_len, BorTag bor_tag,
-                         AllocInfo *alloc_info, Span pc) {
-  return bor_tag;
-}
+                         AllocInfo *alloc_info, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 BorTag __bsan_retag(void *object_addr, uptr access_size, u8 flags,
                     const uptr im_data[2], uptr im_len, const uptr pin_data[2],
                     uptr pin_len, BorTag bor_tag, AllocInfo *alloc_info) {
-  GET_SPAN;
-  BorTag tag =
-      __bsan_retag_impl(object_addr, access_size, flags, im_data, im_len,
-                        pin_data, pin_len, bor_tag, alloc_info, span);
-  HANDLE_ERROR;
-  return tag;
+  BorTag new_tag = bor_tag;
+  if (__bsan_retag_impl) {
+    GET_SPAN;
+    new_tag =
+        __bsan_retag_impl(object_addr, access_size, flags, im_data, im_len,
+                          pin_data, pin_len, bor_tag, alloc_info, span);
+    HANDLE_ERROR;
+  }
+  return new_tag;
 }
 
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_read_impl(void *ptr, uptr access_size, BorTag bor_tag,
-                      AllocInfo *alloc_info, Span pc) {}
+                      AllocInfo *alloc_info, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_read(void *ptr, uptr access_size, BorTag bor_tag,
                  AllocInfo *alloc_info) {
-  GET_SPAN;
-  __bsan_read_impl(ptr, access_size, bor_tag, alloc_info, span);
-  HANDLE_ERROR;
+  if (__bsan_read_impl) {
+    GET_SPAN;
+    __bsan_read_impl(ptr, access_size, bor_tag, alloc_info, span);
+    HANDLE_ERROR;
+  }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_write_impl(void *ptr, uptr access_size, BorTag bor_tag,
-                       AllocInfo *alloc_info, Span pc) {}
+                       AllocInfo *alloc_info, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_write(void *ptr, uptr access_size, BorTag bor_tag,
                   AllocInfo *alloc_info) {
-  GET_SPAN;
-  __bsan_write_impl(ptr, access_size, bor_tag, alloc_info, span);
-  HANDLE_ERROR;
+  if (__bsan_write_impl) {
+    GET_SPAN;
+    __bsan_write_impl(ptr, access_size, bor_tag, alloc_info, span);
+    HANDLE_ERROR;
+  }
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE Provenance *
@@ -379,14 +384,16 @@ __bsan_dealloc(void *ptr, BorTag bor_tag, AllocInfo *alloc_info, Span pc) {}
 
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_alloc_stack_impl(void *base_addr, uptr size, BorTag bor_tag,
-                             AllocInfo *alloc_info, Span pc) {}
+                             AllocInfo *alloc_info, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_alloc_stack(void *base_addr, uptr size, BorTag bor_tag,
                         AllocInfo *alloc_info) {
-  GET_SPAN;
-  __bsan_alloc_stack_impl(base_addr, size, bor_tag, alloc_info, span);
-  HANDLE_ERROR;
+  if (__bsan_alloc_stack_impl) {
+    GET_SPAN;
+    __bsan_alloc_stack_impl(base_addr, size, bor_tag, alloc_info, span);
+    HANDLE_ERROR;
+  }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
@@ -395,9 +402,11 @@ void __bsan_dealloc_stack_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc) {
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_dealloc_stack(void *ptr, BorTag bor_tag, AllocInfo *alloc_info) {
-  GET_SPAN;
-  __bsan_dealloc_stack_impl(bor_tag, alloc_info, span);
-  HANDLE_ERROR;
+  if (__bsan_dealloc_stack_impl) {
+    GET_SPAN;
+    __bsan_dealloc_stack_impl(bor_tag, alloc_info, span);
+    HANDLE_ERROR;
+  }
 }
 
 SANITIZER_WEAK_ATTRIBUTE

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -61,16 +61,25 @@ bool CallerIsInstrumented(void *sym);
 
 #define GET_SPAN_PC_BP                                                         \
   GET_SPAN;                                                                    \
-  uptr pc = StackTrace::GetCurrentPc();                                        \
-  uptr bp = GET_CURRENT_FRAME();
+  GET_CURRENT_PC_BP;                                                           \
 
-#define HANDLE_ERROR(pc, bp)                                                   \
-  if (__bsan_had_error) {                                                      \
+#define HANDLE_ERROR                                                           \
+  if (UNLIKELY(__bsan_had_error)) {                                            \
+    uptr pc = StackTrace::GetCurrentPc();                                      \
+    uptr bp = GET_CURRENT_FRAME();                                             \
     UNINITIALIZED BufferedStackTrace stack;                                    \
     stack.Unwind(pc, bp, nullptr, true, __bsan::GetStackTraceLen());           \
     PrintStackTrace(stack);                                                    \
     Die();                                                                     \
-  }
+  }                                                                            \
+
+#define HANDLE_ERROR_PC_BP(pc, bp)                                             \
+  if (UNLIKELY(__bsan_had_error)) {                                            \
+    UNINITIALIZED BufferedStackTrace stack;                                    \
+    stack.Unwind(pc, bp, nullptr, true, __bsan::GetStackTraceLen());           \
+    PrintStackTrace(stack);                                                    \
+    Die();                                                                     \
+  }                                                                            \
 
 } // namespace __bsan
 #endif // BSAN_H

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -61,7 +61,7 @@ bool CallerIsInstrumented(void *sym);
 
 #define GET_SPAN_PC_BP                                                         \
   GET_SPAN;                                                                    \
-  GET_CURRENT_PC_BP;                                                           \
+  GET_CURRENT_PC_BP;
 
 #define HANDLE_ERROR                                                           \
   if (UNLIKELY(__bsan_had_error)) {                                            \
@@ -71,7 +71,7 @@ bool CallerIsInstrumented(void *sym);
     stack.Unwind(pc, bp, nullptr, true, __bsan::GetStackTraceLen());           \
     PrintStackTrace(stack);                                                    \
     Die();                                                                     \
-  }                                                                            \
+  }
 
 #define HANDLE_ERROR_PC_BP(pc, bp)                                             \
   if (UNLIKELY(__bsan_had_error)) {                                            \
@@ -79,7 +79,7 @@ bool CallerIsInstrumented(void *sym);
     stack.Unwind(pc, bp, nullptr, true, __bsan::GetStackTraceLen());           \
     PrintStackTrace(stack);                                                    \
     Die();                                                                     \
-  }                                                                            \
+  }
 
 } // namespace __bsan
 #endif // BSAN_H

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -105,7 +105,7 @@ INTERCEPTOR(void, free, void *ptr) {
   if (INST_CALLER(free)) {
     Provenance *Slot = GetSlot(0);
     __bsan_dealloc(ptr, Slot->Tag, Slot->Info, span);
-    HANDLE_ERROR(pc, bp);
+    HANDLE_ERROR_PC_BP(pc, bp);
   }
   return REAL(free)(ptr);
 }
@@ -131,7 +131,7 @@ INTERCEPTOR(void *, realloc, void *ptr, SIZE_T size) {
   if (is_inst) {
     Provenance *Slot = GetSlot(0);
     __bsan_dealloc(ptr, Slot->Tag, Slot->Info, span);
-    HANDLE_ERROR(pc, bp);
+    HANDLE_ERROR_PC_BP(pc, bp);
   }
   void *nptr = REAL(realloc)(ptr, size);
   if (is_inst) {


### PR DESCRIPTION
I found a couple optimizations that we can make to improve performance

First, when we execute a run-time check, we unconditionally load the current frame pointer, instruction pointer, and the caller's instruction pointer. 
```C++
GET_SPAN_PC_BP;
__bsan_read_impl(..);
HANDLE_ERROR(pc, bp);
```
All we need is the caller's instruction pointer. We can get the rest once there's an error.
```C++
GET_SPAN;
__bsan_read_impl(..);
HANDLE_ERROR;
```
Next, errors are unlikely. We should mark the relevant branch as such within `HANDLE_ERROR`, to help guide branch prediction away from these expensive parts.
```C++
#define HANDLE_ERROR 
  if (UNLIKELY(__bsan_had_error)) {  
```
Finally, instead of calling our weak, nop symbols unconditionally, we should branch, checking if they're non-null before calling them or loading any caller metadata. We can rely on branch prediction to skip most of what's going on within our nop shims.
```C++
SANITIZER_WEAK_ATTRIBUTE
void __bsan_read_impl(..);

SANITIZER_INTERFACE_ATTRIBUTE
void __bsan_read(..) {
  if (__bsan_read_impl) {
    GET_SPAN;
    __bsan_read_impl(..)
```
Locally, these lead to a small but significant decrease in overhead.