### PR TITLE
Add and fix passing test(s)

### DIFF
--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -172,6 +172,7 @@ impl Command {
         let miri_should_fail = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
         let total_pass = pass + miri_pass + miri_should_pass;
         let total_fail = fail + miri_fail + miri_should_fail;
+        let total = total_pass + total_fail;
 
         println!();
         println!(
@@ -209,6 +210,13 @@ impl Command {
         if should_fail_root.exists() {
             print_tree(&should_fail_root, "  ")?;
         }
+
+        println!(
+            "{}/{} ({}) tests are covered.",
+            total - miri_should_fail - miri_should_pass,
+            total,
+            fmt_percent(total - miri_should_fail - miri_should_pass, total)
+        );
 
         Ok(())
     }

--- a/tests/miri-tests/pass/tree_borrows/wildcard/lazy_expose.rs
+++ b/tests/miri-tests/pass/tree_borrows/wildcard/lazy_expose.rs
@@ -1,3 +1,6 @@
+//@run:0
+//miri: @compile-flags: -Zmiri-tree-borrows -Zmiri-provenance-gc=0 -Zmiri-permissive-provenance
+
 // This program contains a false positive bug found in lazy allocation. Single-node
 // trees should still be able to be exposed, even if they are `Uninit`.
 

--- a/tests/pass/analyze_retags.rs
+++ b/tests/pass/analyze_retags.rs
@@ -1,3 +1,4 @@
+//@run:0
 extern "C" {
     fn __bsan_debug_tree_size(ptr: *mut u8);
     fn __bsan_debug_print_borrow_state(ptr: *mut u8);
@@ -18,7 +19,6 @@ fn print_diff(ptr: *mut i32, msg: &str) {
     }
 }
 
-//@run
 fn main() {
     let mut x = 0;
     let ptr = &mut x as *mut i32;

--- a/tests/pass/copy_non.rs
+++ b/tests/pass/copy_non.rs
@@ -1,6 +1,6 @@
+//@run:0
 use std::ptr::copy_nonoverlapping;
 
-//@run
 fn main() {
     let mut x = [0u8; 10];
     let src = [1u8; 10];

--- a/tests/pass/fmt_ref.rs
+++ b/tests/pass/fmt_ref.rs
@@ -1,4 +1,4 @@
-//@run
+//@run:0
 /// Calling the `Display` implementation for a reference causes a pointer to
 /// an instrumented function to be passed into part of `alloc`, which may or may not
 /// be instrumented depending on whether our custom sysroot is being used. This

--- a/tests/pass/hello.rs
+++ b/tests/pass/hello.rs
@@ -1,4 +1,4 @@
-//@run
+//@run:0
 fn main() {
     println!("Hello, world!");
 }

--- a/tests/pass/lazy_expose.rs
+++ b/tests/pass/lazy_expose.rs
@@ -1,0 +1,22 @@
+// This program contains a false positive bug found in lazy allocation. Single-node
+// trees should still be able to be exposed, even if they are `Uninit`.
+
+fn main() {
+    let mut x: u32 = 0;
+
+    // `&raw mut x` is a raw-pointer retag and x's tree stays `Uninit`.
+    let p: *mut u32 = &raw mut x;
+
+    // Integer cast exposes the root tag via, but it is still `Uninit`.
+    // `expose_tag` now writes `exposed` to true (used to be no-op).
+    let addr = p as usize;
+
+    // Creating `&mut x` triggers a retag so the tree is now `Init`!
+    let _r = &mut x;
+
+    // `addr` was derived from an exposed pointer, so this wildcard read is valid.
+    // The root tag should be in the `ExposedCache` with write-level access.
+    // Previously, lazy alloc falsely reported UB here:
+    let y = addr as *mut u32;
+    let _ = unsafe { *y };
+}

--- a/tests/pass/push_pop.rs
+++ b/tests/pass/push_pop.rs
@@ -1,3 +1,4 @@
+//@run:0
 extern "C" {
     fn __bsan_init();
     fn __bsan_deinit();
@@ -7,7 +8,6 @@ extern "C" {
     fn __bsan_debug_print_borrow_state(ptr: *mut u8);
 }
 
-//@run
 fn main() {
     let mut v: Vec<i64> = Vec::new();
 

--- a/tests/pass/threads.rs
+++ b/tests/pass/threads.rs
@@ -1,3 +1,4 @@
+//@run:0
 use std::thread;
 const NTHREADS: u32 = 5;
 

--- a/tests/pass/vec_debug.rs
+++ b/tests/pass/vec_debug.rs
@@ -1,3 +1,4 @@
+//@run:0
 extern "C" {
     fn __bsan_init();
     fn __bsan_deinit();
@@ -9,7 +10,6 @@ extern "C" {
     fn __bsan_debug_tree_size(ptr: *mut u8);
 }
 
-//@run
 fn main() {
     let mut v: Vec<i64> = Vec::new();
 


### PR DESCRIPTION
This PR contributes 3 things:

1. Added a test case I wrote for Miri, `lazy_expose.rs` to ensure we don't have false positive bugs as we add wildcard provenance.
2. Added an additional line to `xb stats` for total test progress:
```
365/424 (86.08%) tests are covered.
```
3. Adds `//@run:0` annotations to our `tests/pass` original tests. Without them, we were ignoring the results of these cases... which is really Not Good... but they still pass now!