### PR TITLE
Update benchmarking script to add an "all checks enabled" mode and compare against Miri

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   actions: write
   contents: write
+  packages: read
+concurrency:
+  group: benchmarks-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   build:
     strategy:
@@ -35,12 +39,19 @@ jobs:
       id: filename
       run: echo "results=results_$(date +%Y-%m-%d_%H-%M-%S)_${{ matrix.config.target }}" >> $GITHUB_OUTPUT
     - name: Benchmarks
-      run: python3 ./bsan-script/etc/bench.py ./tests/benches/crates.json ${{ matrix.config.target }} ${{ steps.filename.outputs.results }}.json
+      run: | 
+        python3 ./bsan-script/etc/bench.py \
+        ./tests/benches/crates.json \
+        ${{ matrix.config.target }} \
+        ${{ steps.filename.outputs.results }}.json \
+        ${{ steps.filename.outputs.results }}.csv 
     - name: Upload results
       uses: actions/upload-artifact@v4
       with:
         name: ${{ steps.filename.outputs.results }}
-        path: ${{ steps.filename.outputs.results }}.json
+        path: |
+          ${{ steps.filename.outputs.results }}.json
+          ${{ steps.filename.outputs.results }}.csv
         retention-days: 30
   merge:
     name: Merge & Upload
@@ -78,5 +89,5 @@ jobs:
         benchmark-data-dir-path: .
         fail-on-alert: true
         comment-on-alert: true
