### PR TITLE
Add endpoints for incrementing and decrementing reference counts.

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -216,9 +216,13 @@ private:
   /// application address.
   FunctionCallee BsanFuncShadow;
 
-  /// Runtime function storing a provenance value to shadow memory, updating
-  /// any associated reference counts.
-  FunctionCallee BsanFuncRcStore;
+  /// Runtime function for incrementing the reference count associated
+  /// with a provenance value.
+  FunctionCallee BsanFuncRcInc;
+
+  /// Runtime function for decrementing the reference count associated
+  /// with a provenance value.
+  FunctionCallee BsanFuncRcDec;
 
   /// Runtime function for clearing the contents of shadow memory at a given
   /// address.
@@ -488,8 +492,11 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
 
   BsanFuncShadow = M.getOrInsertFunction(BSAN("shadow"), AL, PtrTy, PtrTy);
 
-  BsanFuncRcStore = M.getOrInsertFunction(BSAN("rc_store"), AL, IRB.getVoidTy(),
-                                          IntptrTy, PtrTy, PtrTy);
+  BsanFuncRcInc = M.getOrInsertFunction(BSAN("rc_inc"), AL, IRB.getVoidTy(),
+                                        IntptrTy, PtrTy);
+
+  BsanFuncRcDec = M.getOrInsertFunction(BSAN("rc_dec"), AL, IRB.getVoidTy(),
+                                        IntptrTy, PtrTy);
 
   BsanFuncShadowClear = M.getOrInsertFunction(BSAN("shadow_clear"), AL,
                                               IRB.getVoidTy(), PtrTy, IntptrTy);
@@ -1137,7 +1144,7 @@ private:
       report_fatal_error("Vectors are not supported.");
     } else {
       Value *Shadow = IRB.CreateCall(BS.BsanFuncShadow, {ObjAddr});
-      IRB.CreateCall(BS.BsanFuncRcStore, {Prov.Tag, Prov.Info, Shadow});
+      Prov.store(IRB, BS, Shadow);
     }
   }
 
@@ -1276,8 +1283,7 @@ private:
     Value *Shadow = IRB.CreateCall(BS.BsanFuncShadow, {Operand});
     Provenance SrcProv = Provenance::load(IRB, BS, Shadow);
     Provenance RetaggedProv = instrumentRetag(IRB, CB, SrcAddr, SrcProv);
