### PR TITLE
Wildcard Provenance (Part #1)

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1206,6 +1206,13 @@ private:
     }
   }
 
+  void visitPtrToIntInst(PtrToIntInst &I) {
+    if (auto Prov = getProvenance(I.getParent(), I.getPointerOperand())) {
+      IRBuilder<> IRB(&I);
+      IRB.CreateCall(BS.BsanFuncExposeProv, {(*Prov).Tag, (*Prov).Info});
+    }
+  }
+
   void visitAddrSpaceCastInst(AddrSpaceCastInst &I) {
     // Address space casts do not affect provenance.
     // We can propagage the provenance of the input to the output value.
@@ -1546,6 +1553,9 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
 
   BsanFuncDestroyStackSlot = M.getOrInsertFunction(BSAN("destroy_stack_slot"),
                                                    AL, IRB.getVoidTy(), PtrTy);
+
+  BsanFuncExposeProv = M.getOrInsertFunction(BSAN("expose_prov"), AL,
+                                             IRB.getVoidTy(), IntptrTy, PtrTy);
 
   EHPersonality Pers = getDefaultEHPersonality(TargetTriple);
   DefaultPersonalityFn =

--- a/bsan-pass/BorrowSanitizer.h
+++ b/bsan-pass/BorrowSanitizer.h
@@ -78,6 +78,8 @@ public:
 
   FunctionCallee DefaultPersonalityFn;
 
+  FunctionCallee BsanFuncExposeProv;
+
   // Thread-local storage for paramters
   // and return values.
   Value *ProvStack = nullptr;

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -24,7 +24,8 @@ THREADLOCAL void *__bsan_marker = nullptr;
 
 // represents the number of provenance values that correspond to the variadic
 // arguments being passed to the current function
-SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL uptr __bsan_var_arg_ctr = 0;
+SANITIZER_INTERFACE_ATTRIBUTE
+THREADLOCAL uptr __bsan_var_arg_ctr = 0;
 
 // Pointer to the start of the current frame within the shadow
 // stack, which stores the provenance of pointers that are on
@@ -399,6 +400,16 @@ void __bsan_dealloc_stack(void *ptr, BorTag bor_tag, AllocInfo *alloc_info) {
     InterceptorBarrier Barrier;
     __bsan_dealloc_stack_impl(bor_tag, alloc_info, span);
     HANDLE_ERROR;
+  }
+}
+
+SANITIZER_WEAK_ATTRIBUTE
+void __bsan_expose_prov_impl(BorTag bor_tag, AllocInfo *alloc_info);
+
+SANITIZER_INTERFACE_ATTRIBUTE
+void __bsan_expose_prov(BorTag bor_tag, AllocInfo *alloc_info) {
+  if (__bsan_expose_prov_impl) {
+    __bsan_expose_prov_impl(bor_tag, alloc_info);
   }
 }
 

--- a/bsan-rt/src/borrow_tracker.rs
+++ b/bsan-rt/src/borrow_tracker.rs
@@ -1,62 +1,93 @@
 // Components in this library were ported from Miri and then modified by our team.
-use core::ffi::c_void;
+use core::ops::{Deref, DerefMut};
+use core::ptr::NonNull;
 
-use spin::MutexGuard;
+use spin::{Mutex, MutexGuard};
 
 use crate::errors::{UBInfo, UBResult};
 use crate::helpers::{AllocRange, Size};
 use crate::sanitizer_common::Span;
-use crate::tree_borrows::data_structures::DedupRangeMap;
+use crate::tree_borrows::data_structures::{AccessType, DedupRangeMap};
 use crate::tree_borrows::diagnostics::AccessCause;
 use crate::tree_borrows::perms::{AccessKind, Permission};
 use crate::tree_borrows::tree::LocationState;
-use crate::tree_borrows::{IdempotentForeignAccess, LazyTree, NewPermission};
-use crate::{AllocId, BorTag, GlobalCtx, Provenance, RetagFlags, RetagInfo};
+use crate::tree_borrows::{IdempotentForeignAccess, NewPermission};
+use crate::{AllocId, AllocInfo, BorTag, GlobalCtx, Provenance, RetagFlags, RetagInfo, LazyTree};
 
 #[derive(Debug)]
 pub struct BorrowTracker<'b> {
     alloc_id: AllocId,
     prov: Provenance,
+    base_addr: Size,
     range: AllocRange,
