### PR TITLE
Added support for interception.

### DIFF
--- a/bsan-rt/llvm-wrapper/CMakeLists.txt
+++ b/bsan-rt/llvm-wrapper/CMakeLists.txt
@@ -33,6 +33,9 @@ append_rtti_flag(OFF BSAN_COMMON_CFLAGS)
 append_list_if(COMPILER_RT_HAS_FFREESTANDING_FLAG -ffreestanding BSAN_COMMON_CFLAGS)
 set(BSAN_DYNAMIC_CFLAGS ${BSAN_COMMON_CFLAGS})
 
+set_source_files_properties(bsan_interceptors.cpp PROPERTIES
+  COMPILE_FLAGS "-Wno-unused -Wno-unneeded-internal-declaration")
+
 set(BSAN_COMMON_DEFINITIONS "")
 set(BSAN_DYNAMIC_DEFINITIONS ${BSAN_COMMON_DEFINITIONS} BSAN_DYNAMIC=1)
 

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -44,19 +44,6 @@ atomic_uintptr_t __bsan_bor_tag_ctr{2};
 
 namespace __bsan {
 
-// Much like other MemorySanitizer, we use a thread-local flag to detect
-// if we are currently invoking the unwinder or symbolizer. Both of these
-// will conflict with interceptors.
-static THREADLOCAL int is_in_symbolizer_or_unwinder;
-static void EnterSymbolizerOrUnwider() { ++is_in_symbolizer_or_unwinder; }
-static void ExitSymbolizerOrUnwider() { --is_in_symbolizer_or_unwinder; }
-bool IsInSymbolizerOrUnwider() { return is_in_symbolizer_or_unwinder; }
-
-struct UnwinderScope {
-  UnwinderScope() { EnterSymbolizerOrUnwider(); }
-  ~UnwinderScope() { ExitSymbolizerOrUnwider(); }
-};
-
 bool bsan_inited = false;
 bool bsan_init_running = false;
 bool bsan_deinit_running = false;
@@ -137,7 +124,7 @@ void __sanitizer::BufferedStackTrace::UnwindImpl(uptr pc, uptr bp,
   BsanThread *t = GetCurrentThread();
   if (!t || !StackTrace::WillUseFastUnwind(request_fast)) {
     // Block reports from our interceptors during _Unwind_Backtrace.
-    UnwinderScope sym_scope;
+    InterceptorBarrier Barrier;
     return Unwind(max_depth, pc, bp, context, t ? t->stack_top() : 0,
                   t ? t->stack_bottom() : 0, false);
   }
@@ -317,6 +304,7 @@ BorTag __bsan_retag(void *object_addr, uptr access_size, u8 flags,
   BorTag new_tag = bor_tag;
   if (__bsan_retag_impl) {
     GET_SPAN;
+    InterceptorBarrier Barrier;
     new_tag =
         __bsan_retag_impl(object_addr, access_size, flags, im_data, im_len,
                           pin_data, pin_len, bor_tag, alloc_info, span);
@@ -334,6 +322,7 @@ void __bsan_read(void *ptr, uptr access_size, BorTag bor_tag,
                  AllocInfo *alloc_info) {
   if (__bsan_read_impl) {
     GET_SPAN;
+    InterceptorBarrier Barrier;
     __bsan_read_impl(ptr, access_size, bor_tag, alloc_info, span);
     HANDLE_ERROR;
   }
@@ -348,6 +337,7 @@ void __bsan_write(void *ptr, uptr access_size, BorTag bor_tag,
                   AllocInfo *alloc_info) {
   if (__bsan_write_impl) {
     GET_SPAN;
+    InterceptorBarrier Barrier;
     __bsan_write_impl(ptr, access_size, bor_tag, alloc_info, span);
     HANDLE_ERROR;
   }
@@ -373,7 +363,7 @@ __bsan_reserve_stack_slot() {
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
-__bsan_destroy_stack_slot(AllocInfo *slot) {}
+__bsan_destroy_stack_slot(AllocInfo *slot);
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE AllocInfo *
 __bsan_alloc(void *base_addr, uptr size, BorTag bor_tag, Span pc) {
@@ -391,39 +381,42 @@ void __bsan_alloc_stack(void *base_addr, uptr size, BorTag bor_tag,
                         AllocInfo *alloc_info) {
   if (__bsan_alloc_stack_impl) {
     GET_SPAN;
+    InterceptorBarrier Barrier;
     __bsan_alloc_stack_impl(base_addr, size, bor_tag, alloc_info, span);
     HANDLE_ERROR;
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_dealloc_stack_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc) {
-}
+void __bsan_dealloc_stack_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_dealloc_stack(void *ptr, BorTag bor_tag, AllocInfo *alloc_info) {
   if (__bsan_dealloc_stack_impl) {
     GET_SPAN;
+    InterceptorBarrier Barrier;
     __bsan_dealloc_stack_impl(bor_tag, alloc_info, span);
     HANDLE_ERROR;
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_protector_end_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc) {
-}
+void __bsan_protector_end_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_pop_frame(const Provenance *frame_start, uptr prot,
                       uptr alloca_vec_size) {
-  GET_SPAN;
-  for (uptr i = 0; i < prot + alloca_vec_size; i++) {
-    const Provenance Prov = frame_start[i];
-    if (i < prot) {
-      __bsan_protector_end_impl(Prov.Tag, Prov.Info, span);
-    } else {
-      __bsan_dealloc_stack_impl(Prov.Tag, Prov.Info, span);
-      __bsan_destroy_stack_slot(Prov.Info);
+  if (__bsan_protector_end_impl && __bsan_destroy_stack_slot && __bsan_dealloc_stack_impl) {
+    GET_SPAN;
+    InterceptorBarrier Barrier;
+    for (uptr i = 0; i < prot + alloca_vec_size; i++) {
+      const Provenance Prov = frame_start[i];
+      if (i < prot) {
+        __bsan_protector_end_impl(Prov.Tag, Prov.Info, span);
+      } else {
+        __bsan_dealloc_stack_impl(Prov.Tag, Prov.Info, span);
+        __bsan_destroy_stack_slot(Prov.Info);
+      }
     }
   }
 }
@@ -434,6 +427,7 @@ void __bsan_print(BorTag bor_tag, AllocInfo *alloc_info) {}
 
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print(void *ptr) {
   Provenance *Slot = GetSlot(0);
+  InterceptorBarrier Barrier;
   __bsan_print(Slot->Tag, Slot->Info);
 }
 
@@ -442,6 +436,7 @@ void __bsan_print_borrow_state(BorTag bor_tag, AllocInfo *alloc_info) {}
 
 void __bsan_debug_print_borrow_state(void *ptr) {
   Provenance *Slot = GetSlot(0);
+  InterceptorBarrier Barrier;
   __bsan_print_borrow_state(Slot->Tag, Slot->Info);
 }
 
@@ -450,6 +445,7 @@ void __bsan_tree_size(BorTag bor_tag, AllocInfo *alloc_info) {}
 
 void __bsan_debug_tree_size(void *ptr) {
   Provenance *Slot = GetSlot(0);
+  InterceptorBarrier Barrier;
   __bsan_tree_size(Slot->Tag, Slot->Info);
 }
 
@@ -458,6 +454,7 @@ void __bsan_snapshot(BorTag bor_tag, AllocInfo *alloc_info) {}
 
 void __bsan_debug_snapshot(void *ptr) {
   Provenance *Slot = GetSlot(0);
+  InterceptorBarrier Barrier;
   __bsan_snapshot(Slot->Tag, Slot->Info);
 }
 
@@ -466,6 +463,7 @@ SANITIZER_WEAK_ATTRIBUTE void __bsan_print_diff(BorTag bor_tag,
 
 void __bsan_debug_print_diff(void *ptr) {
   Provenance *Slot = GetSlot(0);
+  InterceptorBarrier Barrier;
   __bsan_print_diff(Slot->Tag, Slot->Info);
 }
 

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -406,7 +406,8 @@ void __bsan_protector_end_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc);
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_pop_frame(const Provenance *frame_start, uptr prot,
                       uptr alloca_vec_size) {
-  if (__bsan_protector_end_impl && __bsan_destroy_stack_slot && __bsan_dealloc_stack_impl) {
+  if (__bsan_protector_end_impl && __bsan_destroy_stack_slot &&
+      __bsan_dealloc_stack_impl) {
     GET_SPAN;
     InterceptorBarrier Barrier;
     for (uptr i = 0; i < prot + alloca_vec_size; i++) {

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -42,6 +42,15 @@ extern bool bsan_init_running;
 extern bool bsan_deinit_running;
 extern atomic_uintptr_t thread_id;
 
+extern THREADLOCAL int block_interception;
+
+struct InterceptorBarrier {
+  InterceptorBarrier() { ++block_interception; }
+  ~InterceptorBarrier() { --block_interception; }
+};
+
+bool BlockInterception();
+
 BorTag NewBorTag();
 
 void InitializeGC();

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -1,16 +1,30 @@
+#define SANITIZER_COMMON_NO_REDEFINE_BUILTINS
+
 #include "bsan.h"
 #include "bsan_interface_internal.h"
 #include "bsan_thread.h"
 #include "interception/interception.h"
+#include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_allocator.h"
 #include "sanitizer_common/sanitizer_allocator_dlsym.h"
 #include "sanitizer_common/sanitizer_allocator_interface.h"
+#include "sanitizer_common/sanitizer_platform_interceptors.h"
 #include "sanitizer_common/sanitizer_linux.h"
 #include "sanitizer_common/sanitizer_stacktrace.h"
+#include "sanitizer_common/sanitizer_atomic.h"
+#include "sanitizer_common/sanitizer_errno.h"
+#include "sanitizer_common/sanitizer_errno_codes.h"
+#include "sanitizer_common/sanitizer_libc.h"
+#include "sanitizer_common/sanitizer_placement_new.h"
 #include "sanitizer_common/sanitizer_vector.h"
 
 using namespace __sanitizer;
 using namespace __bsan;
+
+namespace __bsan {
+  THREADLOCAL int block_interception;
+  bool BlockInterception() { return block_interception; }
+}
 
 DECLARE_REAL(void *, malloc, SIZE_T)
 DECLARE_REAL(void, free, void *)
@@ -32,15 +46,20 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
     }                                                                          \
   } while (0)
 
-struct InterceptorContext {
-  Mutex AtExitLock;
-  Vector<struct BSanAtExitRecord *> AtExitStack;
-  InterceptorContext() : AtExitStack() {}
+
+struct LocalInterceptorContext {
+  bool block_interception;
 };
 
-alignas(64) static char ictx[sizeof(InterceptorContext)];
-InterceptorContext *interceptor_ctx() {
-  return reinterpret_cast<InterceptorContext *>(&ictx[0]);
+struct GlobalInterceptorContext {
+  Mutex AtExitLock;
+  Vector<struct BSanAtExitRecord *> AtExitStack;
+  GlobalInterceptorContext() : AtExitStack() {}
+};
+
+alignas(64) static char ictx[sizeof(GlobalInterceptorContext)];
+GlobalInterceptorContext *global_interceptor_ctx() {
+  return reinterpret_cast<GlobalInterceptorContext *>(&ictx[0]);
 }
 
 static void *BsanThreadStartFunc(void *arg) {
@@ -75,12 +94,15 @@ extern "C" void *__bsan_crt_malloc(SIZE_T size) {
   return REAL(malloc)(size);
 }
 
+
 INTERCEPTOR(void *, malloc, SIZE_T size) {
   GET_SPAN;
   if (DlsymAlloc::Use())
     return DlsymAlloc::Allocate(size);
+  bool already_in_scope = BlockInterception();
+  InterceptorBarrier barrier;
   void *ptr = REAL(malloc)(size);
-  if (INST_CALLER(malloc)) {
+  if (!already_in_scope && INST_CALLER(malloc)) {
     Provenance *RetSlot = GetSlot(0);
     BorTag Tag = NewBorTag();
     *RetSlot = {Tag, __bsan_alloc(ptr, size, Tag, span)};
@@ -102,7 +124,9 @@ INTERCEPTOR(void, free, void *ptr) {
     return;
   if (DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Free(ptr);
-  if (INST_CALLER(free)) {
+  bool already_in_scope = BlockInterception();
+  InterceptorBarrier barrier;
+  if (!already_in_scope && INST_CALLER(free)) {
     Provenance *Slot = GetSlot(0);
     __bsan_dealloc(ptr, Slot->Tag, Slot->Info, span);
     HANDLE_ERROR_PC_BP(pc, bp);
@@ -114,9 +138,11 @@ INTERCEPTOR(void *, calloc, SIZE_T nmemb, SIZE_T size) {
   uptr span = GET_CALLER_PC();
   if (DlsymAlloc::Use())
     return DlsymAlloc::Callocate(nmemb, size);
+  bool already_in_scope = BlockInterception();
+  InterceptorBarrier barrier;
   void *ptr = REAL(calloc)(nmemb, size);
-  Provenance *RetSlot = GetSlot(0);
-  if (INST_CALLER(calloc)) {
+  if (!already_in_scope && INST_CALLER(calloc)) {
+    Provenance *RetSlot = GetSlot(0);
     BorTag Tag = NewBorTag();
     *RetSlot = {Tag, __bsan_alloc(ptr, nmemb * size, Tag, span)};
   }
@@ -127,13 +153,16 @@ INTERCEPTOR(void *, realloc, void *ptr, SIZE_T size) {
   GET_SPAN_PC_BP;
   if (DlsymAlloc::Use() || DlsymAlloc::PointerIsMine(ptr))
     return DlsymAlloc::Realloc(ptr, size);
-  bool is_inst = INST_CALLER(realloc);
+  bool already_in_scope = BlockInterception();
+  InterceptorBarrier barrier;
+  bool is_inst = !already_in_scope && INST_CALLER(realloc);
   if (is_inst) {
     Provenance *Slot = GetSlot(0);
     __bsan_dealloc(ptr, Slot->Tag, Slot->Info, span);
     HANDLE_ERROR_PC_BP(pc, bp);
   }
   void *nptr = REAL(realloc)(ptr, size);
+  __bsan_shadow_transfer(nptr, ptr, size);
   if (is_inst) {
     Provenance *RetSlot = GetSlot(0);
     BorTag Tag = NewBorTag();
@@ -145,7 +174,7 @@ INTERCEPTOR(void *, realloc, void *ptr, SIZE_T size) {
 extern "C" {
 
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memset(void *dest, int c, uptr n) {
-  if (!bsan_inited || bsan_init_running) {
+  if (!bsan_inited || bsan_init_running || BlockInterception()) {
     internal_memset(dest, c, n);
   } else {
     ENSURE_BSAN_INITED();
@@ -156,10 +185,11 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memset(void *dest, int c, uptr n) {
 
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memmove(void *dest, const void *src,
                                                   uptr n) {
-  if (!bsan_inited || bsan_init_running) {
+  if (!bsan_inited || bsan_init_running || BlockInterception()) {
     internal_memmove(dest, src, n);
   } else {
     ENSURE_BSAN_INITED();
+    InterceptorBarrier barrier;
     __bsan_shadow_transfer(dest, src, n);
     internal_memmove(dest, src, n);
   }
@@ -167,11 +197,12 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memmove(void *dest, const void *src,
 
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memcpy(void *dest, const void *src,
                                                  uptr n) {
-  if (!bsan_inited || bsan_init_running) {
+  if (!bsan_inited || bsan_init_running || BlockInterception()) {
     internal_memcpy(dest, src, n);
   } else {
     ENSURE_BSAN_INITED();
     internal_memcpy(dest, src, n);
+    InterceptorBarrier barrier;
     __bsan_shadow_transfer(dest, src, n);
   }
 }
@@ -186,11 +217,11 @@ struct BSanAtExitRecord {
 void BSanAtExitWrapper() {
   BSanAtExitRecord *r;
   {
-    Lock l(&interceptor_ctx()->AtExitLock);
+    Lock l(&global_interceptor_ctx()->AtExitLock);
 
-    uptr element = interceptor_ctx()->AtExitStack.Size() - 1;
-    r = interceptor_ctx()->AtExitStack[element];
-    interceptor_ctx()->AtExitStack.PopBack();
+    uptr element = global_interceptor_ctx()->AtExitStack.Size() - 1;
+    r = global_interceptor_ctx()->AtExitStack[element];
+    global_interceptor_ctx()->AtExitStack.PopBack();
   }
 
   ClearSlot(0);
@@ -238,11 +269,11 @@ static int setup_at_exit_wrapper(void (*f)(), void *arg, void *dso) {
     // NetBSD does not preserve the 2nd argument if dso is equal to 0
     // Store ctx in a local stack-like structure
 
-    Lock l(&interceptor_ctx()->AtExitLock);
+    Lock l(&global_interceptor_ctx()->AtExitLock);
 
     res = REAL(__cxa_atexit)((void (*)(void *a))BSanAtExitWrapper, 0, 0);
     if (!res) {
-      interceptor_ctx()->AtExitStack.PushBack(r);
+      global_interceptor_ctx()->AtExitStack.PushBack(r);
     }
   } else {
     res = REAL(__cxa_atexit)(BSanCxaAtExitWrapper, r, dso);
@@ -250,10 +281,135 @@ static int setup_at_exit_wrapper(void (*f)(), void *arg, void *dso) {
   return res;
 }
 
+#define BSAN_INTERCEPT_FUNC(name)                                       \
+  do {                                                                  \
+    if (!INTERCEPT_FUNCTION(name))                                      \
+      VReport(1, "BorrowSanitizer: failed to intercept '%s'\n", #name); \
+  } while (0)
+
+#define BSAN_INTERCEPT_FUNC_VER(name, ver)                                 \
+  do {                                                                     \
+    if (!INTERCEPT_FUNCTION_VER(name, ver))                                \
+      VReport(1, "BorrowSanitizer: failed to intercept '%s@@%s'\n", #name, \
+              ver);                                                        \
+  } while (0)
+
+#define BSAN_INTERCEPT_FUNC_VER_UNVERSIONED_FALLBACK(name, ver)             \
+  do {                                                                      \
+    if (!INTERCEPT_FUNCTION_VER(name, ver) && !INTERCEPT_FUNCTION(name))    \
+      VReport(1, "BorrowSanitizer: failed to intercept '%s@@%s' or '%s'\n", \
+              #name, ver, #name);                                           \
+  } while (0)
+
+#define COMMON_INTERCEPT_FUNCTION(name) BSAN_INTERCEPT_FUNC(name)
+
+#define COMMON_INTERCEPT_FUNCTION_VER(name, ver) \
+  BSAN_INTERCEPT_FUNC_VER(name, ver)
+
+#define COMMON_INTERCEPT_FUNCTION_VER_UNVERSIONED_FALLBACK(name, ver) \
+  BSAN_INTERCEPT_FUNC_VER_UNVERSIONED_FALLBACK(name, ver) 
+  
+#define COMMON_INTERCEPTOR_UNPOISON_PARAM(count)  \
+  do {} while (false) \
+
+#define COMMON_INTERCEPTOR_WRITE_RANGE(ctx, ptr, size) \
+  do {} while (false) \
+
+#define COMMON_INTERCEPTOR_READ_RANGE(ctx, ptr, size) \
+  do {} while (false) \
+
+#define COMMON_INTERCEPTOR_INITIALIZE_RANGE(ptr, size) \
+  do {} while (false)
+
+#define COMMON_INTERCEPTOR_ENTER(ctx, func, ...)               \
+  if (bsan_init_running)                                       \
+    return REAL(func)(__VA_ARGS__);                            \
+  ENSURE_BSAN_INITED();                                        \
+  LocalInterceptorContext bsan_ctx = {BlockInterception()};    \
+  ctx = (void *)&bsan_ctx;                                     \
+  (void)ctx;                                                   \
+  InterceptorBarrier barrier;                                  \
+
+#define COMMON_INTERCEPTOR_DIR_ACQUIRE(ctx, path) \
+  do {} while (false)
+#define COMMON_INTERCEPTOR_FD_ACQUIRE(ctx, fd) \
+  do {} while (false)
+#define COMMON_INTERCEPTOR_FD_RELEASE(ctx, fd) \
+  do {} while (false)
+#define COMMON_INTERCEPTOR_FD_SOCKET_ACCEPT(ctx, fd, newfd) \
+  do {} while (false)
+#define COMMON_INTERCEPTOR_SET_THREAD_NAME(ctx, name) \
+  do {} while (false)
+#define COMMON_INTERCEPTOR_SET_PTHREAD_NAME(ctx, thread, name) \
+  do {} while (false)
+#define COMMON_INTERCEPTOR_BLOCK_REAL(name) REAL(name)
+#define COMMON_INTERCEPTOR_ON_EXIT(ctx) OnExit()
+
+#define COMMON_INTERCEPTOR_LIBRARY_LOADED(filename, handle) \
+  do {} while (false)
+#define COMMON_INTERCEPTOR_NOTHING_IS_INITIALIZED (!bsan_inited)
+
+#define COMMON_INTERCEPTOR_GET_TLS_RANGE(begin, end) *begin = *end = 0; 
+
+#define COMMON_INTERCEPTOR_MEMSET_IMPL(ctx, block, c, size) \
+  {                                                         \
+    (void)ctx;                                              \
+    __bsan_memset(block, c, size);                          \
+    return block;                                           \
+  }
+#define COMMON_INTERCEPTOR_MEMMOVE_IMPL(ctx, to, from, size) \
+  {                                                          \
+    (void)ctx;                                               \
+    __bsan_memmove(to, from, size);                          \
+    return to;                                               \
+  }
+#define COMMON_INTERCEPTOR_MEMCPY_IMPL(ctx, to, from, size) \
+  {                                                         \
+    (void)ctx;                                              \
+    __bsan_memcpy(to, from, size);                          \
+    return to;                                              \
+  }
+
+#define COMMON_INTERCEPTOR_COPY_STRING(ctx, to, from, size) \
+  do {} while (false) \
+
+#define COMMON_INTERCEPTOR_MMAP_IMPL(ctx, mmap, addr, length, prot, flags, fd, \
+                                     offset)                                   \
+  do {                                                                         \
+    return REAL(mmap)(addr, length, prot, flags, fd, offset);                  \
+  } while (false)
+
+namespace __bsan {
+int OnExit() { return 0; }
+} // namespace __bsan
+
+
+#include "sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc"
+#include "sanitizer_common/sanitizer_common_interceptors.inc"
+
+#define SIGNAL_INTERCEPTOR_ENTER() ENSURE_BSAN_INITED()
+
+#include "sanitizer_common/sanitizer_signal_interceptors.inc"
+
+#define COMMON_SYSCALL_PRE_READ_RANGE(p, s) do {} while (false)
+#define COMMON_SYSCALL_PRE_WRITE_RANGE(p, s) do {} while (false)
+#define COMMON_SYSCALL_POST_READ_RANGE(p, s) do {} while (false)
+#define COMMON_SYSCALL_POST_WRITE_RANGE(p, s) do {} while (false)
+#include "sanitizer_common/sanitizer_common_syscalls.inc"
+#include "sanitizer_common/sanitizer_syscalls_netbsd.inc"
+
 namespace __bsan {
 
 void InitializeInterceptors() {
+  static int inited = 0;
+  CHECK_EQ(inited, 0);
   __interception::DoesNotSupportStaticLinking();
+
+  new(global_interceptor_ctx()) GlobalInterceptorContext();
+
+  InitializeCommonInterceptors();
+  InitializeSignalInterceptors();
+
   INTERCEPT_FUNCTION(pthread_create);
   INTERCEPT_FUNCTION(free);
   INTERCEPT_FUNCTION(malloc);
@@ -261,6 +417,9 @@ void InitializeInterceptors() {
   INTERCEPT_FUNCTION(realloc);
   INTERCEPT_FUNCTION(atexit);
   INTERCEPT_FUNCTION(__cxa_atexit);
+
+  inited = 1;
 }
 
 } // namespace __bsan
+

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -24,6 +24,7 @@ using namespace __bsan;
 namespace __bsan {
 THREADLOCAL int block_interception;
 bool BlockInterception() { return block_interception; }
+int OnExit() { return 0; }
 } // namespace __bsan
 
 DECLARE_REAL(void *, malloc, SIZE_T)
@@ -389,12 +390,10 @@ static int setup_at_exit_wrapper(void (*f)(), void *arg, void *dso) {
     return REAL(mmap)(addr, length, prot, flags, fd, offset);                  \
   } while (false)
 
-namespace __bsan {
-int OnExit() { return 0; }
-} // namespace __bsan
-
-#include "sanitizer_common/sanitizer_common_interceptors.inc"
+// clang-format off
 #include "sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc"
+#include "sanitizer_common/sanitizer_common_interceptors.inc"
+// clang-format on
 
 #define SIGNAL_INTERCEPTOR_ENTER() ENSURE_BSAN_INITED()
 
@@ -412,8 +411,11 @@ int OnExit() { return 0; }
 #define COMMON_SYSCALL_POST_WRITE_RANGE(p, s)                                  \
   do {                                                                         \
   } while (false)
+
+// clang-format off
 #include "sanitizer_common/sanitizer_common_syscalls.inc"
 #include "sanitizer_common/sanitizer_syscalls_netbsd.inc"
+// clang-format on
 
 namespace __bsan {
 

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -4,27 +4,27 @@
 #include "bsan_interface_internal.h"
 #include "bsan_thread.h"
 #include "interception/interception.h"
-#include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_allocator.h"
 #include "sanitizer_common/sanitizer_allocator_dlsym.h"
 #include "sanitizer_common/sanitizer_allocator_interface.h"
-#include "sanitizer_common/sanitizer_platform_interceptors.h"
-#include "sanitizer_common/sanitizer_linux.h"
-#include "sanitizer_common/sanitizer_stacktrace.h"
 #include "sanitizer_common/sanitizer_atomic.h"
+#include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_errno.h"
 #include "sanitizer_common/sanitizer_errno_codes.h"
 #include "sanitizer_common/sanitizer_libc.h"
+#include "sanitizer_common/sanitizer_linux.h"
 #include "sanitizer_common/sanitizer_placement_new.h"
+#include "sanitizer_common/sanitizer_platform_interceptors.h"
+#include "sanitizer_common/sanitizer_stacktrace.h"
 #include "sanitizer_common/sanitizer_vector.h"
 
 using namespace __sanitizer;
 using namespace __bsan;
 
 namespace __bsan {
-  THREADLOCAL int block_interception;
-  bool BlockInterception() { return block_interception; }
-}
+THREADLOCAL int block_interception;
+bool BlockInterception() { return block_interception; }
+} // namespace __bsan
 
 DECLARE_REAL(void *, malloc, SIZE_T)
 DECLARE_REAL(void, free, void *)
@@ -45,7 +45,6 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
       __bsan_init();                                                           \
     }                                                                          \
   } while (0)
-
 
 struct LocalInterceptorContext {
   bool block_interception;
@@ -93,7 +92,6 @@ extern "C" void *__bsan_crt_malloc(SIZE_T size) {
     return DlsymAlloc::Allocate(size);
   return REAL(malloc)(size);
 }
-
 
 INTERCEPTOR(void *, malloc, SIZE_T size) {
   GET_SPAN;
@@ -281,97 +279,109 @@ static int setup_at_exit_wrapper(void (*f)(), void *arg, void *dso) {
   return res;
 }
 
-#define BSAN_INTERCEPT_FUNC(name)                                       \
-  do {                                                                  \
-    if (!INTERCEPT_FUNCTION(name))                                      \
-      VReport(1, "BorrowSanitizer: failed to intercept '%s'\n", #name); \
+#define BSAN_INTERCEPT_FUNC(name)                                              \
+  do {                                                                         \
+    if (!INTERCEPT_FUNCTION(name))                                             \
+      VReport(1, "BorrowSanitizer: failed to intercept '%s'\n", #name);        \
   } while (0)
 
-#define BSAN_INTERCEPT_FUNC_VER(name, ver)                                 \
-  do {                                                                     \
-    if (!INTERCEPT_FUNCTION_VER(name, ver))                                \
-      VReport(1, "BorrowSanitizer: failed to intercept '%s@@%s'\n", #name, \
-              ver);                                                        \
+#define BSAN_INTERCEPT_FUNC_VER(name, ver)                                     \
+  do {                                                                         \
+    if (!INTERCEPT_FUNCTION_VER(name, ver))                                    \
+      VReport(1, "BorrowSanitizer: failed to intercept '%s@@%s'\n", #name,     \
+              ver);                                                            \
   } while (0)
 
-#define BSAN_INTERCEPT_FUNC_VER_UNVERSIONED_FALLBACK(name, ver)             \
-  do {                                                                      \
-    if (!INTERCEPT_FUNCTION_VER(name, ver) && !INTERCEPT_FUNCTION(name))    \
-      VReport(1, "BorrowSanitizer: failed to intercept '%s@@%s' or '%s'\n", \
-              #name, ver, #name);                                           \
+#define BSAN_INTERCEPT_FUNC_VER_UNVERSIONED_FALLBACK(name, ver)                \
+  do {                                                                         \
+    if (!INTERCEPT_FUNCTION_VER(name, ver) && !INTERCEPT_FUNCTION(name))       \
+      VReport(1, "BorrowSanitizer: failed to intercept '%s@@%s' or '%s'\n",    \
+              #name, ver, #name);                                              \
   } while (0)
 
 #define COMMON_INTERCEPT_FUNCTION(name) BSAN_INTERCEPT_FUNC(name)
 
-#define COMMON_INTERCEPT_FUNCTION_VER(name, ver) \
+#define COMMON_INTERCEPT_FUNCTION_VER(name, ver)                               \
   BSAN_INTERCEPT_FUNC_VER(name, ver)
 
-#define COMMON_INTERCEPT_FUNCTION_VER_UNVERSIONED_FALLBACK(name, ver) \
-  BSAN_INTERCEPT_FUNC_VER_UNVERSIONED_FALLBACK(name, ver) 
-  
-#define COMMON_INTERCEPTOR_UNPOISON_PARAM(count)  \
-  do {} while (false) \
+#define COMMON_INTERCEPT_FUNCTION_VER_UNVERSIONED_FALLBACK(name, ver)          \
+  BSAN_INTERCEPT_FUNC_VER_UNVERSIONED_FALLBACK(name, ver)
 
-#define COMMON_INTERCEPTOR_WRITE_RANGE(ctx, ptr, size) \
-  do {} while (false) \
+#define COMMON_INTERCEPTOR_UNPOISON_PARAM(count)                               \
+  do {                                                                         \
+  } while (false)
 
-#define COMMON_INTERCEPTOR_READ_RANGE(ctx, ptr, size) \
-  do {} while (false) \
+#define COMMON_INTERCEPTOR_WRITE_RANGE(ctx, ptr, size)                         \
+  do {                                                                         \
+  } while (false)
 
-#define COMMON_INTERCEPTOR_INITIALIZE_RANGE(ptr, size) \
-  do {} while (false)
+#define COMMON_INTERCEPTOR_READ_RANGE(ctx, ptr, size)                          \
+  do {                                                                         \
+  } while (false)
 
-#define COMMON_INTERCEPTOR_ENTER(ctx, func, ...)               \
-  if (bsan_init_running)                                       \
-    return REAL(func)(__VA_ARGS__);                            \
-  ENSURE_BSAN_INITED();                                        \
-  LocalInterceptorContext bsan_ctx = {BlockInterception()};    \
-  ctx = (void *)&bsan_ctx;                                     \
-  (void)ctx;                                                   \
-  InterceptorBarrier barrier;                                  \
+#define COMMON_INTERCEPTOR_INITIALIZE_RANGE(ptr, size)                         \
+  do {                                                                         \
+  } while (false)
 
-#define COMMON_INTERCEPTOR_DIR_ACQUIRE(ctx, path) \
-  do {} while (false)
-#define COMMON_INTERCEPTOR_FD_ACQUIRE(ctx, fd) \
-  do {} while (false)
-#define COMMON_INTERCEPTOR_FD_RELEASE(ctx, fd) \
-  do {} while (false)
-#define COMMON_INTERCEPTOR_FD_SOCKET_ACCEPT(ctx, fd, newfd) \
-  do {} while (false)
-#define COMMON_INTERCEPTOR_SET_THREAD_NAME(ctx, name) \
-  do {} while (false)
-#define COMMON_INTERCEPTOR_SET_PTHREAD_NAME(ctx, thread, name) \
-  do {} while (false)
+#define COMMON_INTERCEPTOR_ENTER(ctx, func, ...)                               \
+  if (bsan_init_running)                                                       \
+    return REAL(func)(__VA_ARGS__);                                            \
+  ENSURE_BSAN_INITED();                                                        \
+  LocalInterceptorContext bsan_ctx = {BlockInterception()};                    \
+  ctx = (void *)&bsan_ctx;                                                     \
+  (void)ctx;                                                                   \
+  InterceptorBarrier barrier;
+
+#define COMMON_INTERCEPTOR_DIR_ACQUIRE(ctx, path)                              \
+  do {                                                                         \
+  } while (false)
+#define COMMON_INTERCEPTOR_FD_ACQUIRE(ctx, fd)                                 \
+  do {                                                                         \
+  } while (false)
+#define COMMON_INTERCEPTOR_FD_RELEASE(ctx, fd)                                 \
+  do {                                                                         \
+  } while (false)
+#define COMMON_INTERCEPTOR_FD_SOCKET_ACCEPT(ctx, fd, newfd)                    \
+  do {                                                                         \
+  } while (false)
+#define COMMON_INTERCEPTOR_SET_THREAD_NAME(ctx, name)                          \
+  do {                                                                         \
+  } while (false)
+#define COMMON_INTERCEPTOR_SET_PTHREAD_NAME(ctx, thread, name)                 \
+  do {                                                                         \
+  } while (false)
 #define COMMON_INTERCEPTOR_BLOCK_REAL(name) REAL(name)
 #define COMMON_INTERCEPTOR_ON_EXIT(ctx) OnExit()
 
-#define COMMON_INTERCEPTOR_LIBRARY_LOADED(filename, handle) \
-  do {} while (false)
+#define COMMON_INTERCEPTOR_LIBRARY_LOADED(filename, handle)                    \
+  do {                                                                         \
+  } while (false)
 #define COMMON_INTERCEPTOR_NOTHING_IS_INITIALIZED (!bsan_inited)
 
-#define COMMON_INTERCEPTOR_GET_TLS_RANGE(begin, end) *begin = *end = 0; 
+#define COMMON_INTERCEPTOR_GET_TLS_RANGE(begin, end) *begin = *end = 0;
 
-#define COMMON_INTERCEPTOR_MEMSET_IMPL(ctx, block, c, size) \
-  {                                                         \
-    (void)ctx;                                              \
-    __bsan_memset(block, c, size);                          \
-    return block;                                           \
+#define COMMON_INTERCEPTOR_MEMSET_IMPL(ctx, block, c, size)                    \
+  {                                                                            \
+    (void)ctx;                                                                 \
+    __bsan_memset(block, c, size);                                             \
+    return block;                                                              \
   }
-#define COMMON_INTERCEPTOR_MEMMOVE_IMPL(ctx, to, from, size) \
-  {                                                          \
-    (void)ctx;                                               \
-    __bsan_memmove(to, from, size);                          \
-    return to;                                               \
+#define COMMON_INTERCEPTOR_MEMMOVE_IMPL(ctx, to, from, size)                   \
+  {                                                                            \
+    (void)ctx;                                                                 \
+    __bsan_memmove(to, from, size);                                            \
+    return to;                                                                 \
   }
-#define COMMON_INTERCEPTOR_MEMCPY_IMPL(ctx, to, from, size) \
-  {                                                         \
-    (void)ctx;                                              \
-    __bsan_memcpy(to, from, size);                          \
-    return to;                                              \
+#define COMMON_INTERCEPTOR_MEMCPY_IMPL(ctx, to, from, size)                    \
+  {                                                                            \
+    (void)ctx;                                                                 \
+    __bsan_memcpy(to, from, size);                                             \
+    return to;                                                                 \
   }
 
-#define COMMON_INTERCEPTOR_COPY_STRING(ctx, to, from, size) \
-  do {} while (false) \
+#define COMMON_INTERCEPTOR_COPY_STRING(ctx, to, from, size)                    \
+  do {                                                                         \
+  } while (false)
 
 #define COMMON_INTERCEPTOR_MMAP_IMPL(ctx, mmap, addr, length, prot, flags, fd, \
                                      offset)                                   \
@@ -383,18 +393,25 @@ namespace __bsan {
 int OnExit() { return 0; }
 } // namespace __bsan
 
-
-#include "sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc"
 #include "sanitizer_common/sanitizer_common_interceptors.inc"
+#include "sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc"
 
 #define SIGNAL_INTERCEPTOR_ENTER() ENSURE_BSAN_INITED()
 
 #include "sanitizer_common/sanitizer_signal_interceptors.inc"
 
-#define COMMON_SYSCALL_PRE_READ_RANGE(p, s) do {} while (false)
-#define COMMON_SYSCALL_PRE_WRITE_RANGE(p, s) do {} while (false)
-#define COMMON_SYSCALL_POST_READ_RANGE(p, s) do {} while (false)
-#define COMMON_SYSCALL_POST_WRITE_RANGE(p, s) do {} while (false)
+#define COMMON_SYSCALL_PRE_READ_RANGE(p, s)                                    \
+  do {                                                                         \
+  } while (false)
+#define COMMON_SYSCALL_PRE_WRITE_RANGE(p, s)                                   \
+  do {                                                                         \
+  } while (false)
+#define COMMON_SYSCALL_POST_READ_RANGE(p, s)                                   \
+  do {                                                                         \
+  } while (false)
+#define COMMON_SYSCALL_POST_WRITE_RANGE(p, s)                                  \
+  do {                                                                         \
+  } while (false)
 #include "sanitizer_common/sanitizer_common_syscalls.inc"
 #include "sanitizer_common/sanitizer_syscalls_netbsd.inc"
 
@@ -405,7 +422,7 @@ void InitializeInterceptors() {
   CHECK_EQ(inited, 0);
   __interception::DoesNotSupportStaticLinking();
 
-  new(global_interceptor_ctx()) GlobalInterceptorContext();
+  new (global_interceptor_ctx()) GlobalInterceptorContext();
 
   InitializeCommonInterceptors();
   InitializeSignalInterceptors();
@@ -422,4 +439,3 @@ void InitializeInterceptors() {
 }
 
 } // namespace __bsan
-


### PR DESCRIPTION
This PR adds the sanitizer common interceptors for signal handlers and syscalls. It ensures that shadow memory updates associated with `memset`, `memcpy`, and `memmove` are handled. 

This will be crucial for avoiding false positives. We cannot validate read and write accesses that occur in interceptors yet, but we can (at least optimistically) model their effects on shadow memory.