### PR TITLE
Update our Rust fork to add back taint markers

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,8 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.97.0-dev-be3e7c3"
-sha = "be3e7c375a3db751debedb11043116832adb408f"
-version = "1.97.0-dev"
+tag = "rolling-1.98.0-dev-0d3a8b3"
+sha = "0d3a8b3f36e43f9cb92d63ec47ba38daa903128c"
+version = "1.98.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
-llvm_branch = "rustc/22.1-2026-03-22"
+llvm_branch = "rustc/22.1-2026-05-19"
 llvm_url = "https://github.com/rust-lang/llvm-project.git"

--- a/tests/miri-tests/fail/aliasing/async-shared-mutable.run.stderr
+++ b/tests/miri-tests/fail/aliasing/async-shared-mutable.run.stderr
@@ -7,7 +7,7 @@ LL | *x = 1; //miri: ~ERROR: write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
    --> bsan/tests/miri-tests/fail/aliasing/async-shared-mutable.rs:LL:CC
    |
-LL | .await
+LL | core::future::poll_fn(move |_| {
    |
 help: the accessed tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x8..0x9]
    --> bsan/tests/miri-tests/fail/aliasing/async-shared-mutable.rs:LL:CC

--- a/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.rs
+++ b/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.rs
@@ -11,7 +11,7 @@ fn main() {
     let xref = unsafe { &*xraw };
     let xref_in_mem = Box::new(xref);
     unsafe { *xraw = 42 }; // unfreeze
-    let _val = *xref_in_mem;
+    let _val = *xref_in_mem; //miri: ~[tree]| ERROR: /reborrow through .* is forbidden/
     //miri: ~[stack]^ ERROR: /retag .* tag does not exist in the borrow stack/
-    //miri: ~[tree]| ERROR: /reborrow through .* is forbidden/
+    
 }

--- a/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.run.stderr
@@ -1,13 +1,13 @@
 error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is forbidden
    --> bsan/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.rs:LL:CC
    |
-LL | let _val = *xref_in_mem;
+LL | let _val = *xref_in_mem; //miri: ~[tree]| ERROR: /reborrow through .* is forbidden/
    |
     = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
-LL | pub fn new(x: T) -> Self {
+LL | unsafe { core::intrinsics::write_via_move(ptr, x) };
    |
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
    --> bsan/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.rs:LL:CC


### PR DESCRIPTION
This adds back taint markers to our Rust fork ([rolling-1.98.0-dev-0d3a8b3](https://github.com/BorrowSanitizer/rust/releases/tag/rolling-1.98.0-dev-0d3a8b3)), which were lost during rebasing.