-    tree: MutexGuard<'b, LazyTree>,
+    tree: &'b Mutex<Option<LazyTree>>,
+}
+
+/// A guard over the `Tree` for an allocation.
+struct TreeGuard<'b>(MutexGuard<'b, Option<LazyTree>>);
+
+impl Deref for TreeGuard<'_> {
+    type Target = LazyTree;
+    fn deref(&self) -> &LazyTree {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl DerefMut for TreeGuard<'_> {
+    fn deref_mut(&mut self) -> &mut LazyTree {
+        self.0.as_mut().unwrap()
+    }
 }
 
 impl<'b> BorrowTracker<'b> {
-    fn tree_mut(&mut self) -> &mut LazyTree {
-        &mut self.tree
+    fn tree(&self) -> TreeGuard<'_> {
+        TreeGuard(self.tree.lock())
     }
 
-    fn tree(&self) -> &LazyTree {
-        &self.tree
+    fn alloc_info(&self) -> NonNull<AllocInfo> {
+        // SAFETY:
+        // When we construct an instance of `BorrowTracker`, we validate
+        // that its provenance value is nonnull.
+        unsafe { NonNull::new_unchecked(self.prov.alloc_info) }
     }
 
-    pub fn for_alloc<T, F>(prov: Provenance, f: F) -> UBResult<Option<T>>
+    fn alloc_size(&self) -> Size {
+        // SAFETY: see `alloc_info`; the pointer is non-null and valid for the
+        // lifetime of this `BorrowTracker`.
+        unsafe { (*self.prov.alloc_info).size }
+    }
+
+    unsafe fn for_alloc_inner(prov: Provenance) -> UBResult<Self> {
+        // Safety:
+        // Our instrumentation pass guarantees that if a pointer's
+        // provenance is non-null and not omnivalid, then it will contain
+        // valid allocation info pointer.
+        // TODO: support wildcard provenance
+        debug_assert!(!prov.alloc_info.is_null());
+        let alloc_id = unsafe { (*prov.alloc_info).alloc_id };
+        let base_addr = unsafe { (*prov.alloc_info).base_addr.base_addr };
+
+        let tree = unsafe { &(*prov.alloc_info).tree_lock };
+        if tree.lock().is_none() {
+            return Err(UBInfo::UseAfterFree);
+        }
+
+        let size = unsafe { (*prov.alloc_info).size };
+        let range = AllocRange { start: Size::ZERO, size };
+        Ok(Self { alloc_id, prov, base_addr, range, tree })
+    }
+
+    pub fn for_alloc<T, F>(prov: Provenance, f: F) -> UBResult<T>
     where
         F: FnOnce(Self) -> UBResult<T>,
+        T: Default,
     {
         if prov.bor_tag == BorTag::omnivalid() {
-            Ok(None)
+            Ok(T::default())
         } else if prov.bor_tag == BorTag::invalid() {
             Err(UBInfo::UseAfterFree)
         } else {
-            // Safety:
-            // Our instrumentation pass guarantees that if a pointer's
-            // provenance is non-null and not omnivalid, then it will contain
-            // valid allocation info pointer.
-            // TODO: support wildcard provenance
-            debug_assert!(!prov.alloc_info.is_null());
-            let alloc_id = unsafe { (*prov.alloc_info).alloc_id };
-
-            let tree = if let Some(tree_lock) = unsafe { (*prov.alloc_info).tree_lock.as_ref() } {
-                tree_lock
-            } else {
-                return Err(UBInfo::UseAfterFree);
-            };
-
-            let size = Size::from_bytes(unsafe { (*prov.alloc_info).size });
-            let range = AllocRange { start: Size::ZERO, size };
-            let tree = tree.lock();
-            f(Self { alloc_id, prov, range, tree }).map(|v| Some(v))
+            unsafe { BorrowTracker::for_alloc_inner(prov) }.and_then(f)
         }
     }
 
@@ -64,18 +95,19 @@ impl<'b> BorrowTracker<'b> {
     /// Takes in provenance pointer that is checked via debug_asserts
     pub fn for_access<T, F>(
         prov: Provenance,
-        start: *mut c_void,
-        access_size: Option<usize>,
+        start: Size,
+        access_size: Option<Size>,
         f: F,
-    ) -> UBResult<Option<T>>
+    ) -> UBResult<T>
     where
         F: FnOnce(Self) -> UBResult<T>,
+        T: Default,
     {
         if prov.bor_tag == BorTag::omnivalid() {
-            Ok(None)
+            Ok(T::default())
         } else if prov.bor_tag == BorTag::invalid() {
-            if access_size == Some(0) {
-                Ok(None)
+            if access_size == Some(Size::ZERO) {
+                Ok(T::default())
             } else {
                 Err(UBInfo::UseAfterFree)
             }
@@ -90,53 +122,45 @@ impl<'b> BorrowTracker<'b> {
             let alloc_id = unsafe { (*prov.alloc_info).alloc_id };
 
             let (alloc_size, base_addr) =
-                unsafe { ((*prov.alloc_info).size, (*prov.alloc_info).base_addr.addr) };
+                unsafe { ((*prov.alloc_info).size, (*prov.alloc_info).base_addr.base_addr) };
 
             let access_size = access_size.unwrap_or(alloc_size);
-            let tree = if let Some(tree_lock) = unsafe { (*prov.alloc_info).tree_lock.as_ref() } {
-                tree_lock
-            } else {
-                return if access_size != 0 { Err(UBInfo::UseAfterFree) } else { Ok(None) };
-            };
 
-            let tree = tree.lock();
-            if !tree.contains_tag(prov.bor_tag) {
-                return if access_size != 0 { Err(UBInfo::UseAfterFree) } else { Ok(None) };
-            }
-
-            let offset = start.addr().wrapping_sub(base_addr);
-            if start.addr() < base_addr || (offset + access_size > alloc_size) {
-                return if access_size != 0 {
-                    Err(UBInfo::AccessOutOfBounds { alloc_id, access_size, alloc_size, offset })
+            let tree = unsafe { &(*prov.alloc_info).tree_lock };
+            // The allocation has been freed (`None`), or the pointer's tag is no
+            // longer live in the tree (e.g. it referred to a now-reallocated
+            // allocation): either way, accessing it is a use-after-free. A
+            // zero-sized access is always permitted.
+            let is_live = matches!(
+                tree.lock().as_ref(),
+                Some(tree) if tree.contains_tag(prov.bor_tag)
+            );
+            if !is_live {
+                return if access_size != Size::ZERO {
+                    Err(UBInfo::UseAfterFree)
                 } else {
-                    Ok(None)
+                    Ok(T::default())
                 };
             }
 
-            let start = Size::from_bytes(offset);
-            let size = Size::from_bytes(access_size);
-            let range = AllocRange { start, size };
+            // It is crucial for this to be a wrapping sub here, since we want to accurately
+            // model the affect of applying an oversized offset on the allocation.
+            let offset = Size::from_bytes(start.bytes().wrapping_sub(base_addr.bytes()));
+            if start < base_addr || (offset + access_size > alloc_size) {
+                return if access_size != Size::ZERO {
+                    Err(UBInfo::AccessOutOfBounds { alloc_id, access_size, alloc_size, offset })
+                } else {
+                    Ok(T::default())
+                };
+            }
 
-            f(Self { alloc_id, prov, range, tree }).map(|r| Some(r))
+            let range = AllocRange { start: offset, size: access_size };
+            f(Self { alloc_id, prov, base_addr, range, tree })
         }
     }
 
     pub fn retag(
-        ctx: &GlobalCtx,
-        prov: Provenance,
-        start: *mut c_void,
-        retag_info: RetagInfo<'_>,
-        span: Span,
-    ) -> UBResult<BorTag> {
-        Self::for_access(prov, start, Some(retag_info.size), |mut bt| {
-            bt.retag_inner(ctx, retag_info, span)
-        })
-        .map(|opt| opt.unwrap_or(prov.bor_tag))
-    }
-
-    #[inline]
-    pub fn retag_inner(
-        &mut self,
+        &self,
         global_ctx: &GlobalCtx,
         retag_info: RetagInfo<'_>,
         span: Span,
@@ -170,7 +194,7 @@ impl<'b> BorrowTracker<'b> {
         };
 
         let mut inside_perms = DedupRangeMap::new(
-            Size::from_bytes(retag_info.size),
+            retag_info.size,
             LocationState::new_accessed(Permission::new_disabled(), IdempotentForeignAccess::None),
         );
 
@@ -187,17 +211,15 @@ impl<'b> BorrowTracker<'b> {
                 }
                 cursor = offset + size
             }
-            if cursor < Size::from_bytes(retag_info.size) {
-                let width = Size::from_bytes(retag_info.size - cursor.bytes() as usize);
+            if cursor < retag_info.size {
+                let width = retag_info.size - cursor;
                 for (_loc_range, loc) in inside_perms.iter_mut(cursor, width) {
                     *loc = loc_state(true);
                 }
             }
-        } else if retag_info.size > 0 {
+        } else if retag_info.size > Size::ZERO {
             let perm = loc_state(retag_info.flags.contains(RetagFlags::IS_FREEZE));
-            for (_loc_range, loc) in
-                inside_perms.iter_mut(Size::ZERO, Size::from_bytes(retag_info.size))
-            {
+            for (_loc_range, loc) in inside_perms.iter_mut(Size::ZERO, retag_info.size) {
                 *loc = perm;
             }
         }
@@ -213,7 +235,7 @@ impl<'b> BorrowTracker<'b> {
                 };
 
                 // Perform the access (update the Tree Borrows FSM)
-                self.tree_mut().perform_access(
+                self.tree().perform_access(
                     parent_tag,
                     range_in_alloc,
                     access_kind,
@@ -226,7 +248,7 @@ impl<'b> BorrowTracker<'b> {
         }
 
         // base offset should be the offset, from zero, where the retag is taking place within the allocation.
-        self.tree_mut().new_child(
+        self.tree().new_child(
             base_offset,
             parent_tag,
             new_tag,
@@ -239,9 +261,9 @@ impl<'b> BorrowTracker<'b> {
         Ok(new_tag)
     }
 
-    pub fn protector_end(&mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
+    pub fn protector_end(&self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
         let (bor_tag, alloc_id) = (self.prov.bor_tag, self.alloc_id);
-        self.tree_mut().perform_protector_end_access(
+        self.tree().perform_protector_end_access(
             bor_tag,
             &global_ctx.protected_tags(),
             alloc_id,
@@ -250,13 +272,13 @@ impl<'b> BorrowTracker<'b> {
     }
 
     pub fn access(
-        &mut self,
+        &self,
         global_ctx: &GlobalCtx,
         access_kind: AccessKind,
         span: Span,
     ) -> UBResult<()> {
         let (range, bor_tag, alloc_id) = (self.range, self.prov.bor_tag, self.alloc_id);
-        self.tree_mut().perform_access(
+        self.tree().perform_access(
             bor_tag,
             range,
             access_kind,
@@ -267,24 +289,67 @@ impl<'b> BorrowTracker<'b> {
         )
     }
 
-    pub fn dealloc(&mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
+    pub fn dealloc(&self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
         let (range, bor_tag, alloc_id) = (self.range, self.prov.bor_tag, self.alloc_id);
-        let tree = self.tree_mut();
-        tree.dealloc(bor_tag, range, &global_ctx.protected_tags(), alloc_id, span)?;
-        let info = unsafe { &mut *self.prov.alloc_info };
-        drop(info.tree_lock.take());
+
+        let mut guard = self.tree.lock();
+        if let Some(tree) = guard.as_mut() {
+            tree.dealloc(bor_tag, range, &global_ctx.protected_tags(), alloc_id, span)?;
+        }
+
+        *guard = None;
         Ok(())
     }
 
-    pub fn expose_tag(&mut self, global_ctx: &GlobalCtx) -> UBResult<()> {
+    /// Ensure that the allocation is invalidated without triggering UB for a use-after-free.
+    /// This is specific to stack deallocation. 
+    pub fn dealloc_weak(ctx: &GlobalCtx, prov: Provenance, span: Span) -> UBResult<()> {
+        if !prov.bor_tag.is_concrete() {
+            return Ok(());
+        }
+        // SAFETY: a concrete provenance is guaranteed by the instrumentation
+        // pass to carry a non-null, valid `alloc_info` pointer.
+        debug_assert!(!prov.alloc_info.is_null());
+        let info = unsafe { &*prov.alloc_info };
+        let mut guard = info.tree_lock.lock();
+        let Some(tree) = guard.as_mut() else {
+            unreachable!("double-free on a stack allocation.")
+        };
+        let range = AllocRange { start: Size::ZERO, size: info.size };
+        tree.dealloc(prov.bor_tag, range, &ctx.protected_tags(), info.alloc_id, span)?;
+        *guard = None;
+        Ok(())
+    }
+
+    pub fn expose_tag(&self, global_ctx: &GlobalCtx) -> UBResult<()> {
         let tag = self.prov.bor_tag;
-        let protected = global_ctx.protected_tags().get_protector_kind(tag).is_some();
-        self.tree_mut().expose_tag(tag, protected);
+
+        // First, we need to mark that the allocation has been exposed in our global mapping.
+        // We do this using a range object map covering the span of the entire address space.
+        let range = AllocRange { start: self.base_addr, size: self.alloc_size() };
+
+        let mut exposed = global_ctx.exposed_provenance_mut();
+        if let AccessType::Empty(pos) = exposed.access_type(range) {
+            exposed.insert_at_pos(pos, range, self.alloc_info());
+        }
+        drop(exposed);
+
+        // Then, within the tree associated with this allocation, we need to indicate that 
+        // this particular tag has been exposed. 
+        let mut tree = self.tree();
+        if tree.contains_tag(tag) {
+            let protected = global_ctx.protected_tags().get_protector_kind(tag).is_some();
+            tree.expose_tag(tag, protected);
+        }
         Ok(())
     }
 
-    pub fn expose(ctx: &GlobalCtx, prov: Provenance) -> UBResult<()> {
-        Self::for_alloc(prov, |mut bt| bt.expose_tag(ctx)).map(|_| ())
+    pub fn expose(ctx: &GlobalCtx, prov: Provenance) {
+        // Only concrete tags have valid `AllocInfo` to expose.
+        if prov.bor_tag.is_concrete() {
+            let _ =
+                unsafe { BorrowTracker::for_alloc_inner(prov) }.and_then(|bt| bt.expose_tag(ctx));
+        }
     }
 
     pub fn debug_take_snapshot(&self, ctx: &GlobalCtx) {

--- a/bsan-rt/src/borrow_tracker.rs
+++ b/bsan-rt/src/borrow_tracker.rs
@@ -12,7 +12,7 @@ use crate::tree_borrows::diagnostics::AccessCause;
 use crate::tree_borrows::perms::{AccessKind, Permission};
 use crate::tree_borrows::tree::LocationState;
 use crate::tree_borrows::{IdempotentForeignAccess, NewPermission};
-use crate::{AllocId, AllocInfo, BorTag, GlobalCtx, Provenance, RetagFlags, RetagInfo, LazyTree};
+use crate::{AllocId, AllocInfo, BorTag, GlobalCtx, LazyTree, Provenance, RetagFlags, RetagInfo};
 
 #[derive(Debug)]
 pub struct BorrowTracker<'b> {
@@ -302,7 +302,7 @@ impl<'b> BorrowTracker<'b> {
     }
 
     /// Ensure that the allocation is invalidated without triggering UB for a use-after-free.
-    /// This is specific to stack deallocation. 
+    /// This is specific to stack deallocation.
     pub fn dealloc_weak(ctx: &GlobalCtx, prov: Provenance, span: Span) -> UBResult<()> {
         if !prov.bor_tag.is_concrete() {
             return Ok(());
@@ -312,9 +312,7 @@ impl<'b> BorrowTracker<'b> {
         debug_assert!(!prov.alloc_info.is_null());
         let info = unsafe { &*prov.alloc_info };
         let mut guard = info.tree_lock.lock();
-        let Some(tree) = guard.as_mut() else {
-            unreachable!("double-free on a stack allocation.")
-        };
+        let Some(tree) = guard.as_mut() else { unreachable!("double-free on a stack allocation.") };
         let range = AllocRange { start: Size::ZERO, size: info.size };
         tree.dealloc(prov.bor_tag, range, &ctx.protected_tags(), info.alloc_id, span)?;
         *guard = None;
@@ -334,8 +332,8 @@ impl<'b> BorrowTracker<'b> {
         }
         drop(exposed);
 
-        // Then, within the tree associated with this allocation, we need to indicate that 
-        // this particular tag has been exposed. 
+        // Then, within the tree associated with this allocation, we need to indicate that
+        // this particular tag has been exposed.
         let mut tree = self.tree();
         if tree.contains_tag(tag) {
             let protected = global_ctx.protected_tags().get_protector_kind(tag).is_some();

--- a/bsan-rt/src/borrow_tracker.rs
+++ b/bsan-rt/src/borrow_tracker.rs
@@ -312,7 +312,7 @@ impl<'b> BorrowTracker<'b> {
         debug_assert!(!prov.alloc_info.is_null());
         let info = unsafe { &*prov.alloc_info };
         let mut guard = info.tree_lock.lock();
-        let Some(tree) = guard.as_mut() else { unreachable!("double-free on a stack allocation.") };
+        let Some(tree) = guard.as_mut() else { return Ok(()) };
         let range = AllocRange { start: Size::ZERO, size: info.size };
         tree.dealloc(prov.bor_tag, range, &ctx.protected_tags(), info.alloc_id, span)?;
         *guard = None;

--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -4,12 +4,13 @@ use core::cmp::max;
 
 use hashbrown::HashMap;
 
+use crate::helpers::Size;
 use crate::sanitizer_common::{SanitizerCommon, Span, Symbol};
 use crate::tree_borrows::diagnostics::TreeBorrowsUb;
 use crate::AllocId;
 
 pub enum UBInfo {
-    AccessOutOfBounds { alloc_id: AllocId, access_size: usize, offset: usize, alloc_size: usize },
+    AccessOutOfBounds { alloc_id: AllocId, access_size: Size, offset: Size, alloc_size: Size },
     UseAfterFree,
     AliasingViolation(TreeBorrowsUb),
 }
@@ -40,7 +41,7 @@ impl ErrorFormatContext {
             }
             UBInfo::AccessOutOfBounds { alloc_id, access_size, alloc_size, offset } => {
                 result.push_str(&format!(
-                    "an access of size {access_size}b at offset 0x{offset:x} is out of bounds for {alloc_id:?} of size {alloc_size}b.\n"
+                    "an access of size {access_size:x}b at offset 0x{offset:x} is out of bounds for {alloc_id:?} of size {alloc_size:x}b.\n"
                 ));
                 result.push_str(&self.format_symbol_standalone(symbol));
                 result.push('\n');

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -10,7 +10,8 @@ use crate::errors::{ErrorFormatContext, UBInfo};
 use crate::helpers::FxHashMap;
 use crate::local::LocalCtx;
 use crate::memory::{Heap, ShadowHeap};
-use crate::tree_borrows::{LazyTree, ProtectorKind};
+use crate::tree_borrows::data_structures::RangeObjectMap;
+use crate::tree_borrows::{ProtectorKind, LazyTree};
 use crate::*;
 
 pub static DISABLE_NODE_DEBUG_INFO: AtomicBool = AtomicBool::new(false);
@@ -63,6 +64,32 @@ impl<'a> Deref for ProtectedTagsRef<'a> {
     }
 }
 
+pub struct ExposedProvenanceRef<'a>(RwLockReadGuard<'a, RangeObjectMap<NonNull<AllocInfo>>>);
+
+impl<'a> Deref for ExposedProvenanceRef<'a> {
+    type Target = RangeObjectMap<NonNull<AllocInfo>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub struct ExposedProvenanceRefMut<'a>(RwLockWriteGuard<'a, RangeObjectMap<NonNull<AllocInfo>>>);
+
+impl<'a> Deref for ExposedProvenanceRefMut<'a> {
+    type Target = RangeObjectMap<NonNull<AllocInfo>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> DerefMut for ExposedProvenanceRefMut<'a> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
 /// Every action that requires a heap allocation must be performed through a globally
 /// accessible, singleton instance of `GlobalCtx`. Initializing or obtaining
 /// a reference to this instance is unsafe, since it requires having been initialized
@@ -78,6 +105,7 @@ pub struct GlobalCtx {
     alloc_metadata_map: Heap<AllocInfo>,
     snapshots: RwLock<FxHashMap<AllocId, LazyTree>>,
     threads: RwLock<FxHashMap<ThreadId, NonNull<LocalCtx>>>,
+    exposed_provenance: RwLock<RangeObjectMap<NonNull<AllocInfo>>>,
 }
 
 impl GlobalCtx {
@@ -88,6 +116,7 @@ impl GlobalCtx {
             shadow_heap: ShadowHeap::new(),
             snapshots: RwLock::new(FxHashMap::default()),
             threads: RwLock::new(FxHashMap::default()),
+            exposed_provenance: RwLock::new(RangeObjectMap::new()),
         }
     }
 
@@ -117,6 +146,15 @@ impl GlobalCtx {
 
     pub fn protected_tags_mut<'a>(&'a self) -> ProtectedTagsRefMut<'a> {
         ProtectedTagsRefMut(self.protected_tags.write())
+    }
+
+    #[allow(unused)]
+    pub fn exposed_provenance<'a>(&'a self) -> ExposedProvenanceRef<'a> {
+        ExposedProvenanceRef(self.exposed_provenance.read())
+    }
+
+    pub fn exposed_provenance_mut<'a>(&'a self) -> ExposedProvenanceRefMut<'a> {
+        ExposedProvenanceRefMut(self.exposed_provenance.write())
     }
 
     pub fn handle_error(&self, ub_info: UBInfo, pc: Span) {

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -11,7 +11,7 @@ use crate::helpers::FxHashMap;
 use crate::local::LocalCtx;
 use crate::memory::{Heap, ShadowHeap};
 use crate::tree_borrows::data_structures::RangeObjectMap;
-use crate::tree_borrows::{ProtectorKind, LazyTree};
+use crate::tree_borrows::{LazyTree, ProtectorKind};
 use crate::*;
 
 pub static DISABLE_NODE_DEBUG_INFO: AtomicBool = AtomicBool::new(false);

--- a/bsan-rt/src/helpers.rs
+++ b/bsan-rt/src/helpers.rs
@@ -15,6 +15,7 @@ pub struct Size(u64);
 // Abstraction to get number of bits/bytes. Internally stores as bytes
 impl Size {
     pub const ZERO: Size = Size(0);
+    pub const MAX: Size = Size(u64::MAX);
     /// Get a Size defined by a number of bits
     /// Rounds `bits` up to the next-higher byte boundary, if `bits` is
     /// not a multiple of 8.
@@ -29,6 +30,12 @@ impl Size {
     pub fn from_bytes(bytes: impl TryInto<u64>) -> Size {
         Size(bytes.try_into().ok().unwrap())
     }
+
+    /// Get a Size defined by a number of bytes
+    pub fn from_addr<T>(ptr: impl TryInto<*mut T>) -> Size {
+        Self::from_bytes(ptr.try_into().ok().unwrap().addr())
+    }
+
     /// Get the number of bytes in a size
     pub fn bytes(self) -> u64 {
         self.0
@@ -45,6 +52,12 @@ impl fmt::Debug for Size {
     }
 }
 
+impl fmt::LowerHex for Size {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:x}", self.0)
+    }
+}
+
 impl ops::Add for Size {
     type Output = Size;
     fn add(self, other: Size) -> Size {
@@ -58,50 +71,9 @@ impl ops::Sub for Size {
     type Output = Size;
     fn sub(self, other: Size) -> Size {
         Size::from_bytes(self.bytes().checked_sub(other.bytes()).unwrap_or_else(|| {
-            panic!("Size::add: {} + {} doesn't fit in u64", self.bytes(), other.bytes())
+            panic!("Size::sub: {} - {} underflows u64", self.bytes(), other.bytes())
         }))
     }
-}
-
-#[macro_export]
-macro_rules! vec_in {
-    ($alloc:expr) => {
-        Vec::new_in(alloc)
-    };
-
-    // Handle the custom "Elem" syntax for range initialization
-    // This is more specific, so it must come before the next arm.
-    ($alloc:expr, Elem { range: $range:expr, init: $init:expr }) => (
-        {
-            let init_fn = $init;
-            let range = $range;
-
-            // Be efficient: pre-allocate if the iterator gives a size hint
-            let (lower, upper) = range.size_hint();
-            let capacity = upper.unwrap_or(lower);
-            let mut vec = Vec::with_capacity_in(capacity, $alloc);
-
-            // Create the items by iterating and calling the initializer
-            for i in range {
-                vec.push(init_fn(i));
-            }
-            vec
-        }
-    );
-
-    // Handle a comma-separated list of expressions (your original arm)
-    // This is a general "catch-all", so it must come last.
-    ($alloc:expr, $($x:expr),+ $(,)?) => (
-        {
-            // This is a simple way, but not the most efficient for many elements.
-            // A more advanced macro could count the elements to pre-allocate.
-            let mut vec = Vec::new_in($alloc);
-            $(
-                vec.push($x);
-            )+
-            vec
-        }
-    );
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -185,8 +185,23 @@ pub struct BorTag(usize);
 
 impl BorTag {
     #[inline]
-    pub fn is_wildcard(&self) -> bool {
-        *self == Self::wildcard()
+    pub fn is_wildcard(self) -> bool {
+        self == Self::wildcard()
+    }
+
+    #[inline]
+    pub fn is_invalid(self) -> bool {
+        self == Self::invalid()
+    }
+
+    #[inline]
+    pub fn is_omnivalid(self) -> bool {
+        self == Self::omnivalid()
+    }
+
+    #[inline]
+    pub fn is_concrete(&self) -> bool {
+        self.0 > Self::wildcard().0
     }
 
     #[inline]
@@ -255,13 +270,13 @@ impl Provenance {
 
 #[derive(Clone, Copy)]
 pub(crate) union FreeListAddrUnion {
-    pub addr: usize,
+    pub base_addr: Size,
     pub free_list_next: Option<NonNull<AllocInfo>>,
 }
 
 impl Debug for FreeListAddrUnion {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:x}", unsafe { self.addr })
+        write!(f, "{:x}", unsafe { self.base_addr.bytes() })
     }
 }
 
@@ -271,29 +286,29 @@ impl Debug for FreeListAddrUnion {
 /// do not match, then the access is invalid. If they do match, then we proceed to validate the access against
 /// the tree for the allocation.
 #[repr(C)]
-pub(crate) struct AllocInfo {
+pub struct AllocInfo {
     pub alloc_id: AllocId,
-    pub base_addr: FreeListAddrUnion,
-    pub size: usize,
-    pub tree_lock: Option<Mutex<LazyTree>>,
+    pub(crate) base_addr: FreeListAddrUnion,
+    pub size: Size,
+    pub tree_lock: Mutex<Option<LazyTree>>,
 }
 
 impl AllocInfo {
     fn invalid() -> Self {
         AllocInfo {
             alloc_id: AllocId::invalid(),
-            base_addr: FreeListAddrUnion { addr: 0 },
-            size: 0,
-            tree_lock: None,
+            base_addr: FreeListAddrUnion { base_addr: Size::ZERO },
+            size: Size::ZERO,
+            tree_lock: Mutex::default(),
         }
     }
 
-    fn new(base_addr: *mut c_void, size: usize, bor_tag: BorTag, span: Span) -> Self {
+    fn new(base_addr: Size, size: Size, bor_tag: BorTag, span: Span) -> Self {
         Self {
             alloc_id: AllocId::default(),
-            base_addr: FreeListAddrUnion { addr: base_addr.addr() },
+            base_addr: FreeListAddrUnion { base_addr },
             size,
-            tree_lock: Some(Mutex::new(LazyTree::new(bor_tag, Size::from_bytes(size), span))),
+            tree_lock: Mutex::new(Some(LazyTree::new(bor_tag, size, span))),
         }
     }
 
@@ -320,7 +335,7 @@ pub(crate) enum AllocInfoSummary {
     Valid {
         alloc_id: AllocId,
         base_addr: FreeListAddrUnion,
-        size: usize,
+        size: Size,
     },
 }
 
@@ -378,7 +393,7 @@ bitflags::bitflags! {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct RetagInfo<'a> {
-    pub size: usize,
+    pub size: Size,
     pub flags: RetagFlags,
     pub im_layout: Option<&'a [[Size; 2]]>,
     pub pin_layout: Option<&'a [[Size; 2]]>,
@@ -387,12 +402,12 @@ pub struct RetagInfo<'a> {
 /// Creates a new borrow tag for the given provenance object.
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn __bsan_retag_impl(
-    object_addr: *mut c_void,
-    size: usize,
+    ptr: *mut c_void,
+    size: Size,
     flags: RetagFlags,
-    im_data: *const [Size; 2],
+    im_data: Option<NonNull<[Size; 2]>>,
     im_len: usize,
-    pin_data: *const [Size; 2],
+    pin_data: Option<NonNull<[Size; 2]>>,
     pin_len: usize,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
@@ -401,8 +416,9 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
     debug_bsan!("retag", object_addr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
-    let opt_slice = |ptr, len| -> Option<_> {
-        (!im_data.is_null()).then(|| unsafe { slice::from_raw_parts(ptr, len) })
+
+    let opt_slice = |opt_ptr: Option<NonNull<[Size; 2]>>, len| -> Option<_> {
+        opt_ptr.map(|ptr| unsafe { slice::from_raw_parts(ptr.as_ptr(), len) })
     };
 
     let retag_info = RetagInfo {
@@ -412,26 +428,21 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
         pin_layout: opt_slice(pin_data, pin_len),
     };
 
-    BorrowTracker::retag(ctx, prov, object_addr, retag_info, pc).unwrap_or_else(|err| {
+    BorrowTracker::for_access(prov, Size::from_addr(ptr), Some(size), |bt| {
+        bt.retag(ctx, retag_info, pc).map(Some)
+    })
+    .map(|opt| opt.unwrap_or(bor_tag))
+    .unwrap_or_else(|err| {
         ctx.handle_error(err, pc);
         bor_tag
     })
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_expose_tag(bor_tag: BorTag, alloc_info: *mut AllocInfo, pc: Span) {
-    let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
-    if let Err(ub) = BorrowTracker::expose(ctx, prov) {
-        ctx.handle_error(ub, pc);
-    }
-}
-
-#[unsafe(no_mangle)]
 extern "C" fn __bsan_protector_end_impl(bor_tag: BorTag, alloc_info: *mut AllocInfo, pc: Span) {
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
-    let _ = BorrowTracker::for_alloc(prov, |mut bt| bt.protector_end(ctx, pc));
+    let _ = BorrowTracker::for_alloc(prov, |bt| bt.protector_end(ctx, pc));
     ctx.protected_tags_mut().remove_protector(prov.bor_tag);
 }
 
@@ -439,7 +450,7 @@ extern "C" fn __bsan_protector_end_impl(bor_tag: BorTag, alloc_info: *mut AllocI
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn __bsan_read_impl(
     ptr: *mut c_void,
-    access_size: usize,
+    access_size: Size,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
     pc: Span,
@@ -447,20 +458,17 @@ unsafe extern "C-unwind" fn __bsan_read_impl(
     debug_bsan!("read", ptr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
-    BorrowTracker::for_access(prov, ptr, Some(access_size), |mut bt| {
+    BorrowTracker::for_access(prov, Size::from_addr(ptr), Some(access_size), |bt| {
         bt.access(ctx, AccessKind::Read, pc)
     })
-    .unwrap_or_else(|err| {
-        let _: () = ctx.handle_error(err, pc);
-        ().into()
-    });
+    .unwrap_or_else(|err| ctx.handle_error(err, pc));
 }
 
 /// Records a write access of size `access_size` at the given address `addr` using the provenance `prov`.
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn __bsan_write_impl(
     ptr: *mut c_void,
-    access_size: usize,
+    access_size: Size,
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
     pc: Span,
@@ -469,26 +477,24 @@ unsafe extern "C-unwind" fn __bsan_write_impl(
     let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
 
-    BorrowTracker::for_access(prov, ptr, Some(access_size), |mut bt| {
+    BorrowTracker::for_access(prov, Size::from_addr(ptr), Some(access_size), |bt| {
         bt.access(ctx, AccessKind::Write, pc)
     })
-    .unwrap_or_else(|err| {
-        let _: () = ctx.handle_error(err, pc);
-        ().into()
-    });
+    .unwrap_or_else(|err| ctx.handle_error(err, pc));
 }
 
 // Registers a heap allocation of size `size`, storing its provenance in the return pointer.
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn __bsan_alloc(
     base_addr: *mut c_void,
-    size: usize,
+    size: Size,
     bor_tag: BorTag,
     pc: Span,
 ) -> NonNull<AllocInfo> {
     let ctx = unsafe { global_ctx() };
     #[allow(clippy::let_and_return)]
-    let alloc_info = ctx.create_alloc_info(AllocInfo::new(base_addr, size, bor_tag, pc));
+    let alloc_info =
+        ctx.create_alloc_info(AllocInfo::new(Size::from_addr(base_addr), size, bor_tag, pc));
     debug_bsan!("alloc", base_addr, bor_tag, alloc_info.as_ptr());
     alloc_info
 }
@@ -504,12 +510,8 @@ extern "C" fn __bsan_dealloc(
     debug_bsan!("dealloc", ptr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
     let prov: Provenance = Provenance { bor_tag, alloc_info };
-    BorrowTracker::for_access(prov, ptr, None, |mut bt| bt.dealloc(ctx, pc)).unwrap_or_else(
-        |err| {
-            let _: () = ctx.handle_error(err, pc);
-            ().into()
-        },
-    );
+    BorrowTracker::for_access(prov, Size::from_addr(ptr), None, |bt| bt.dealloc(ctx, pc))
+        .unwrap_or_else(|err| ctx.handle_error(err, pc));
     if let Some(alloc_info) = NonNull::new(alloc_info) {
         unsafe { ctx.destroy_alloc_info(alloc_info) };
     }
@@ -525,19 +527,9 @@ unsafe extern "C-unwind" fn __bsan_dealloc_stack_impl(
     debug_bsan!("dealloc", ptr, bor_tag, alloc_info);
     let ctx = unsafe { global_ctx() };
     let prov: Provenance = Provenance { bor_tag, alloc_info };
-    if alloc_info.is_null() {
-        return;
+    if let Err(err) = BorrowTracker::dealloc_weak(ctx, prov, pc) {
+        ctx.handle_error(err, pc);
     }
-    if prov.bor_tag == BorTag::invalid() {
-        return;
-    }
-    if unsafe { (*prov.alloc_info).tree_lock.is_none() } {
-        return;
-    }
-    BorrowTracker::for_alloc(prov, |mut bt| bt.dealloc(ctx, pc)).unwrap_or_else(|err| {
-        let _: () = ctx.handle_error(err, pc);
-        ().into()
-    });
 }
 
 /// Copies the provenance stored in the range `[src_addr, src_addr + access_size)` within the shadow heap
@@ -597,16 +589,26 @@ unsafe extern "C" fn __bsan_destroy_stack_slot(slot: NonNull<AllocInfo>) {
 /// Initializes stack allocation metadata in-place.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn __bsan_alloc_stack_impl(
-    base_addr: *mut c_void,
-    size: usize,
+    ptr: *mut c_void,
+    size: Size,
     bor_tag: BorTag,
     alloc_info: NonNull<AllocInfo>,
     pc: Span,
 ) {
-    debug_bsan!("alloc_stack", base_addr, bor_tag, alloc_info.as_ptr().cast::<AllocInfo>());
+    debug_bsan!("alloc_stack", ptr, bor_tag, alloc_info.as_ptr().cast::<AllocInfo>());
     unsafe {
-        alloc_info.write(AllocInfo::new(base_addr, size, bor_tag, pc));
+        alloc_info.write(AllocInfo::new(Size::from_addr(ptr), size, bor_tag, pc));
     }
+}
+
+/// Records that a pointer's provenance has been exposed (e.g. via a
+/// pointer-to-integer cast), so that it can later be recovered when an
+/// integer is cast back to a pointer with wildcard provenance.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __bsan_expose_prov_impl(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+    let global_ctx = unsafe { global_ctx() };
+    let prov = Provenance { bor_tag, alloc_info };
+    BorrowTracker::expose(global_ctx, prov);
 }
 
 #[unsafe(no_mangle)]

--- a/bsan-rt/src/tree_borrows/data_structures/mod.rs
+++ b/bsan-rt/src/tree_borrows/data_structures/mod.rs
@@ -1,4 +1,6 @@
 mod dedup_range_map;
+mod range_object_map;
 mod unimap;
 pub use dedup_range_map::*;
+pub use range_object_map::*;
 pub use unimap::*;

--- a/bsan-rt/src/tree_borrows/data_structures/range_object_map.rs
+++ b/bsan-rt/src/tree_borrows/data_structures/range_object_map.rs
@@ -1,7 +1,7 @@
-// Ported from Miri (commit:072a9fa)
 //! Implements a map from allocation ranges to data. This is somewhat similar to RangeMap, but the
 //! ranges and data are discrete and non-splittable -- they represent distinct "objects". An
 //! allocation in the map will always have the same range until explicitly removed
+#![allow(unused)]
 use alloc::vec::Vec;
 use core::ops::{Index, IndexMut, Range};
 

--- a/bsan-script/src/utils.rs
+++ b/bsan-script/src/utils.rs
@@ -123,20 +123,19 @@ pub fn install_git_hooks(root_dir: &PathBuf) -> Result<()> {
         let hooks_dir = path!(root_dir / "bsan-script" / "etc");
         let hook_name = hook.value();
 
-        println!("Installing {:?} hook...", &hook_name);
+        println!("Installing {hook_name:?} hook...");
 
         let hook_path = path!(hooks_dir / format!("{hook_name}.sh"));
 
         if !hook_path.exists() {
-            show_error!("{} script {:?} not found", &hook_name, &hook_path);
+            show_error!("{hook_name} script {hook_path:?} not found");
         }
 
         if let Ok(metadata) = std::fs::symlink_metadata(path!(&git_hooks_dir / &hook_name))
             && metadata.is_symlink()
         {
             println!(
-                "{:?} hook is already symlinked (added). If you wish to reinstall, remove symlink from {:?}",
-                &hook_name, &git_hooks_dir
+                "{hook_name:?} hook is already symlinked (added). If you wish to reinstall, remove symlink from {git_hooks_dir:?}"
             );
             return;
         }
@@ -147,15 +146,15 @@ pub fn install_git_hooks(root_dir: &PathBuf) -> Result<()> {
             path!(hooks_dir / hook_script),
             path!(&git_hooks_dir / &hook_name),
         ) {
-            Err(e) => show_error!("Failed to symlink {} script\nFS ERROR: {e}", &hook_name),
+            Err(e) => show_error!("Failed to symlink {hook_name} script: {e:?}"),
             _ => {
                 // Check for successful symlink
                 match std::fs::symlink_metadata(path!(&git_hooks_dir / &hook_name)) {
                     Ok(metadata) => {
                         if !metadata.is_symlink() {
-                            show_error!("Failed to add {:?} hook. Failed symlink", &hook_name);
+                            show_error!("Failed to add {hook_name} hook. Failed symlink");
                         }
-                        println!("Successfully added {:?} hook", &hook_name);
+                        println!("Successfully added {hook_name} hook");
                     }
                     Err(e) => show_error!("{:?}", e),
                 }
@@ -169,7 +168,7 @@ pub fn install_git_hooks(root_dir: &PathBuf) -> Result<()> {
 
     for hook in GitHook::iter() {
         let hook_name = hook.value();
-        if prompt_user(&format!("Would you like to install {} hook?", &hook_name))?.unwrap()
+        if prompt_user(&format!("Would you like to install {hook_name} hook?"))?.unwrap()
             == PromptResult::No
         {
             continue;

--- a/tests/pass/push_pop.run.stderr
+++ b/tests/pass/push_pop.run.stderr
@@ -1,25 +1,25 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  32..  40..  64
-| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────

--- a/tests/pass/vec_debug.run.stderr
+++ b/tests/pass/vec_debug.run.stderr
@@ -1,65 +1,65 @@
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  32
-| Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  32
-| Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32
-| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32
-| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..  32..  40..  64
-| Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  32..  40..  64
-| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────
 ──────────────────────────────────────────────────
 Warning: this tree is indicative only. Some tags may have been hidden.
 0..   8..  16..  24..  32..  40..  64
-| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation>
+| Unq | Unq | Unq | Unq | Unq | Unq |    └────<TAG=root of the allocation> (exposed)
 ──────────────────────────────────────────────────


### PR DESCRIPTION
This is step 1 for implementing wildcard provenance. 

With this PR, when we see a `ptrtoint` instruction in LLVM, we will call the function `__bsan_expose_prov` on the pointer's provenance.

This marks the borrow tag as exposed within the tree. It also adds a mapping between the bounds of the underlying allocation and its associated `AllocInfo` to a global table.
```
GlobalCtx {
  ...
  exposed_provenance: RwLock<RangeObjectMap<NonNull<AllocInfo>>>,
}
```
The `RangeObjectMap` is reused here from `StackedBorrows`. Its contents will need to be garbage-collected.

This PR also cleans up several patterns in `BorrowTracker` and `AllocInfo` that could lead to UB in our runtime. Originally, `AllocInfo` contained `Option<Mutex<Tree>>`. We would check the `Option` to validate the state of the allocation. However, liveness is allowed to be racy. This switches to using `Mutex<Option<LazyTree>>`, instead, and avoids mutably borrowing anything within `AllocInfo` that falls outside of the `Mutex`. 