### PR TITLE
Fail gracefully when shadow memory reservation fails

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="BackendCodeEditorMiscSettings">
+    <option name="/Default/Housekeeping/FeatureSuggestion/FeatureSuggestionManager/DisabledSuggesters/=SwitchToGoToActionSuggester/@EntryIndexedValue" value="true" type="bool" />
+  </component>
+  <component name="CMakePresetLoader"><![CDATA[{
+  "useNewFormat": true
+}]]></component>
+  <component name="CMakeProjectFlavorService">
+    <option name="flavorId" value="CMakePlainProjectFlavor" />
+  </component>
+  <component name="CMakeReloadState">
+    <option name="reloaded" value="true" />
+  </component>
+  <component name="CMakeRunConfigurationManager">
+    <generated>
+      <config projectName="bsan" targetName="bsan_plugin" />
+      <config projectName="bsan" targetName="clang-format" />
+      <config projectName="bsan" targetName="clang-format-check" />
+    </generated>
+  </component>
+  <component name="CMakeSettings">
+    <configurations>
+      <configuration PROFILE_NAME="Debug" ENABLED="true" CONFIG_NAME="Debug" />
+    </configurations>
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="1cc2605a-60cf-48ee-a192-3cf4a0c86a48" name="Changes" comment="">
+      <change beforePath="$PROJECT_DIR$/bsan-pass/BorrowSanitizer.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/bsan-pass/BorrowSanitizer.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/bsan-rt/llvm-wrapper/bsan.cpp" beforeDir="false" afterPath="$PROJECT_DIR$/bsan-rt/llvm-wrapper/bsan.cpp" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/bsan-rt/src/borrow_tracker.rs" beforeDir="false" afterPath="$PROJECT_DIR$/bsan-rt/src/borrow_tracker.rs" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/bsan-rt/src/lib.rs" beforeDir="false" afterPath="$PROJECT_DIR$/bsan-rt/src/lib.rs" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="ClangdSettings">
+    <option name="formatViaClangd" value="false" />
+  </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="CMakeBuildProfile:Debug" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MacroExpansionManager">
+    <option name="directoryName" value="7kQ14Mhl" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 3,
+  &quot;fromUser&quot;: false
+}</component>
+  <component name="ProjectId" id="3FYKFxDh2WPOcOwoWzTq6vljN1n" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.RadMigrateCodeStyle": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.TerminalTabsStorage.copyFrom.TerminalArrangementManager.252": "true",
+    "RunOnceActivity.cidr.known.project.marker": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "RunOnceActivity.readMode.enableVisualFormatting": "true",
+    "RunOnceActivity.typescript.service.memoryLimit.init": "true",
+    "RunOnceActivity.west.config.association.type.startup.service": "true",
+    "cf.first.check.clang-format": "false",
+    "cidr.known.project.marker": "true",
+    "codeWithMe.voiceChat.enabledByDefault": "false",
+    "last_opened_file_path": "/IdeaProjects/bsan/bsan-pass/CMakeLists.txt",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RunManager" selected="CMake Application.bsan_plugin">
+    <configuration default="true" type="CLionExternalRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true">
+      <method v="2">
+        <option name="CLION.EXTERNAL.BUILD" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="bsan_plugin" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="bsan" TARGET_NAME="bsan_plugin" CONFIG_NAME="Debug">
+      <method v="2">
+        <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="clang-format-check" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="bsan" TARGET_NAME="clang-format-check" CONFIG_NAME="Debug">
+      <method v="2">
+        <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="clang-format" type="CMakeRunConfiguration" factoryName="Application" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="bsan" TARGET_NAME="clang-format" CONFIG_NAME="Debug">
+      <method v="2">
+        <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+      </method>
+    </configuration>
+    <list>
+      <item itemvalue="CMake Application.bsan_plugin" />
+      <item itemvalue="CMake Application.clang-format" />
+      <item itemvalue="CMake Application.clang-format-check" />
+    </list>
+  </component>
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="1cc2605a-60cf-48ee-a192-3cf4a0c86a48" name="Changes" comment="" />
+      <created>1782246463635</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1782246463635</updated>
+      <workItem from="1782246464953" duration="1474000" />
+      <workItem from="1782248007662" duration="836000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VCPKGProject">
+    <isAutomaticCheckingOnLaunch value="false" />
+    <isAutomaticFoundErrors value="true" />
+    <isAutomaticReloadCMake value="true" />
+    <isAutomaticBootstrapAfterUpdate value="false" />
+  </component>
+  <component name="XSLT-Support.FileAssociations.UIState">
+    <expand />
+    <select />
+  </component>
+</project>

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -156,7 +156,11 @@ void __bsan_init() {
   __bsan_internal_init();
   InitializePlatformEarly();
 
-  InitShadowWithReExec();
+  if (!InitShadowWithReExec()) {
+    Printf("FATAL: BorrowSanitizer can not mmap the shadow memory.\n");
+    DumpProcessMap();
+    Die();
+  }
   InitializeAllocator();
   InitializeInterceptors();
   InitializeTSD();

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -41,13 +41,15 @@ static void CheckMemoryLayout() {
 
 // TODO: CheckMemoryRangeAvailability is based on msan.
 // Consider refactoring these into a shared implementation.
-static bool CheckMemoryRangeAvailability(uptr beg, uptr size, bool verbose) {
+static bool CheckMemoryRangeAvailability(uptr beg, uptr size, bool verbose,
+                                         const char *name) {
   if (size > 0) {
     uptr end = beg + size - 1;
     if (!MemoryRangeIsAvailable(beg, end)) {
       if (verbose)
-        Printf("FATAL: Memory range %p - %p is not available.\n", (void *)beg,
-               (void *)end);
+        Printf("FATAL: BorrowSanitizer: memory range %p - %p is not available "
+               "(%s).\n",
+               (void *)beg, (void *)end, name);
       return false;
     }
   }
@@ -67,8 +69,9 @@ static bool ProtectMemoryRange(uptr beg, uptr size, const char *name) {
     }
     if ((uptr)addr != beg) {
       uptr end = beg + size - 1;
-      Printf("FATAL: Cannot protect memory range %p - %p (%s).\n", (void *)beg,
-             (void *)end, name);
+      Printf("FATAL: BorrowSanitizer: cannot protect memory range %p - %p "
+             "(%s).\n",
+             (void *)beg, (void *)end, name);
       return false;
     }
   }
@@ -88,7 +91,8 @@ static bool InitShadow(bool init_origins, bool dry_run) {
 
   if (!MEM_IS_APP(&__bsan_init)) {
     if (!dry_run)
-      Printf("FATAL: Code %p is out of application range. Non-PIE build?\n",
+      Printf("FATAL: BorrowSanitizer: code %p is out of application range. "
+             "Non-PIE build?\n",
              (void *)&__bsan_init);
     return false;
   }
@@ -114,20 +118,27 @@ static bool InitShadow(bool init_origins, bool dry_run) {
       CHECK(type == MappingDesc::APP || type == MappingDesc::ALLOCATOR);
 
       if (dry_run && type == MappingDesc::ALLOCATOR &&
-          !CheckMemoryRangeAvailability(start, size, !dry_run))
+          !CheckMemoryRangeAvailability(start, size, !dry_run,
+                                        kMemoryLayout[i].name))
         return false;
     }
     if (map) {
-      if (dry_run && !CheckMemoryRangeAvailability(start, size, !dry_run))
+      if (dry_run && !CheckMemoryRangeAvailability(start, size, !dry_run,
+                                                    kMemoryLayout[i].name))
         return false;
       if (!dry_run &&
-          !MmapFixedSuperNoReserve(start, size, kMemoryLayout[i].name))
+          !MmapFixedSuperNoReserve(start, size, kMemoryLayout[i].name)) {
+        Printf("FATAL: BorrowSanitizer: failed to map memory range %p - %p "
+               "(%s).\n",
+               (void *)start, (void *)(end - 1), kMemoryLayout[i].name);
         return false;
+      }
       if (!dry_run && common_flags()->use_madv_dontdump)
         DontDumpShadowMemory(start, size);
     }
     if (protect) {
-      if (dry_run && !CheckMemoryRangeAvailability(start, size, !dry_run))
+      if (dry_run && !CheckMemoryRangeAvailability(start, size, !dry_run,
+                                                    kMemoryLayout[i].name))
         return false;
       if (!dry_run && !ProtectMemoryRange(start, size, kMemoryLayout[i].name))
         return false;
@@ -135,6 +146,30 @@ static bool InitShadow(bool init_origins, bool dry_run) {
   }
 
   return true;
+}
+
+static void ReportUnavailableMemoryRegions(bool init_origins) {
+  const uptr maxVirtualAddress = GetMaxUserVirtualAddress();
+  for (unsigned i = 0; i < kMemoryLayoutSize; ++i) {
+    uptr start = kMemoryLayout[i].start;
+    uptr end = kMemoryLayout[i].end;
+    uptr size = end - start;
+    MappingDesc::Type type = kMemoryLayout[i].type;
+
+    if (start >= maxVirtualAddress)
+      continue;
+
+    bool map = type == MappingDesc::SHADOW ||
+               (init_origins && type == MappingDesc::ORIGIN);
+    bool protect = type == MappingDesc::INVALID ||
+                   (!init_origins && type == MappingDesc::ORIGIN);
+    if (!map && !protect) {
+      if (type == MappingDesc::ALLOCATOR)
+        CheckMemoryRangeAvailability(start, size, true, kMemoryLayout[i].name);
+      continue;
+    }
+    CheckMemoryRangeAvailability(start, size, true, kMemoryLayout[i].name);
+  }
 }
 
 namespace __bsan {
@@ -152,7 +187,7 @@ bool InitShadowWithReExec() {
         (old_personality != -1) && ((old_personality & ADDR_NO_RANDOMIZE) == 0);
 
     if (aslr_on) {
-      VReport(1, "WARNING: DataflowSanitizer: memory layout is incompatible, "
+      VReport(1, "WARNING: BorrowSanitizer: memory layout is incompatible, "
                  "possibly due to high-entropy ASLR.\n"
                  "Re-execing with fixed virtual address space.\n"
                  "N.B. reducing ASLR entropy is preferable.\n");
@@ -160,11 +195,13 @@ bool InitShadowWithReExec() {
       ReExec();
     }
 #endif
+    ReportUnavailableMemoryRegions(init_origins);
+    return false;
   }
 
   // The earlier dry run didn't actually map or protect anything. Run again in
   // non-dry run mode.
-  return success && InitShadow(init_origins, false);
+  return InitShadow(init_origins, false);
 }
 
 static void AlignPtr8(uptr addr, uptr &aligned_addr) {

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -124,7 +124,7 @@ static bool InitShadow(bool init_origins, bool dry_run) {
     }
     if (map) {
       if (dry_run && !CheckMemoryRangeAvailability(start, size, !dry_run,
-                                                    kMemoryLayout[i].name))
+                                                   kMemoryLayout[i].name))
         return false;
       if (!dry_run &&
           !MmapFixedSuperNoReserve(start, size, kMemoryLayout[i].name)) {
@@ -138,7 +138,7 @@ static bool InitShadow(bool init_origins, bool dry_run) {
     }
     if (protect) {
       if (dry_run && !CheckMemoryRangeAvailability(start, size, !dry_run,
-                                                    kMemoryLayout[i].name))
+                                                   kMemoryLayout[i].name))
         return false;
       if (!dry_run && !ProtectMemoryRange(start, size, kMemoryLayout[i].name))
         return false;


### PR DESCRIPTION
- Mirror DFSan's InitShadowWithReExec failure handling in __bsan_init so programs exit with a clear fatal error and process map instead of segfaulting when a shadow/origin region (e.g. origin-2) cannot be reserved.

- Report the failing region name and address range on mmap/reservation failures, and rename leftover DataflowSanitizer messages to BorrowSanitizer

Closes #261