### PR TITLE
Fix flaky interceptors test

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -47,6 +47,7 @@ namespace __bsan {
 bool bsan_inited = false;
 bool bsan_init_running = false;
 bool bsan_deinit_running = false;
+bool bsan_deinited = false;
 
 // Every thread has a unique ID
 atomic_uintptr_t thread_id{0};
@@ -177,6 +178,7 @@ void __bsan_deinit() {
   DeinitializeGC();
   bsan_deinit_running = false;
   bsan_inited = false;
+  bsan_deinited = true;
 }
 
 /// When we call a possibly uninstrumented function, we store our frame

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -40,6 +40,7 @@ extern THREADLOCAL void *bsan_thread;
 extern bool bsan_inited;
 extern bool bsan_init_running;
 extern bool bsan_deinit_running;
+extern bool bsan_deinited;
 extern atomic_uintptr_t thread_id;
 
 extern THREADLOCAL int block_interception;

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -325,7 +325,7 @@ static int setup_at_exit_wrapper(void (*f)(), void *arg, void *dso) {
   } while (false)
 
 #define COMMON_INTERCEPTOR_ENTER(ctx, func, ...)                               \
-  if (bsan_init_running || bsan_deinited)                                      \
+  if (bsan_init_running)                                                       \
     return REAL(func)(__VA_ARGS__);                                            \
   ENSURE_BSAN_INITED();                                                        \
   LocalInterceptorContext bsan_ctx = {BlockInterception()};                    \

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -42,7 +42,7 @@ struct DlsymAlloc : public DlSymAllocator<DlsymAlloc> {
 #define ENSURE_BSAN_INITED()                                                   \
   do {                                                                         \
     CHECK(!bsan_init_running);                                                 \
-    if (!bsan_inited) {                                                        \
+    if (!bsan_inited && !bsan_deinited) {                                      \
       __bsan_init();                                                           \
     }                                                                          \
   } while (0)
@@ -325,7 +325,7 @@ static int setup_at_exit_wrapper(void (*f)(), void *arg, void *dso) {
   } while (false)
 
 #define COMMON_INTERCEPTOR_ENTER(ctx, func, ...)                               \
-  if (bsan_init_running)                                                       \
+  if (bsan_init_running || bsan_deinited)                                      \
     return REAL(func)(__VA_ARGS__);                                            \
   ENSURE_BSAN_INITED();                                                        \
   LocalInterceptorContext bsan_ctx = {BlockInterception()};                    \

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -172,6 +172,7 @@ impl Command {
         let miri_should_fail = count_rs(&path!(root / "tests" / "miri-tests" / "should-fail"))?;
         let total_pass = pass + miri_pass + miri_should_pass;
         let total_fail = fail + miri_fail + miri_should_fail;
+        let total = total_pass + total_fail;
 
         println!();
         println!(
@@ -209,6 +210,13 @@ impl Command {
         if should_fail_root.exists() {
             print_tree(&should_fail_root, "  ")?;
         }
+
+        println!(
+            "{}/{} ({}) tests are covered.",
+            total - miri_should_fail - miri_should_pass,
+            total,
+            fmt_percent(total - miri_should_fail - miri_should_pass, total)
+        );
 
         Ok(())
     }

--- a/tests/miri-tests/pass/tree_borrows/wildcard/lazy_expose.rs
+++ b/tests/miri-tests/pass/tree_borrows/wildcard/lazy_expose.rs
@@ -1,3 +1,6 @@
+//@run:0
+//miri: @compile-flags: -Zmiri-tree-borrows -Zmiri-provenance-gc=0 -Zmiri-permissive-provenance
+
 // This program contains a false positive bug found in lazy allocation. Single-node
 // trees should still be able to be exposed, even if they are `Uninit`.
 

--- a/tests/pass/analyze_retags.rs
+++ b/tests/pass/analyze_retags.rs
@@ -1,3 +1,4 @@
+//@run:0
 extern "C" {
     fn __bsan_debug_tree_size(ptr: *mut u8);
     fn __bsan_debug_print_borrow_state(ptr: *mut u8);
@@ -18,7 +19,6 @@ fn print_diff(ptr: *mut i32, msg: &str) {
     }
 }
 
-//@run
 fn main() {
     let mut x = 0;
     let ptr = &mut x as *mut i32;

--- a/tests/pass/copy_non.rs
+++ b/tests/pass/copy_non.rs
@@ -1,6 +1,6 @@
+//@run:0
 use std::ptr::copy_nonoverlapping;
 
-//@run
 fn main() {
     let mut x = [0u8; 10];
     let src = [1u8; 10];

--- a/tests/pass/fmt_ref.rs
+++ b/tests/pass/fmt_ref.rs
@@ -1,4 +1,4 @@
-//@run
+//@run:0
 /// Calling the `Display` implementation for a reference causes a pointer to
 /// an instrumented function to be passed into part of `alloc`, which may or may not
 /// be instrumented depending on whether our custom sysroot is being used. This

--- a/tests/pass/hello.rs
+++ b/tests/pass/hello.rs
@@ -1,4 +1,4 @@
-//@run
+//@run:0
 fn main() {
     println!("Hello, world!");
 }

--- a/tests/pass/lazy_expose.rs
+++ b/tests/pass/lazy_expose.rs
@@ -1,0 +1,22 @@
+// This program contains a false positive bug found in lazy allocation. Single-node
+// trees should still be able to be exposed, even if they are `Uninit`.
+
+fn main() {
+    let mut x: u32 = 0;
+
+    // `&raw mut x` is a raw-pointer retag and x's tree stays `Uninit`.
+    let p: *mut u32 = &raw mut x;
+
+    // Integer cast exposes the root tag via, but it is still `Uninit`.
+    // `expose_tag` now writes `exposed` to true (used to be no-op).
+    let addr = p as usize;
+
+    // Creating `&mut x` triggers a retag so the tree is now `Init`!
+    let _r = &mut x;
+
+    // `addr` was derived from an exposed pointer, so this wildcard read is valid.
+    // The root tag should be in the `ExposedCache` with write-level access.
+    // Previously, lazy alloc falsely reported UB here:
+    let y = addr as *mut u32;
+    let _ = unsafe { *y };
+}

--- a/tests/pass/push_pop.rs
+++ b/tests/pass/push_pop.rs
@@ -1,3 +1,4 @@
+//@run:0
 extern "C" {
     fn __bsan_init();
     fn __bsan_deinit();
@@ -7,7 +8,6 @@ extern "C" {
     fn __bsan_debug_print_borrow_state(ptr: *mut u8);
 }
 
-//@run
 fn main() {
     let mut v: Vec<i64> = Vec::new();
 

--- a/tests/pass/threads.rs
+++ b/tests/pass/threads.rs
@@ -1,3 +1,4 @@
+//@run:0
 use std::thread;
 const NTHREADS: u32 = 5;
 

--- a/tests/pass/vec_debug.rs
+++ b/tests/pass/vec_debug.rs
@@ -1,3 +1,4 @@
+//@run:0
 extern "C" {
     fn __bsan_init();
     fn __bsan_deinit();
@@ -9,7 +10,6 @@ extern "C" {
     fn __bsan_debug_tree_size(ptr: *mut u8);
 }
 
-//@run
 fn main() {
     let mut v: Vec<i64> = Vec::new();
 


### PR DESCRIPTION
In the CI of #214 I noticed this in `tests/miri-tests/pass/getpid`:
```
SanitizerTool: CHECK failed: bsan_interceptors.cpp:424 "((inited)) == ((0))" (0x1, 0x0) (tid=15110)
```

Claude says that after `main()` returns and `bsan_inited = false`, that something in the teardown calls an intercepted function and `ENSURE_BSAN_INITED()` is checked. This reinits bsan and does `CHECK_EQ(inited, 0)` but at this point `inited` is already `1`.

We fixed it by adding a `bsan_deinited` flag which is set to true in `__bsan_deinit()`. That way we can prevent checking `ENSURE_BSAN_INITED()` after the program has finished.

Ignore the first two commits, since this is rebased off #214 (new change is in 3 files in `bsan_rt/llvm-wrapper`)