-        alert-threshold: 130%
+        alert-threshold: 150%
         alert-comment-cc-users: '@icmccorm,@mojeanmac'

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -22,14 +22,16 @@ NATIVE = {
 
 MIRI = {
     "name": "miri-tb",
-    "flags": [
-        "-Zmiri-tree-borrows",
-        "-Zmiri-provenance-gc=0",
-        "-Zmiri-mute-stdout-stderr",
-        "-Zmiri-disable-data-race-detector",
-        "-Zmiri-deterministic-concurrency",
-        "-Zmiri-disable-alignment-check"
-    ],
+    "env": {
+        "MIRIFLAGS": [
+            "-Zmiri-tree-borrows",
+            "-Zmiri-provenance-gc=0",
+            "-Zmiri-mute-stdout-stderr",
+            "-Zmiri-disable-data-race-detector",
+            "-Zmiri-deterministic-concurrency",
+            "-Zmiri-disable-alignment-check"
+        ]
+    },
     "runs": 3,
     "warmup": 1
 }
@@ -230,7 +232,6 @@ def process_config(
     compile_miri_tests(src_dir)
 
     ratios: dict[tuple[str, str], list[float]] = {}
-
     for t in tests:
         print(f"  -> {t}")
         per_test_means = {}
@@ -246,9 +247,6 @@ def process_config(
         if miri_mean <= 0:
             sys.exit(f"Reported 0s mean execution time for {MIRI['name']} on test {t} from {bench_name}")
         print(f"    - {MIRI['name']}={round(miri_mean, 8)}s")
-
-        # Baselines (denominators). Pop native out of per_test_means so what's
-        # left is exactly the BSAN modes (the numerators).
         baselines = {
             NATIVE["name"]: per_test_means.pop(NATIVE["name"]),
             MIRI["name"]: miri_mean,
@@ -264,14 +262,16 @@ def process_config(
     for (mode, baseline), ratio_list in ratios.items():
         results.append({
             "name": bench_name,
-            "unit": "Median Relative Execution Time",
-            "value": statistics.median(ratio_list),
+            "unit": "Mean Relative Execution Time",
+            "value": statistics.mean(ratio_list),
             "extra": json.dumps({
                 "mode": mode,
                 "baseline": baseline,
                 "target": target,
                 "version": version,
                 "crate": crate,
+                "max": max(ratio_list),
+                "min": min(ratio_list)
             }),
         })
     return results

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -1,7 +1,6 @@
 # This script calculates BorrowSanitizer's relative execution time
-# across all test cases for a crate, and provides the output in a 
+# across all test cases for a crate, and provides the output in a
 # .JSON file.
-from dataclasses import dataclass
 import argparse
 import statistics
 import json
@@ -23,7 +22,7 @@ NATIVE = {
 
 MIRI = {
     "name": "miri-tb",
-    "flags": ["-Zmiri-tree-borrows", "-Zmiri-provenance-gc=0"],
+    "flags": ["-Zmiri-tree-borrows", "-Zmiri-provenance-gc=0", "-Zmiri-mute-stdout-stderr"],
     "runs": 1,
     "warmup": 1
 }
@@ -44,7 +43,7 @@ CONFIGS = [
 ]
 
 
-ALL = [NATIVE] + CONFIGS
+ALL_BINARY_CONFIGS = [NATIVE] + CONFIGS
 
 def run(
     cmd: list[str],
@@ -102,7 +101,7 @@ def download_crate(crate: str, version: str, dest_dir: Path) -> Path:
 def compile_test_binary(config: dict, cwd: Path, out_dir: Path) -> Path:
     """Compiles the test binary for the given cargo invocation and return its
     path. Aborts on compile failure or if no test executable is produced."""
-    print(f">>> compiling test binary ({config["name"]}): {' '.join(config["cmd"])}",
+    print(f">>> compiling tests ({config["name"]}): {' '.join(config["cmd"])}",
           file=sys.stderr)
     # We need to parse the output JSON to find the name of the test binary.
     msg_json = run_capture(
@@ -121,15 +120,15 @@ def compile_test_binary(config: dict, cwd: Path, out_dir: Path) -> Path:
         target = msg.get("target") or {}
         if exe and target.get("test"):
             print(">>> done.")
-            bin = out_dir / config["name"]
-            shutil.copy2(exe, bin)
-            bin.chmod(0o755)
+            binary = out_dir / config["name"]
+            shutil.copy2(exe, binary)
+            binary.chmod(0o755)
             return
-        
+
     sys.exit(f"Error: could not locate {config["name"]} test binary.")
 
 def compile_miri_tests(cwd: Path):
-    print(f">>> compiling test binary MIR for Miri")
+    print(">>> compiling tests (Miri)")
     run_capture(
         ["cargo", "miri", "test", "--no-run", "--message-format=json"],
         cwd=cwd,
@@ -181,7 +180,7 @@ def process_config(
     crate = cfg.get("name")
     version = cfg.get("version")
     excluded_tests = set(cfg.get("exclude") or [])
-    
+
     if not crate or not version:
         sys.exit(f"Error: invalid per-crate config:\n{cfg}")
 
@@ -194,14 +193,12 @@ def process_config(
             print(f"- {test_name}")
 
     src_dir = download_crate(crate, version, scratch)
-    compile_test_binary(NATIVE, cwd=src_dir, out_dir=scratch)
-    try:
-        run(["cargo", "clean", "--quiet"], cwd=src_dir)
-    except subprocess.CalledProcessError:
-        pass
-
-    for config in CONFIGS:
+    for config in ALL_BINARY_CONFIGS:
         compile_test_binary(config, cwd=src_dir, out_dir=scratch)
+        try:
+            run(["cargo", "clean", "--quiet"], cwd=src_dir)
+        except subprocess.CalledProcessError:
+            pass
 
     all_tests = list_tests(scratch / NATIVE["name"])
     if not all_tests:
@@ -210,34 +207,33 @@ def process_config(
     tests = [t for t in all_tests if t not in excluded_tests]
     if not tests:
         sys.exit(f"Error: every discovered test was excluded for {bench_name}.")
-    
     compile_miri_tests(src_dir)
 
     means = {}
     for t in tests:
         print(f"  -> {t}")
-        for config in ALL:
-            bin = scratch / config["name"]
-            mean = hyperfine_mean(f"{bin} --exact {t} --nocapture", config)
+        for config in ALL_BINARY_CONFIGS:
+            binary = scratch / config["name"]
+            mean = hyperfine_mean(f"{binary} --exact {t} --nocapture", config)
             if mean <= 0:
                 sys.exit(f"Reported 0s mean native execution time for test {t} from {bench_name}")
             print(f"    - {config["name"]}={round(mean, 8)}s")
             means[config["name"]] = mean
         mean = run_miri_test(src_dir, t, MIRI)
-
+        means[MIRI["name"]] = mean
     results = []
 
     native_mean = means[NATIVE["name"]]
     del means[NATIVE["name"]]
 
-    for key in means.keys():
-        ratio = means[key] / native_mean
+    for mode, mean in means.items():
+        ratio = mean / native_mean
         results.append({
             "name": bench_name,
             "unit": "Median Relative Execution Time",
             "value": statistics.median(ratio),
             "extra": json.dumps({
-                "mode": key,
+                "mode": mode,
                 "target": target,
                 "version": version,
                 "crate": crate

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -16,34 +16,42 @@ from pathlib import Path
 NATIVE = {
     "name": "native",
     "cmd": ["cargo", "test", "--lib"],
-    "runs": 1,
+    "runs": 3,
     "warmup": 1
 }
 
 MIRI = {
     "name": "miri-tb",
     "flags": ["-Zmiri-tree-borrows", "-Zmiri-provenance-gc=0", "-Zmiri-mute-stdout-stderr"],
-    "runs": 1,
+    "runs": 3,
     "warmup": 1
 }
 
-CONFIGS = [
+BSAN_CONFIGS = [
     {
         "name": "full",
         "cmd": ["cargo", "bsan", "test", "--lib"],
-        "runs": 1,
+        "runs": 3,
         "warmup": 1
     },
     {
         "name": "no-op",
         "cmd": ["cargo", "bsan", "test", "--nop", "--lib"],
-        "runs": 1,
+        "runs": 3,
         "warmup": 1
     }
 ]
 
 
-ALL_BINARY_CONFIGS = [NATIVE] + CONFIGS
+ALL_BINARY_CONFIGS = [NATIVE] + BSAN_CONFIGS
+
+def _build_env(kwargs: dict) -> dict:
+    """Pop an optional `env` mapping from kwargs and merge it on top of a copy
+    of the current environment, so callers can override individual variables
+    without dropping the inherited ones."""
+    env = os.environ.copy()
+    env.update(kwargs.pop("env", None) or {})
+    return env
 
 def run(
     cmd: list[str],
@@ -53,8 +61,7 @@ def run(
 
     The command inherits the current environment.
     """
-    return subprocess.run(cmd, check=True, env=os.environ.copy(), **kwargs)
-
+    return subprocess.run(cmd, check=True, env=_build_env(kwargs), **kwargs)
 
 def run_capture(
     cmd: list[str],
@@ -67,7 +74,7 @@ def run_capture(
     proc = subprocess.run(
         cmd, check=True,
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
-        env=os.environ.copy(),
+        env=_build_env(kwargs),
         **kwargs,
     )
     return proc.stdout
@@ -127,15 +134,20 @@ def compile_test_binary(config: dict, cwd: Path, out_dir: Path) -> Path:
 
     sys.exit(f"Error: could not locate {config["name"]} test binary.")
 
+def miri_env(config: dict) -> dict:
+    """Build the environment overrides for a Miri run, exposing the config's
+    `flags` as the MIRIFLAGS variable."""
+    return {"MIRIFLAGS": " ".join(config.get("flags") or [])}
+
 def compile_miri_tests(cwd: Path):
-    print(">>> compiling tests (Miri)")
+    print(">>> compiling tests (miri)")
     run_capture(
         ["cargo", "miri", "test", "--no-run", "--message-format=json"],
         cwd=cwd,
     )
 def run_miri_test(cwd: Path, t: str, config: dict):
     cmd = f"cargo miri test -q --lib -- --exact {t} --nocapture"
-    return hyperfine_mean(cmd, config, cwd=cwd)
+    return hyperfine_mean(cmd, config, cwd=cwd, env=miri_env(config))
 
 def list_tests(test_bin: Path) -> list[str]:
     """Return all #[test] names discovered in the given test binary."""
@@ -154,6 +166,7 @@ def hyperfine_mean(cmd, config: dict, **kwargs) -> float:
         out_path = Path(out_json.name)
     try:
         kwargs["stdout"] = subprocess.DEVNULL
+        kwargs["stderr"] = subprocess.DEVNULL
         run(
             [
                 "hyperfine",
@@ -221,6 +234,7 @@ def process_config(
             means[config["name"]] = mean
         mean = run_miri_test(src_dir, t, MIRI)
         means[MIRI["name"]] = mean
+        print(f"    - {MIRI["name"]}={round(mean, 8)}s")
     results = []
 
     native_mean = means[NATIVE["name"]]

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -26,7 +26,7 @@ MIRI = {
         "-Zmiri-tree-borrows",
         "-Zmiri-provenance-gc=0",
         "-Zmiri-mute-stdout-stderr",
-        "-Zmiri-disable-data-race-detector"
+        "-Zmiri-disable-data-race-detector",
         "-Zmiri-deterministic-concurrency",
         "-Zmiri-disable-alignment-check"
     ],

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -1,10 +1,17 @@
 # This script calculates BorrowSanitizer's relative execution time
-# across all test cases for a crate, and provides the output in a
-# .JSON file.
+# across all test cases for a crate. It produces two output files:
+#
+# * A JSON file with relative execution times in a format that is
+#   compatible with `github-actions-benchmark`
+#
+# * A CSV file listing the mean execution times of each mode, including
+#   both the baselines and tested configurations.
 import argparse
 import statistics
 import json
+import csv
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -13,55 +20,74 @@ import tempfile
 import urllib.request
 from pathlib import Path
 
+RUNS = 3
+WARMUP = 1
+
+# Uninstrumented native execution.
 NATIVE = {
     "name": "native",
-    "label": "uninstrumented native execution",
     "cmd": ["cargo", "test", "--lib"],
-    "runs": 3,
-    "warmup": 1
+    "env": {"RUSTFLAGS": "--cfg=bsan"},
 }
 
+# Flags shared by every Miri configuration. These disable most forms of
+# checking, and ensure deterministic execution.
+MIRI_COMMON_FLAGS = (
+    "-Zmiri-provenance-gc=0 -Zmiri-mute-stdout-stderr "
+    "-Zmiri-disable-data-race-detector -Zmiri-deterministic-concurrency "
+    "-Zmiri-disable-alignment-check -Zmiri-ignore-leaks"
+)
+
+# Miri with Tree Borrows enabled,and all other checking disabled
+# (to the extent possible).
 MIRI = {
     "name": "miri-tb",
-    "label": "Miri (Tree Borrows)",
-    "env": {
-        "MIRIFLAGS": [
-            "-Zmiri-tree-borrows",
-            "-Zmiri-provenance-gc=0",
-            "-Zmiri-mute-stdout-stderr",
-            "-Zmiri-disable-data-race-detector",
-            "-Zmiri-deterministic-concurrency",
-            "-Zmiri-disable-alignment-check"
-        ]
-    },
-    "runs": 3,
-    "warmup": 1
+    "env": {"MIRIFLAGS": f"-Zmiri-tree-borrows {MIRI_COMMON_FLAGS}"},
 }
 
+# Miri with Tree Borrows disabled. This is as close to "just interpret" as
+# we can get. However, the core interpreter will still check for certain forms
+# of UB, like accessese out-of-bounds, use-after-free errors, and uninitialized accesses.
+MIRI_BASE = {
+    "name": "miri-base",
+    "env": {"MIRIFLAGS": f"-Zmiri-disable-stacked-borrows {MIRI_COMMON_FLAGS}"},
+}
+
+# Every Miri configuration.
+MIRI_CONFIGS = [MIRI, MIRI_BASE]
+
+# BorrowSanitizer configurations.
 BSAN_CONFIGS = [
+    # Full checking
     {
         "name": "full",
-        "label": "checks enabled",
         "cmd": ["cargo", "bsan", "test", "--lib"],
-        "runs": 3,
-        "warmup": 1
     },
+    # No-op checking. Instrumentation is inserted, but
+    # all memory access checks, retags, and reference count
+    # updates are disabled.
     {
         "name": "no-op",
-        "label": "no-op",
         "cmd": ["cargo", "bsan", "test", "--nop", "--lib"],
-        "runs": 3,
-        "warmup": 1
     }
 ]
 
-
+# Every configuration that requires compiling a native binary.
 ALL_BINARY_CONFIGS = [NATIVE] + BSAN_CONFIGS
 
+
+# Raw timing results are output as a CSV with these headers.
+CSV_HEADERS = [
+    'target',
+    'crate_name',
+    'version',
+    'test_name',
+    'mode',
+    'mean_exec_time_seconds'
+]
+
 def _build_env(kwargs: dict) -> dict:
-    """Pop an optional `env` mapping from kwargs and merge it on top of a copy
-    of the current environment, so callers can override individual variables
-    without dropping the inherited ones."""
+    """Creates a copy of the current environment, merged with an `env` mapping from `kwargs`."""
     env = os.environ.copy()
     env.update(kwargs.pop("env", None) or {})
     return env
@@ -118,16 +144,17 @@ def download_crate(crate: str, version: str, dest_dir: Path) -> Path:
         sys.exit(f"Error: expected extracted directory {extracted} not found.")
     return extracted
 
-def compile_test_binary(config: dict, cwd: Path, out_dir: Path, env: dict = {}) -> Path:
-    """Compiles the test binary for the given cargo invocation and return its
-    path. Aborts on compile failure or if no test executable is produced."""
+def compile_test_binary(config: dict, cwd: Path, out_dir: Path):
+    """Compiles the test binary for the given cargo invocation and copies it into
+    `out_dir`. Aborts on compile failure or if no executable is created.
+    """
     print(f">>> compiling tests ({config["name"]}): {' '.join(config["cmd"])}",
           file=sys.stderr)
     # We need to parse the output JSON to find the name of the test binary.
     msg_json = run_capture(
         config["cmd"] + ["--no-run", "--message-format=json"],
         cwd=cwd,
-        env=env,
+        env=config.get("env"),
     )
     for line in msg_json.splitlines():
         if not line.strip():
@@ -148,10 +175,54 @@ def compile_test_binary(config: dict, cwd: Path, out_dir: Path, env: dict = {}) 
 
     sys.exit(f"Error: could not locate {config["name"]} test binary.")
 
-def miri_env(config: dict) -> dict:
-    """Build the environment overrides for a Miri run, exposing the config's
-    `flags` as the MIRIFLAGS variable."""
-    return {"MIRIFLAGS": " ".join(config.get("flags") or [])}
+def miri_binary() -> str:
+    """Resolve the real `miri` executable for the active toolchain."""
+    return run_capture(["rustup", "which", "miri"]).strip()
+
+
+# The only way to execute a program in Miri is through Miri's cargo plugin
+# (e.g. `cargo miri ...`). This adds additional overhead that is not present
+# for natively compiled code. We want our timing measurements to be as accurate
+# as possible, so instead of timing `cargo miri test`, we capture Miri's
+# environment right before it invokes the actual `miri` binary as an interpreter.
+# Then, we create a shell script to recreate that environment and execute `miri`
+# directly, bypassing `cargo-miri`.
+#
+# This happens in two stages. First, we emit the shell script below. This is a one-time
+# operation; we reuse it for subsequent invocations. Whenever we execute Miri, we set
+# the `MIRI` environment variable to point to this script. Every time that `cargo-miri`
+# invokes the `miri` binary, this script will be executed instead. It forwards all
+# argument to `miri`, but it also checks to see if it is being invoked as the final call
+# to the interpreter. We identify this case if the variable `CARGO_PRIMARY_PACKAGE` is set
+# and the flag `--test` is provided. In that situation, we capture the environment and all
+# flags, and emit it as an additional shell script. That final shell script, which is
+# created per-test, is what gets benchmarked.
+#
+# This generally saves ~0.1 seconds of overhead, which is small but significant when
+# comparing against native execution.
+MIRI_WRAPPER_TEMPLATE = """#!/usr/bin/env bash
+if [ -n "$CARGO_PRIMARY_PACKAGE" ] && [[ " $* " == *" --test "* ]]; then
+    {
+        echo '#!/usr/bin/env bash'
+        printf 'cd %q || exit 1\\n' "$PWD"
+        printf 'exec env -i'
+        while IFS= read -r -d '' var; do printf ' %q' "$var"; done < <(env -0)
+        printf ' %q' @MIRI_BIN@ "$@"
+        echo
+    } > "$BSAN_MIRI_REPLAY"
+    chmod +x "$BSAN_MIRI_REPLAY"
+fi
+exec @MIRI_BIN@ "$@"
+"""
+
+def ensure_miri_wrapper(scratch: Path) -> Path:
+    """Ensure that the wrapper script for capturing Miri invocations is initialized."""
+    wrapper = scratch / "miri-wrapper.sh"
+    if not wrapper.is_file():
+        script = MIRI_WRAPPER_TEMPLATE.replace("@MIRI_BIN@", shlex.quote(miri_binary()))
+        wrapper.write_text(script)
+        wrapper.chmod(0o755)
+    return wrapper
 
 def compile_miri_tests(cwd: Path):
     print(">>> compiling tests (miri)")
@@ -159,9 +230,23 @@ def compile_miri_tests(cwd: Path):
         ["cargo", "miri", "test", "--no-run", "--message-format=json"],
         cwd=cwd,
     )
-def run_miri_test(cwd: Path, t: str, config: dict):
-    cmd = f"cargo miri test -q --lib -- --exact {t} --nocapture"
-    return hyperfine_mean(cmd, config, cwd=cwd, env=miri_env(config))
+
+def run_miri_test(cwd: Path, t: str, config: dict, scratch: Path) -> float:
+    """Time a single Miri test, excluding `cargo-miri` overhead, by capturing its
+    final `miri` invocation as a standalone script."""
+    replay = scratch / "miri-replay.sh"
+
+    override_env = { **(config.get("env") or {}) }
+    override_env["MIRI"] = str(ensure_miri_wrapper(scratch))
+    override_env["BSAN_MIRI_REPLAY"] = str(replay)
+
+    # One cargo-miri run generates the replay script for this test's final miri
+    # invocation; we then time that script on its own, free of cargo overhead.
+    run_capture(["cargo", "miri", "test", "-q", "--lib", "--", "--exact", t, "--nocapture"],
+                cwd=cwd, env=override_env)
+    if not replay.is_file():
+        sys.exit(f"Error: failed to intercept miri invocation for test {t}.")
+    return hyperfine_mean(str(replay), config)
 
 def list_tests(test_bin: Path) -> list[str]:
     """Return all #[test] names discovered in the given test binary."""
@@ -175,7 +260,7 @@ def list_tests(test_bin: Path) -> list[str]:
 
 def hyperfine_mean(cmd, config: dict, **kwargs) -> float:
     """Run hyperfine on a single command and return its mean wall time in
-    seconds. Aborts the script on failure (no `-i`)."""
+    seconds. Aborts on failure"""
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_json:
         out_path = Path(out_json.name)
     try:
@@ -184,8 +269,8 @@ def hyperfine_mean(cmd, config: dict, **kwargs) -> float:
         run(
             [
                 "hyperfine",
-                "--runs", str(config["runs"]),
-                "--warmup", str(config["warmup"]),
+                "--runs", str(RUNS),
+                "--warmup", str(WARMUP),
                 "--shell=none",
                 "--export-json", str(out_path),
                 "--show-output",
@@ -199,11 +284,16 @@ def hyperfine_mean(cmd, config: dict, **kwargs) -> float:
     finally:
         out_path.unlink(missing_ok=True)
 
+def require_positive_mean(mean: float, name: str, t: str, bench_name: str) -> None:
+    """Abort if a benchmark reported a non-positive mean execution time."""
+    if mean <= 0:
+        sys.exit(f"Reported 0s mean execution time for {name} on test {t} from {bench_name}")
+
 def process_config(
     cfg: dict,
     target: str,
     scratch: Path,
-) -> None:
+) -> list:
     crate = cfg.get("name")
     version = cfg.get("version")
     excluded_tests = set(cfg.get("exclude") or [])
@@ -221,10 +311,7 @@ def process_config(
 
     src_dir = download_crate(crate, version, scratch)
     for config in ALL_BINARY_CONFIGS:
-        env = {}
-        if config == NATIVE:
-            env["RUSTFLAGS"] = "--cfg=bsan"
-        compile_test_binary(config, cwd=src_dir, out_dir=scratch, env=env)
+        compile_test_binary(config, cwd=src_dir, out_dir=scratch)
         try:
             run(["cargo", "clean", "--quiet"], cwd=src_dir)
         except subprocess.CalledProcessError:
@@ -239,36 +326,57 @@ def process_config(
         sys.exit(f"Error: every discovered test was excluded for {bench_name}.")
     compile_miri_tests(src_dir)
 
+    # a mapping from (config, baseline) pairs to mean execution times for each test case
+    # for example, we would have `ratios[("no-op", "miri-tb")]` map to the list of
+    # mean execution times for our no-op mode relative to Miri with tree borrows enabled.
     ratios: dict[tuple[str, str], list[float]] = {}
+
+    # a raw list of execution times per crate, version, test case, and mode
+    raw_results: tuple[str, str, str, str, str, float] = []
+
+    count = 0
     for t in tests:
+        count += 1
+        if count > 1:
+            break
+        row_start = (target, crate, version, t)
         print(f"  -> {t}")
-        per_test_means = {}
+        # a mapping from each config to its mean execution time
+        per_test_means: dict[str, float] = {}
+
+        # execute every natively-compiled binary and record its mean execution time
         for config in ALL_BINARY_CONFIGS:
             binary = scratch / config["name"]
-            mean = hyperfine_mean(f"{binary} --exact {t} --nocapture", config)
+            mean = hyperfine_mean(f"{binary} --exact {t} --nocapture", config,
+                                  env=config.get("env"))
             if mean <= 0:
-                sys.exit(f"Reported 0s mean execution time for {config['name']} on test {t} from {bench_name}")
+                sys.exit(f"""Reported 0s mean execution time for
+                          {config["name"]} on test {t} from {bench_name}""")
             print(f"    - {config['name']}={round(mean, 8)}s")
             per_test_means[config["name"]] = mean
+            raw_results.append(row_start + (config["name"], mean))
 
-        miri_mean = run_miri_test(src_dir, t, MIRI)
-        if miri_mean <= 0:
-            sys.exit(f"Reported 0s mean execution time for {MIRI['name']} on test {t} from {bench_name}")
-        print(f"    - {MIRI['name']}={round(miri_mean, 8)}s")
-        baselines = {
-            NATIVE["name"]: per_test_means.pop(NATIVE["name"]),
-            MIRI["name"]: miri_mean,
-        }
+        baselines = {NATIVE["name"]: per_test_means.pop(NATIVE["name"])}
+
+        # execute Miri and add each configuration as a baseline for comparison
+        for miri_config in MIRI_CONFIGS:
+            miri_mean = run_miri_test(src_dir, t, miri_config, scratch)
+            if mean <= 0:
+                sys.exit(f"""Reported 0s mean execution time for
+                          {config["name"]} on test {t} from {bench_name}""")
+            print(f"    - {miri_config['name']}={round(miri_mean, 8)}s")
+            baselines[miri_config["name"]] = miri_mean
+            raw_results.append(row_start + (miri_config["name"], mean))
 
         for mode, mode_mean in per_test_means.items():
             for baseline, baseline_mean in baselines.items():
                 ratio = mode_mean / baseline_mean
                 ratios.setdefault((mode, baseline), []).append(ratio)
-                print(f"      {mode} vs {baseline} = {round(ratio, 4)}x")
+                print(f"    - {mode} vs {baseline} = {round(ratio, 4)}x")
 
-    results = []
+    relative_results = []
     for (mode, baseline), ratio_list in ratios.items():
-        results.append({
+        relative_results.append({
             "name": bench_name,
             "unit": "Mean Relative Execution Time",
             "value": statistics.mean(ratio_list),
@@ -282,18 +390,24 @@ def process_config(
                 "min": min(ratio_list)
             }),
         })
-    return results
+
+    all_results = {
+        "relative": relative_results,
+        "raw": raw_results
+    }
+    return all_results
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Benchmark relative execution time",
         usage=(
-            "%(prog)s <crates> <target> <output>"
+            "%(prog)s <crates> <target> <output_json> <output_csv>"
         ),
     )
     parser.add_argument("crates_json", type=Path)
     parser.add_argument("target", type=str)
     parser.add_argument("output_json", type=Path)
+    parser.add_argument("output_csv", type=Path)
 
     args = parser.parse_args(argv)
     for tool in ["cargo", "hyperfine"]:
@@ -303,14 +417,25 @@ def main(argv: list[str]) -> int:
     if not crates_json.is_file():
         sys.exit(f"Error: invalid config file: {crates_json}")
 
-    results = []
+    all_results = {}
     with tempfile.TemporaryDirectory() as scratch_str:
         scratch = Path(scratch_str)
         for cfg in json.loads(crates_json.read_text()):
-            results += process_config(cfg, args.target, scratch)
+            cfg_results = process_config(cfg, args.target, scratch)
+            all_results.setdefault("relative", [])
+            all_results["relative"] += cfg_results["relative"]
+            all_results.setdefault("raw", [])
+            all_results["raw"] += cfg_results["raw"]
 
-    args.output_json.write_text(json.dumps(results, indent=4))
-    print(f"Results written to {args.output_json}")
+    args.output_json.write_text(json.dumps(all_results["relative"], indent=4))
+    if "raw" in all_results:
+        with open(args.output_csv, 'w') as out:
+            csv_out=csv.writer(out)
+            csv_out.writerow(CSV_HEADERS)
+            for row in all_results["raw"]:
+                csv_out.writerow(row)
+
+    print(f"Results written to {args.output_json} and {args.output_csv}")
     return 0
 
 if __name__ == "__main__":

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -14,19 +14,37 @@ import tempfile
 import urllib.request
 from pathlib import Path
 
-HYPERFINE_RUNS = 10
-HYPERFINE_WARMUP = 3
+NATIVE = {
+    "name": "native",
+    "cmd": ["cargo", "test", "--lib"],
+    "runs": 1,
+    "warmup": 1
+}
 
-# Uninstrumented native execution
-NATIVE_CARGO = ["cargo", "test", "--lib"]
+MIRI = {
+    "name": "miri-tb",
+    "flags": ["-Zmiri-tree-borrows", "-Zmiri-provenance-gc=0"],
+    "runs": 1,
+    "warmup": 1
+}
 
-# Instrumented native execution in our "nop" mode, which 
-# adds in our runtime checks, but does not enable the core Rust
-# library with our Tree Borrows implementation. Every check is a
-# nop. This is significantly less expensive than running BorrowSanitizer
-# in full, and it helps debug issues associated with the LLVM components
-# of the tool.
-NOP_CARGO = ["cargo", "bsan", "test", "--nop", "--lib"]
+CONFIGS = [
+    {
+        "name": "full",
+        "cmd": ["cargo", "bsan", "test", "--lib"],
+        "runs": 1,
+        "warmup": 1
+    },
+    {
+        "name": "no-op",
+        "cmd": ["cargo", "bsan", "test", "--nop", "--lib"],
+        "runs": 1,
+        "warmup": 1
+    }
+]
+
+
+ALL = [NATIVE] + CONFIGS
 
 def run(
     cmd: list[str],
@@ -81,17 +99,16 @@ def download_crate(crate: str, version: str, dest_dir: Path) -> Path:
         sys.exit(f"Error: expected extracted directory {extracted} not found.")
     return extracted
 
-def compile_test_binary(cargo_cmd: list[str], label: str, cwd: Path, out: Path) -> Path:
+def compile_test_binary(config: dict, cwd: Path, out_dir: Path) -> Path:
     """Compiles the test binary for the given cargo invocation and return its
     path. Aborts on compile failure or if no test executable is produced."""
-    print(f">>> compiling test binary ({label}): {' '.join(cargo_cmd)}",
+    print(f">>> compiling test binary ({config["name"]}): {' '.join(config["cmd"])}",
           file=sys.stderr)
     # We need to parse the output JSON to find the name of the test binary.
     msg_json = run_capture(
-        cargo_cmd + ["--no-run", "--message-format=json"],
+        config["cmd"] + ["--no-run", "--message-format=json"],
         cwd=cwd,
     )
-
     for line in msg_json.splitlines():
         if not line.strip():
             continue
@@ -104,11 +121,22 @@ def compile_test_binary(cargo_cmd: list[str], label: str, cwd: Path, out: Path) 
         target = msg.get("target") or {}
         if exe and target.get("test"):
             print(">>> done.")
-            shutil.copy2(exe, out)
-            out.chmod(0o755)
+            bin = out_dir / config["name"]
+            shutil.copy2(exe, bin)
+            bin.chmod(0o755)
             return
         
-    sys.exit(f"Error: could not locate {label} test binary.")
+    sys.exit(f"Error: could not locate {config["name"]} test binary.")
+
+def compile_miri_tests(cwd: Path):
+    print(f">>> compiling test binary MIR for Miri")
+    run_capture(
+        ["cargo", "miri", "test", "--no-run", "--message-format=json"],
+        cwd=cwd,
+    )
+def run_miri_test(cwd: Path, t: str, config: dict):
+    cmd = f"cargo miri test -q --lib -- --exact {t} --nocapture"
+    return hyperfine_mean(cmd, config, cwd=cwd)
 
 def list_tests(test_bin: Path) -> list[str]:
     """Return all #[test] names discovered in the given test binary."""
@@ -120,22 +148,24 @@ def list_tests(test_bin: Path) -> list[str]:
             tests.append(line[:-len(": test")])
     return tests
 
-def hyperfine_mean(command: str) -> float:
+def hyperfine_mean(cmd, config: dict, **kwargs) -> float:
     """Run hyperfine on a single command and return its mean wall time in
     seconds. Aborts the script on failure (no `-i`)."""
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_json:
         out_path = Path(out_json.name)
     try:
+        kwargs["stdout"] = subprocess.DEVNULL
         run(
             [
                 "hyperfine",
-                "--runs", str(HYPERFINE_RUNS),
-                "--warmup", str(HYPERFINE_WARMUP),
+                "--runs", str(config["runs"]),
+                "--warmup", str(config["warmup"]),
                 "--shell=none",
                 "--export-json", str(out_path),
-                command,
+                "--show-output",
+                cmd,
             ],
-            stdout=subprocess.DEVNULL,
+            **kwargs
         )
         data = json.loads(out_path.read_text())
         mean = float(data["results"][0]["mean"])
@@ -155,7 +185,7 @@ def process_config(
     if not crate or not version:
         sys.exit(f"Error: invalid per-crate config:\n{cfg}")
 
-    bench_name = f"{crate}@{version} (nop) - {target}"
+    bench_name = f"{crate}@{version} - {target}"
 
     print(f"Running: {bench_name}")
     if excluded_tests:
@@ -164,49 +194,56 @@ def process_config(
             print(f"- {test_name}")
 
     src_dir = download_crate(crate, version, scratch)
-
-    native_bin = scratch / "native_test_bin"
-    compile_test_binary(NATIVE_CARGO, "native", cwd=src_dir, out=native_bin)
-
+    compile_test_binary(NATIVE, cwd=src_dir, out_dir=scratch)
     try:
         run(["cargo", "clean", "--quiet"], cwd=src_dir)
     except subprocess.CalledProcessError:
         pass
 
-    nop_bin = scratch / "nop_test_bin"
-    compile_test_binary(NOP_CARGO, "nop", cwd=src_dir, out=nop_bin)
+    for config in CONFIGS:
+        compile_test_binary(config, cwd=src_dir, out_dir=scratch)
 
-    all_tests = list_tests(native_bin)
+    all_tests = list_tests(scratch / NATIVE["name"])
     if not all_tests:
         sys.exit(f"Error: no tests discovered for {bench_name}.")
 
     tests = [t for t in all_tests if t not in excluded_tests]
     if not tests:
         sys.exit(f"Error: every discovered test was excluded for {bench_name}.")
+    
+    compile_miri_tests(src_dir)
 
-    ratios: list[float] = []
+    means = {}
     for t in tests:
         print(f"  -> {t}")
-        n_mean = hyperfine_mean(f"{native_bin} --exact {t} --nocapture")
-        i_mean = hyperfine_mean(f"{nop_bin} --exact {t} --nocapture")
-        if n_mean <= 0:
-            sys.exit(f"Reported 0s mean native execution time for test {t} from {bench_name}")
-        ratio = round(i_mean / n_mean, 2)
-        print(f" - native={round(n_mean, 8)}s  inst={round(i_mean, 8)}s  ratio={round(ratio, 2)}")
-        ratios.append(ratio)
-        
-    result = {
-        "name": bench_name,
-        "unit": "Median Relative Execution Time",
-        "value": statistics.median(ratios),
-        "extra": json.dumps({
-            "mode": "nop",
-            "target": target,
-            "version": version,
-            "crate": crate
-        }),
-    }
-    return result
+        for config in ALL:
+            bin = scratch / config["name"]
+            mean = hyperfine_mean(f"{bin} --exact {t} --nocapture", config)
+            if mean <= 0:
+                sys.exit(f"Reported 0s mean native execution time for test {t} from {bench_name}")
+            print(f"    - {config["name"]}={round(mean, 8)}s")
+            means[config["name"]] = mean
+        mean = run_miri_test(src_dir, t, MIRI)
+
+    results = []
+
+    native_mean = means[NATIVE["name"]]
+    del means[NATIVE["name"]]
+
+    for key in means.keys():
+        ratio = means[key] / native_mean
+        results.append({
+            "name": bench_name,
+            "unit": "Median Relative Execution Time",
+            "value": statistics.median(ratio),
+            "extra": json.dumps({
+                "mode": key,
+                "target": target,
+                "version": version,
+                "crate": crate
+            }),
+        })
+    return results
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
@@ -231,11 +268,7 @@ def main(argv: list[str]) -> int:
     with tempfile.TemporaryDirectory() as scratch_str:
         scratch = Path(scratch_str)
         for cfg in json.loads(crates_json.read_text()):
-            result = process_config(cfg, args.target, scratch)
-            print(
-                f"Median relative execution time for {result["name"]}: {result["value"]}"
-            )
-            results.append(result)
+            results += process_config(cfg, args.target, scratch)
 
     args.output_json.write_text(json.dumps(results, indent=4))
     print(f"Results written to {args.output_json}")

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 NATIVE = {
     "name": "native",
+    "label": "uninstrumented native execution",
     "cmd": ["cargo", "test", "--lib"],
     "runs": 3,
     "warmup": 1
@@ -22,6 +23,7 @@ NATIVE = {
 
 MIRI = {
     "name": "miri-tb",
+    "label": "Miri (Tree Borrows)",
     "env": {
         "MIRIFLAGS": [
             "-Zmiri-tree-borrows",
@@ -39,12 +41,14 @@ MIRI = {
 BSAN_CONFIGS = [
     {
         "name": "full",
+        "label": "checks enabled",
         "cmd": ["cargo", "bsan", "test", "--lib"],
         "runs": 3,
         "warmup": 1
     },
     {
         "name": "no-op",
+        "label": "no-op",
         "cmd": ["cargo", "bsan", "test", "--nop", "--lib"],
         "runs": 3,
         "warmup": 1
@@ -114,7 +118,7 @@ def download_crate(crate: str, version: str, dest_dir: Path) -> Path:
         sys.exit(f"Error: expected extracted directory {extracted} not found.")
     return extracted
 
-def compile_test_binary(config: dict, cwd: Path, out_dir: Path) -> Path:
+def compile_test_binary(config: dict, cwd: Path, out_dir: Path, env: dict = {}) -> Path:
     """Compiles the test binary for the given cargo invocation and return its
     path. Aborts on compile failure or if no test executable is produced."""
     print(f">>> compiling tests ({config["name"]}): {' '.join(config["cmd"])}",
@@ -123,6 +127,7 @@ def compile_test_binary(config: dict, cwd: Path, out_dir: Path) -> Path:
     msg_json = run_capture(
         config["cmd"] + ["--no-run", "--message-format=json"],
         cwd=cwd,
+        env=env,
     )
     for line in msg_json.splitlines():
         if not line.strip():
@@ -216,7 +221,10 @@ def process_config(
 
     src_dir = download_crate(crate, version, scratch)
     for config in ALL_BINARY_CONFIGS:
-        compile_test_binary(config, cwd=src_dir, out_dir=scratch)
+        env = {}
+        if config == NATIVE:
+            env["RUSTFLAGS"] = "--cfg=bsan"
+        compile_test_binary(config, cwd=src_dir, out_dir=scratch, env=env)
         try:
             run(["cargo", "clean", "--quiet"], cwd=src_dir)
         except subprocess.CalledProcessError:

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -22,7 +22,14 @@ NATIVE = {
 
 MIRI = {
     "name": "miri-tb",
-    "flags": ["-Zmiri-tree-borrows", "-Zmiri-provenance-gc=0", "-Zmiri-mute-stdout-stderr"],
+    "flags": [
+        "-Zmiri-tree-borrows",
+        "-Zmiri-provenance-gc=0",
+        "-Zmiri-mute-stdout-stderr",
+        "-Zmiri-disable-data-race-detector"
+        "-Zmiri-deterministic-concurrency",
+        "-Zmiri-disable-alignment-check"
+    ],
     "runs": 3,
     "warmup": 1
 }
@@ -222,35 +229,49 @@ def process_config(
         sys.exit(f"Error: every discovered test was excluded for {bench_name}.")
     compile_miri_tests(src_dir)
 
-    means = {}
+    ratios: dict[tuple[str, str], list[float]] = {}
+
     for t in tests:
         print(f"  -> {t}")
+        per_test_means = {}
         for config in ALL_BINARY_CONFIGS:
             binary = scratch / config["name"]
             mean = hyperfine_mean(f"{binary} --exact {t} --nocapture", config)
             if mean <= 0:
-                sys.exit(f"Reported 0s mean native execution time for test {t} from {bench_name}")
-            print(f"    - {config["name"]}={round(mean, 8)}s")
-            means[config["name"]] = mean
-        mean = run_miri_test(src_dir, t, MIRI)
-        means[MIRI["name"]] = mean
-        print(f"    - {MIRI["name"]}={round(mean, 8)}s")
+                sys.exit(f"Reported 0s mean execution time for {config['name']} on test {t} from {bench_name}")
+            print(f"    - {config['name']}={round(mean, 8)}s")
+            per_test_means[config["name"]] = mean
+
+        miri_mean = run_miri_test(src_dir, t, MIRI)
+        if miri_mean <= 0:
+            sys.exit(f"Reported 0s mean execution time for {MIRI['name']} on test {t} from {bench_name}")
+        print(f"    - {MIRI['name']}={round(miri_mean, 8)}s")
+
+        # Baselines (denominators). Pop native out of per_test_means so what's
+        # left is exactly the BSAN modes (the numerators).
+        baselines = {
+            NATIVE["name"]: per_test_means.pop(NATIVE["name"]),
+            MIRI["name"]: miri_mean,
+        }
+
+        for mode, mode_mean in per_test_means.items():
+            for baseline, baseline_mean in baselines.items():
+                ratio = mode_mean / baseline_mean
+                ratios.setdefault((mode, baseline), []).append(ratio)
+                print(f"      {mode} vs {baseline} = {round(ratio, 4)}x")
+
     results = []
-
-    native_mean = means[NATIVE["name"]]
-    del means[NATIVE["name"]]
-
-    for mode, mean in means.items():
-        ratio = mean / native_mean
+    for (mode, baseline), ratio_list in ratios.items():
         results.append({
             "name": bench_name,
             "unit": "Median Relative Execution Time",
-            "value": statistics.median(ratio),
+            "value": statistics.median(ratio_list),
             "extra": json.dumps({
                 "mode": mode,
+                "baseline": baseline,
                 "target": target,
                 "version": version,
-                "crate": crate
+                "crate": crate,
             }),
         })
     return results

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
 tag = "rolling-1.98.0-dev-0d3a8b3"
-sha = "0d3a8b3f36e43f9cb92d63ec47ba38daa903128c"
+sha = "c78cf5bfd2d4683da1693e0a9b0fad2dc864b362"
 version = "1.98.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,5 @@
 artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.98.0-dev-0d3a8b3"
+tag = "rolling-1.98.0-dev-c78cf5b"
 sha = "c78cf5bfd2d4683da1693e0a9b0fad2dc864b362"
 version = "1.98.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]

--- a/tests/benches/crates.json
+++ b/tests/benches/crates.json
@@ -5,5 +5,10 @@
         "exclude": [
             "map::test_map::test_lots_of_insertions"
         ]
+    },
+    {
+        "name": "indexmap",
+        "version": "2.14.0",
+        "exclude": []
     }
 ]

--- a/tests/benches/crates.json
+++ b/tests/benches/crates.json
@@ -5,10 +5,5 @@
         "exclude": [
             "map::test_map::test_lots_of_insertions"
         ]
-    },
-    {
-        "name": "indexmap",
-        "version": "2.14.0",
-        "exclude": []
     }
 ]


### PR DESCRIPTION
This updates our benchmarking script to include our full runtime checking mode and to compare against Miri. 

It also bumps the version of our custom Rust fork. The newest changes make it so that we skip parsing terminal information in `libtest` and use default values instead, if we have `--cfg=bsan` enabled. Miri also does this under `--cfg=miri`, because this parsing step is expensive to validate.