### PR TITLE
Add random shuffling to bytewise copy test

### DIFF
--- a/tests/miri-tests/should-fail/aliasing/tree_borrows/bytewise_copy_alias.rs
+++ b/tests/miri-tests/should-fail/aliasing/tree_borrows/bytewise_copy_alias.rs
@@ -1,38 +1,32 @@
 //@run: 1
 //
 // FALSE NEGATIVE (tracked by BorrowSanitizer#225).
-
-use std::mem::{size_of, MaybeUninit};
+use rand::seq::SliceRandom;
+use core::mem;
 
 fn main() {
-    let mut x: i32 = 67;
+    let mut x: i32 = 1;
     let rx = &mut x;
     let ptr_x = rx as *mut i32; // raw pointer carrying unique tag A
 
     let vx = &mut x; // sibling mutable borrow of the same location
-    *vx = 42; // foreign write: disables tag A under Tree Borrows
+    *vx = 1; // foreign write: disables tag A under Tree Borrows
 
-    // create an unitiliazed buffer to copy ptr_x value to byte-byte
-    let mut buf = MaybeUninit::<*mut i32>::uninit();
-    let dst = buf.as_mut_ptr().cast::<u8>();
-
-    // cast to first byte of ptr_x
-    let src = (&ptr_x as *const *mut i32).cast::<u8>();
-    // loop 4 times (size_of(i32) == 4 bytes)
-    for i in 0..size_of::<*mut i32>() {
-        unsafe {
-            // https://doc.rust-lang.org/std/ptr/fn.read_volatile.html
-            // tell the compiler to treat this as a volatile operation so that it does not optimize away our byte-byte copy
-            *dst.add(i) = src.add(i).read_volatile();
+    unsafe fn memcpy<T>(to: *mut T, from: *const T) {
+        let to = to.cast::<mem::MaybeUninit<u8>>();
+        let from = from.cast::<mem::MaybeUninit<u8>>();
+        let mut indices = (0..mem::size_of::<T>()).collect::<Vec<usize>>();
+        // Randomly shuffle the order in which bytes are copied.
+        indices.shuffle(&mut rand::rng());
+        for i in indices {
+            unsafe {
+                let b = from.add(i).read();
+                to.add(i).write(b);
+            }
         }
     }
-    let laundered = unsafe { buf.assume_init() };
 
-    // same as ptr_x except ptr reads 0 provenance (omnivalid) due to `__bsan_memcpy` early return
-    // when `num_bytes < PTR_BYTES`
-    unsafe {
-        *laundered = 69;
-    }
-
-    println!("aliasing violation through a byte-copied pointer was not detected");
+    let mut ptr2 = core::ptr::null_mut();
+    unsafe { memcpy(&mut ptr2, &ptr_x) };
+    unsafe { *ptr2 = 0; }
 }


### PR DESCRIPTION
Randomly selects the order in which bytes are copied for our byte-level provenance failing test.