### PR TITLE
Retain unprunable dead tags for future GC passes 

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -85,15 +85,30 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
   }
   quarantine_.swap(filtered);
 
-  pending_.drain([&](AllocInfo *info, const BorTagSet &tags) {
+  // A pending set of unpruned tags
+  ConcreteProvenanceSet still_pending;
+  pending_.drain([&](AllocInfo *info, BorTagSet &tags) {
+    // If `__bsan_prune` returns true, then the allocation's tree is empty;
+    // every single tag was pruned.
     if (__bsan_prune(info, tags.data(), tags.size())) {
       if (snap.min_drained == snap.gen) {
         __bsan_eject(info);
       } else {
         quarantine_.push_back({info, snap.gen});
       }
+    } else {
+      // The Rust core zeroes out every tag that no longer needs tracking.
+      // The remaining nonzero tags are dead nodes that could not be pruned
+      // yet; collect them for a future GC pass.
+      const BorTag *retained = tags.data();
+      for (uptr i = 0; i < tags.size(); ++i) {
+        if (retained[i] != 0) {
+          still_pending.insert({retained[i], info});
+        }
+      }
     }
   });
+  pending_.swap(still_pending);
 }
 
 void GlobalContext::RequestGC() {

--- a/bsan-rt/llvm-wrapper/bsan_interface_internal.h
+++ b/bsan-rt/llvm-wrapper/bsan_interface_internal.h
@@ -64,7 +64,7 @@ void __bsan_request_gc();
 // Returns true if every tag has been pruned, indicating that the allocation
 // metadata object can also be reclaimed.
 SANITIZER_WEAK_ATTRIBUTE
-bool __bsan_prune(AllocInfo *Info, const BorTag *tags, uptr len);
+bool __bsan_prune(AllocInfo *Info, BorTag *tags, uptr len);
 
 // Frees an `AllocInfo` object. The pointer must be nonnull and unreachable
 // in shadow memory.

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -33,6 +33,8 @@ public:
   void destroy();
 
   const BorTag *data() const { return tags_.data(); }
+  // Mutable access to the underlying array.
+  BorTag *data() { return tags_.data(); }
   uptr size() const { return tags_.size(); }
 
   template <typename Fn> void forEach(Fn fn) const {
@@ -74,6 +76,8 @@ public:
 
   void clear();
   bool contains(Provenance prov);
+
+  void swap(ConcreteProvenanceSet &other) { set_.swap(other.set_); }
 
   // Removes all entries from the set, after executing the
   // given callback for each allocation.

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -556,12 +556,19 @@ unsafe extern "C" fn __bsan_expose_prov_impl(bor_tag: BorTag, alloc_info: *mut A
 #[unsafe(no_mangle)]
 unsafe extern "C" fn __bsan_prune(
     alloc_info: NonNull<AllocInfo>,
-    bor_tags: *const BorTag,
+    bor_tags: *mut BorTag,
     len: usize,
 ) -> bool {
     let alloc: AllocInfoPtr = alloc_info.into();
-    let dead_tags = unsafe { slice::from_raw_parts(bor_tags, len) };
-    alloc.tree.lock().as_mut().map(|tree| tree.remove_dead_tags(dead_tags)).unwrap_or(false)
+    let dead_tags = unsafe { slice::from_raw_parts_mut(bor_tags, len) };
+    match alloc.tree.lock().as_mut() {
+        Some(tree) => tree.remove_dead_tags(dead_tags),
+        None => {
+            // The tree is already deallocated, so we can zero out dead_tags
+            dead_tags.fill(BorTag::omnivalid());
+            false
+        }
+    }
 }
 
 /// Deallocates an instance of [AllocInfo]. This instance must

--- a/bsan-rt/src/tree_borrows/tree.rs
+++ b/bsan-rt/src/tree_borrows/tree.rs
@@ -628,27 +628,39 @@ impl EagerTree {
     /// to be sorted in ascending order. Since a child must be allocated after its parent,
     /// we maintain the following invariant: `child.tag > parent.tag`. Iterating through
     /// `dead_tags` in reverse gives a valid reverse-topological (bottom-up) traversal.
-    fn remove_useless_children_dead(&mut self, dead_tags: &[BorTag]) {
-        debug_assert!(
-            dead_tags.is_sorted(),
-            "remove_useless_children_dead requires ascending-sorted tags"
-        );
+    ///
+    /// Each entry in `dead_tags` is zeroed out (set to [`BorTag::omnivalid`]) once its tag
+    /// no longer needs to be tracked: either the node was removed, or it is guaranteed to
+    /// re-enter a zero-count table before it can next become prunable. Entries left nonzero
+    /// are dead nodes that could not be pruned yet (they still have multiple reachable
+    /// children); the caller must keep them pending for a future GC pass.
+    fn remove_useless_children_dead(&mut self, dead_tags: &mut [BorTag]) {
+        // debug_assert!(
+        //     dead_tags.is_sorted(),
+        //     "remove_useless_children_dead requires ascending-sorted tags"
+        // );
 
         // Iterating through dead_tags in reverse (descending tag order)
-        for &tag in dead_tags.iter().rev() {
-            // A missing entry means the node was already removed earlier in this pass.
-            let Some(idx) = self.tag_mapping.get(&tag) else { continue };
+        for entry in dead_tags.iter_mut().rev() {
+            let tag = *entry;
+            // A missing entry means the node was already removed; zero out the entry
+            let Some(idx) = self.tag_mapping.get(&tag) else {
+                *entry = BorTag::omnivalid();
+                continue;
+            };
             let node = self.nodes.get(idx).unwrap();
 
-            // The ZCT may contain tags with a non-zero reference count. Since this is
-            // possible, we skip these tags
+            // The ZCT may contain tags with a non-zero reference count. These must be
+            // dropped; the tag will re-enter the ZCT when it drops back to zero.
             if node.refcount.get() != 0 {
+                *entry = BorTag::omnivalid();
                 continue;
             }
 
             // Do not remove exposed nodes. They could be used for future accesses via
             // wildcard pointers.
             if node.is_exposed {
+                *entry = BorTag::omnivalid();
                 continue;
             }
 
@@ -672,6 +684,7 @@ impl EagerTree {
                     }
                 }
                 self.remove_useless_node(idx);
+                *entry = BorTag::omnivalid();
             }
             // Node has exactly one child
             else if let Some(child_idx) = self.can_be_replaced_by_single_child_dead(idx) {
@@ -690,10 +703,12 @@ impl EagerTree {
                 }
                 self.nodes.get_mut(child_idx).unwrap().parent = parent;
                 self.remove_useless_node(idx);
+                *entry = BorTag::omnivalid();
             }
-            // Otherwise, the dead node has more than one reachable child and we retain it
+            // Otherwise, the dead node has more than one reachable child. Leave its
+            // entry nonzero so that the caller retains it for a future GC pass.
 
-            // To-do: Consider cases where there are multiple descendants of a parent
+            // TODO: Consider cases where there are multiple descendants of a parent
             // node with varying permissions
         }
     }
@@ -1112,7 +1127,7 @@ pub trait AllocState: Clone {
     #[allow(dead_code)]
     fn remove_unreachable_tags(&mut self, live_tags: &FxHashSet<BorTag>);
     #[allow(dead_code)]
-    fn remove_dead_tags(&mut self, dead_tags: &[BorTag]) -> bool;
+    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool;
 }
 
 impl AllocState for LazyTree {
@@ -1209,11 +1224,17 @@ impl AllocState for LazyTree {
             tree.remove_unreachable_tags(live_tags);
         }
     }
-    fn remove_dead_tags(&mut self, dead_tags: &[BorTag]) -> bool {
-        if let LazyTree::Init(tree) = self {
-            tree.remove_dead_tags(dead_tags)
-        } else {
-            false
+    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
+        match self {
+            LazyTree::Init(tree) => tree.remove_dead_tags(dead_tags),
+            LazyTree::Uninit { root_tag, refcount, .. } => {
+                // A tree in the Uninit state only has a single node (the root). If
+                // this node is in the dead list with a zero reference count, then the
+                // tree is dead and the associated AllocInfo metadata can be freed.
+                let root_is_dead = refcount.get() == 0 && dead_tags.contains(root_tag);
+                dead_tags.fill(BorTag::omnivalid());
+                root_is_dead
+            }
         }
     }
     fn increment(&self, tag: BorTag) -> bool {
@@ -1504,7 +1525,7 @@ impl AllocState for EagerTree {
         }
         self.locations.merge_adjacent_thorough();
     }
-    fn remove_dead_tags(&mut self, dead_tags: &[BorTag]) -> bool {
+    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
         self.remove_useless_children_dead(dead_tags);
         self.locations.merge_adjacent_thorough();
         self.roots.is_empty()

--- a/bsan-rt/src/tree_borrows/tree/tests.rs
+++ b/bsan-rt/src/tree_borrows/tree/tests.rs
@@ -769,3 +769,89 @@ mod spurious_read {
         }
     }
 }
+
+// The tests below are for BSAN's GC pruning that are not a part of Miri's GC.
+
+const ALLOC_BYTES: usize = 8;
+
+fn t(n: usize) -> BorTag {
+    assert!(BorTag(n).is_concrete());
+    BorTag(n)
+}
+
+fn new_tree(root: BorTag) -> EagerTree {
+    EagerTree::new(root, Size::from_bytes(ALLOC_BYTES), Span::dummy())
+}
+
+fn add_child(tree: &mut EagerTree, parent: BorTag, child: BorTag) {
+    let perm = Permission::new_frozen();
+    let sifa = perm.strongest_idempotent_foreign_access(false);
+    let inside_perms = DedupRangeMap::new(
+        Size::from_bytes(ALLOC_BYTES),
+        LocationState::new_non_accessed(perm, sifa),
+    );
+    let result =
+        tree.new_child(Size::ZERO, parent, child, inside_perms, perm, false, Span::dummy());
+    assert!(result.is_ok());
+}
+
+#[test]
+fn dead_leaf_is_removed_and_zeroed() {
+    let mut tree = new_tree(t(10));
+    add_child(&mut tree, t(10), t(11));
+
+    let mut dead = [t(11)];
+    let empty = tree.remove_dead_tags(&mut dead);
+
+    assert!(!empty, "the root is still in the tree");
+    assert_eq!(dead, [BorTag::omnivalid()]);
+    assert!(!tree.contains_tag(t(11)));
+    assert_eq!(tree.node_count(), 1);
+}
+
+#[test]
+fn dead_node_with_multiple_children_is_retained() {
+    let mut tree = new_tree(t(10));
+    add_child(&mut tree, t(10), t(11));
+    add_child(&mut tree, t(11), t(12));
+    add_child(&mut tree, t(11), t(13));
+    tree.increment(t(12));
+    tree.increment(t(13));
+
+    let mut dead = [t(11)];
+    let empty = tree.remove_dead_tags(&mut dead);
+
+    assert!(!empty);
+    // The dead node has two live children, so it cannot be pruned yet. Its
+    // slot must stay nonzero so that the caller keeps it pending.
+    assert_eq!(dead, [t(11)]);
+    assert!(tree.contains_tag(t(11)));
+    assert_eq!(tree.node_count(), 4);
+}
+
+#[test]
+fn retained_tag_is_pruned_once_children_die() {
+    let mut tree = new_tree(t(10));
+    add_child(&mut tree, t(10), t(11));
+    add_child(&mut tree, t(11), t(12));
+    add_child(&mut tree, t(11), t(13));
+    tree.increment(t(12));
+    tree.increment(t(13));
+
+    // First GC pass: the dead parent is blocked by its two live children.
+    let mut dead = [t(11)];
+    assert!(!tree.remove_dead_tags(&mut dead));
+    assert_eq!(dead, [t(11)]);
+
+    // The children die, re-entering a ZCT. The next pass merges them with
+    // the retained tag (the pending set keeps tags in ascending order).
+    tree.decrement(t(12));
+    tree.decrement(t(13));
+    let mut dead = [t(11), t(12), t(13)];
+    let empty = tree.remove_dead_tags(&mut dead);
+
+    assert!(!empty, "the root is still in the tree");
+    assert_eq!(dead, [BorTag::omnivalid(); 3]);
+    assert_eq!(tree.node_count(), 1);
+    assert!(tree.contains_tag(t(10)));
+}


### PR DESCRIPTION
Closes #265. A dead node with multiple live children cannot be pruned. However, we must keep these nodes so that they can be collected in a future GC pass. I implemented a `pending` set which keeps track of these unpruned nodes so that such nodes can be collected in future GC passes. Primarily,

- `remove_dead_tags` and the associated pruning methods now take `&mut [BorTag]` and pruned entries are zeroed out.
- Unpruned entries are kept in the list and swapped with the old dead_tags list.
- Note: uninitialized trees now reports itself as empty when its root is dead (and its reference count is zero), allowing the `AllocInfo` metadata to be reclaimed.