### PR TITLE
GC activation based on node visits

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -62,6 +62,11 @@ THREADLOCAL uptr __bsan_had_error = 0;
 SANITIZER_INTERFACE_ATTRIBUTE
 atomic_uintptr_t __bsan_bor_tag_ctr{3};
 
+// Accumulates the number of tree-node visits performed by the Rust runtime
+// since the last garbage collection request
+SANITIZER_INTERFACE_ATTRIBUTE
+atomic_uintptr_t __bsan_visits_since_gc{0};
+
 namespace __bsan {
 
 // Is the runtime initialized?
@@ -75,18 +80,16 @@ BorTag NewBorTag() {
   return atomic_fetch_add(&__bsan_bor_tag_ctr, 1, memory_order_relaxed);
 }
 
-// Counts retags so that we can periodically trigger garbage collection.
-static atomic_uintptr_t retag_ctr{0};
-
-// Increments the retag counter and asks the global context to run the garbage
-// collector once every `retags_per_gc` retags. Concurrent requests across
-// threads are coalesced by `RequestGC`.
+// Asks the global context to run the garbage collector once the Rust runtime
+// has reported at least `visits_per_gc` tree-node visits since the last
+// request, then resets the counter. Concurrent requests across threads are
+// coalesced by `RequestGC`.
 static void MaybeRequestGC() {
-  uptr interval = flags()->retags_per_gc;
+  uptr interval = flags()->visits_per_gc;
   if (interval == 0)
     return;
-  uptr count = atomic_fetch_add(&retag_ctr, 1, memory_order_relaxed) + 1;
-  if (count % interval == 0) {
+  if (atomic_load(&__bsan_visits_since_gc, memory_order_relaxed) >= interval) {
+    atomic_store(&__bsan_visits_since_gc, 0, memory_order_relaxed);
     global_ctx()->RequestGC();
   }
 }

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -57,6 +57,9 @@ extern SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL uptr __bsan_had_error;
 
 extern SANITIZER_INTERFACE_ATTRIBUTE atomic_uintptr_t __bsan_bor_tag_ctr;
 
+// Tree-node visits accumulated by the Rust runtime since the last GC request.
+extern SANITIZER_INTERFACE_ATTRIBUTE atomic_uintptr_t __bsan_visits_since_gc;
+
 namespace __bsan {
 
 typedef uptr ThreadId;

--- a/bsan-rt/llvm-wrapper/bsan_flags.inc
+++ b/bsan-rt/llvm-wrapper/bsan_flags.inc
@@ -9,6 +9,6 @@ BSAN_FLAG(bool, disable_node_debug_info, false,
           "Disable NodeDebugInfo diagnostics from the tree.")
 BSAN_FLAG(uptr, stacktrace_max_len, 3,
           "Maximum number of frames captured for BorrowSanitizer stack traces.")
-BSAN_FLAG(uptr, visits_per_gc, 40000,
+BSAN_FLAG(uptr, visits_per_gc, 150000,
           "Trigger a garbage collection request after this many retags."
           "0 disables the garbage collector.")

--- a/bsan-rt/llvm-wrapper/bsan_flags.inc
+++ b/bsan-rt/llvm-wrapper/bsan_flags.inc
@@ -9,6 +9,6 @@ BSAN_FLAG(bool, disable_node_debug_info, false,
           "Disable NodeDebugInfo diagnostics from the tree.")
 BSAN_FLAG(uptr, stacktrace_max_len, 3,
           "Maximum number of frames captured for BorrowSanitizer stack traces.")
-BSAN_FLAG(uptr, visits_per_gc, 20000,
+BSAN_FLAG(uptr, visits_per_gc, 40000,
           "Trigger a garbage collection request after this many retags."
           "0 disables the garbage collector.")

--- a/bsan-rt/llvm-wrapper/bsan_flags.inc
+++ b/bsan-rt/llvm-wrapper/bsan_flags.inc
@@ -9,6 +9,6 @@ BSAN_FLAG(bool, disable_node_debug_info, false,
           "Disable NodeDebugInfo diagnostics from the tree.")
 BSAN_FLAG(uptr, stacktrace_max_len, 3,
           "Maximum number of frames captured for BorrowSanitizer stack traces.")
-BSAN_FLAG(uptr, retags_per_gc, 1000,
+BSAN_FLAG(uptr, visits_per_gc, 20000,
           "Trigger a garbage collection request after this many retags."
           "0 disables the garbage collector.")

--- a/bsan-rt/src/sanitizer_common.rs
+++ b/bsan-rt/src/sanitizer_common.rs
@@ -105,6 +105,9 @@ unsafe extern "C" {
     #[thread_local]
     pub unsafe static mut __bsan_had_error: usize;
 
+    /// Tree-node visits accumulated since the last GC request.
+    pub unsafe static __bsan_visits_since_gc: core::sync::atomic::AtomicUsize;
+
     /// Symbolize a single PC into "file:line:column" and returns 1 on success.
     fn __bsan_symbolize_pc(
         pc: usize,

--- a/bsan-rt/src/tree_borrows/tree.rs
+++ b/bsan-rt/src/tree_borrows/tree.rs
@@ -849,7 +849,9 @@ impl LocationTree {
             let old_state = perm.copied().unwrap_or_else(|| node.default_location_state());
             old_state.skip_if_known_noop(access_kind, args.rel_pos)
         };
+        let mut visit_count: usize = 0;
         let node_app = |args: NodeAppArgs<'_, LocationTree>| {
+            visit_count += 1;
             let node = args.nodes.get_mut(args.idx).unwrap();
             let mut perm = args.data.perms.entry(args.idx);
 
@@ -880,14 +882,19 @@ impl LocationTree {
         };
 
         let visitor = TreeVisitor { nodes, data: self };
-        match visit_children {
+        let result = match visit_children {
             ChildrenVisitMode::VisitChildrenOfAccessed => visitor
                 .traverse_this_parents_children_other(access_source, node_skipper, node_app)
                 .map_err(|e| e.into()),
             ChildrenVisitMode::SkipChildrenOfAccessed => visitor
                 .traverse_nonchildren(access_source, node_skipper, node_app)
                 .map_err(|e| e.into()),
+        };
+        unsafe {
+            crate::sanitizer_common::__bsan_visits_since_gc
+                .fetch_add(visit_count, core::sync::atomic::Ordering::Relaxed);
         }
+        result
     }
 
     /// Performs a wildcard access on the tree with root `root`. Takes the `access_relatedness`
@@ -922,6 +929,7 @@ impl LocationTree {
 
         // Whether there is an exposed node in this tree that allows this access.
         let mut has_valid_exposed = false;
+        let mut visit_count: usize = 0;
 
         // This does a traversal across the tree updating children before their parents. The
         // difference to `perform_normal_access` is that we take the access relatedness from
@@ -958,6 +966,7 @@ impl LocationTree {
                 }
             },
             |args| {
+                visit_count += 1;
                 let node = args.nodes.get_mut(args.idx).unwrap();
 
                 let protected = global.get_protector_kind(node.tag).is_some();
@@ -1013,6 +1022,10 @@ impl LocationTree {
                 })
             },
         )?;
+        unsafe {
+            crate::sanitizer_common::__bsan_visits_since_gc
+                .fetch_add(visit_count, core::sync::atomic::Ordering::Relaxed);
+        }
         // If there is no exposed node in this tree that allows this access, then the access *must*
         // be foreign to the entire subtree. Foreign accesses are only possible on wildcard subtrees
         // as there are no ancestors to the main root. So if we do not find a valid exposed node in

--- a/tests/pass/analyze_retags.rs
+++ b/tests/pass/analyze_retags.rs
@@ -1,5 +1,5 @@
 //@run:0
-//@rustc-env: BSAN_OPTIONS=retags_per_gc=0
+//@rustc-env: BSAN_OPTIONS=visits_per_gc=0
 #[path = "../utils/mod.rs"]
 #[macro_use]
 mod utils;

--- a/tests/pass/vec_debug.rs
+++ b/tests/pass/vec_debug.rs
@@ -1,5 +1,5 @@
 //@run:0
-//@rustc-env: BSAN_OPTIONS=retags_per_gc=0
+//@rustc-env: BSAN_OPTIONS=visits_per_gc=0
 
 #[path = "../utils/mod.rs"]
 #[macro_use]


### PR DESCRIPTION
(satisfies part 3 of #275)

Previously, we were using a retag-based interval for how often to run the GC, which is roughly equivalent to the amount of new nodes created since the last pass.

Visits, which happen during every event (retags, reads, writes, etc), more accurately express how much trees are being *used* and need compaction than how large the trees have gotten. Additionally, visits and tree size are correlated by a power relation (roughly `v = 3.27s^1.44` where `v`=visits and `s`=size) allowing us to activate the GC more aggressively for executions involving large trees and less so for small trees.

In the implementation, `visit_count` is incremented locally during the `visitor` traversal in `perform_normal_access` and `perform_wildcard_access`. After, it's added to the global accumulator so that we're minimizing any extra compute during every node visit. The accumulator, `__bsan_visits_since_gc` is checked within `MaybeRequestGC()` in the llvm wrapper in our runtime.

I found that activation every 150,000 visits was most optimal (as opposed to 20,000 in Miri). As we make the GC pass faster, we should be able to turn down this value by default. The visit count can also be set via `BSAN_OPTIONS=visits_per_gc=...`.

After benchmarking performance on 105 crates where there is at least 1 successful test case run, this GC outperforms the previous in ~95% of cases. I did not take multiple samples, so there's bound to be some noise at <10s. This was compared against the [better-bt](https://github.com/BorrowSanitizer/bsan/pull/231/commits/f8fb8b156239e651c564eb259a3ca5c5976e69a4) branch which is up-to-date with main (and does not include the extra spans per node)

<img width="1800" height="1050" alt="image" src="https://github.com/user-attachments/assets/76f1565f-71f0-4df6-82f6-7fb9ae1ddde2" />