-    IRB.CreateCall(BS.BsanFuncRcStore,
-                   {RetaggedProv.Tag, RetaggedProv.Info, Shadow});
+    RetaggedProv.store(IRB, BS, Shadow);
   }
 
   void instrumentRetagReg(CallBase &CB) {

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -357,11 +357,28 @@ __bsan_shadow_transfer(void *dest, const void *src, uptr access_size) {}
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
 __bsan_shadow_clear(void *dest, uptr access_size) {}
 
-SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
-__bsan_rc_store(BorTag Tag, AllocInfo *Info, Provenance *Dest) {}
+SANITIZER_WEAK_ATTRIBUTE void
+__bsan_rc_inc_impl(BorTag Tag, AllocInfo *Info);
 
-SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE AllocInfo *
-__bsan_reserve_stack_slot() {
+SANITIZER_INTERFACE_ATTRIBUTE 
+void __bsan_rc_inc(BorTag Tag, AllocInfo *Info) {
+  if(__bsan_rc_inc_impl) {
+    __bsan_rc_inc_impl(Tag, Info);
+  }
+}
+
+SANITIZER_WEAK_ATTRIBUTE 
+void __bsan_rc_dec_impl(BorTag Tag, AllocInfo *Info);
+
+SANITIZER_INTERFACE_ATTRIBUTE 
+void __bsan_rc_dec(BorTag Tag, AllocInfo *Info) {
+  if(__bsan_rc_dec_impl) {
+    __bsan_rc_dec_impl(Tag, Info);
+  }
+}
+
+SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE 
+AllocInfo *__bsan_reserve_stack_slot() {
   return nullptr;
 }
 

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -357,28 +357,27 @@ __bsan_shadow_transfer(void *dest, const void *src, uptr access_size) {}
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
 __bsan_shadow_clear(void *dest, uptr access_size) {}
 
-SANITIZER_WEAK_ATTRIBUTE void
-__bsan_rc_inc_impl(BorTag Tag, AllocInfo *Info);
+SANITIZER_WEAK_ATTRIBUTE void __bsan_rc_inc_impl(BorTag Tag, AllocInfo *Info);
 
-SANITIZER_INTERFACE_ATTRIBUTE 
+SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_rc_inc(BorTag Tag, AllocInfo *Info) {
-  if(__bsan_rc_inc_impl) {
+  if (__bsan_rc_inc_impl) {
     __bsan_rc_inc_impl(Tag, Info);
   }
 }
 
-SANITIZER_WEAK_ATTRIBUTE 
+SANITIZER_WEAK_ATTRIBUTE
 void __bsan_rc_dec_impl(BorTag Tag, AllocInfo *Info);
 
-SANITIZER_INTERFACE_ATTRIBUTE 
+SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_rc_dec(BorTag Tag, AllocInfo *Info) {
-  if(__bsan_rc_dec_impl) {
+  if (__bsan_rc_dec_impl) {
     __bsan_rc_dec_impl(Tag, Info);
   }
 }
 
-SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE 
-AllocInfo *__bsan_reserve_stack_slot() {
+SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE AllocInfo *
+__bsan_reserve_stack_slot() {
   return nullptr;
 }
 

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -563,19 +563,11 @@ unsafe extern "C-unwind" fn __bsan_shadow(addr: *mut c_void) -> NonNull<Provenan
 
 /// Increments the reference count associated with a provenance value.
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_rc_inc_impl(
-    _bor_tag: BorTag,
-    _alloc_info: *mut AllocInfo,
-) {
-}
+unsafe extern "C-unwind" fn __bsan_rc_inc_impl(_bor_tag: BorTag, _alloc_info: *mut AllocInfo) {}
 
 /// Decrements the reference count associated with a provenance value.
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_rc_dec_impl(
-    _bor_tag: BorTag,
-    _alloc_info: *mut AllocInfo,
-) {
-}
+unsafe extern "C-unwind" fn __bsan_rc_dec_impl(_bor_tag: BorTag, _alloc_info: *mut AllocInfo) {}
 
 /// Reserves a stack slot for allocation metadata.
 #[unsafe(no_mangle)]

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -561,15 +561,20 @@ unsafe extern "C-unwind" fn __bsan_shadow(addr: *mut c_void) -> NonNull<Provenan
     unsafe { global_ctx().shadow_heap().get(addr.addr()) }
 }
 
-/// Stores the given provenance value into shadow memory at the location for the given address.
+/// Increments the reference count associated with a provenance value.
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_rc_store(
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-    dest: NonNull<Provenance>,
+unsafe extern "C-unwind" fn __bsan_rc_inc_impl(
+    _bor_tag: BorTag,
+    _alloc_info: *mut AllocInfo,
 ) {
-    let prov = Provenance { bor_tag, alloc_info };
-    unsafe { dest.write(prov) };
+}
+
+/// Decrements the reference count associated with a provenance value.
+#[unsafe(no_mangle)]
+unsafe extern "C-unwind" fn __bsan_rc_dec_impl(
+    _bor_tag: BorTag,
+    _alloc_info: *mut AllocInfo,
+) {
 }
 
 /// Reserves a stack slot for allocation metadata.


### PR DESCRIPTION
This removes our current `__bsan_rc_store`, and adds two new endpoints for incrementing (`__bsan_rc_inc`) and decrementing (`__bsan_rc_dec`) reference counts. These are not being called by our runtime yet.