### PR TITLE
Use the `BorTag` as a proxy for `AllocInfo` when clearing shadow.

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -227,7 +227,6 @@ void CopyAligned(void *dest, const void *src, uptr size) {
   uptr s_aligned, s_size;
   AlignPtr8((uptr)dest, d_aligned);
   AlignRange8((uptr)src, size, s_aligned, s_size);
-
   internal_memcpy((void *)d_aligned, (const void *)s_aligned, s_size);
 }
 
@@ -323,9 +322,11 @@ void ClearShadow(void *dest, uptr size) {
     AllocInfo **info_ptr =
         reinterpret_cast<AllocInfo **>(origin_start + offset);
 
-    if (*info_ptr != nullptr) {
+    // We use the borrow tag as a proxy for the initialization of the
+    // `AllocInfo` component of provenance metadata.
+    if (*tag_ptr != 0) {
       __bsan_rc_dec(*tag_ptr, *info_ptr);
-      *info_ptr = nullptr;
+      *tag_ptr = 0;
     }
   }
 }
@@ -340,7 +341,7 @@ void WriteShadow(void *dest, Provenance prov) {
 
   BorTag *tag_ptr = reinterpret_cast<BorTag *>(shadow_start);
   AllocInfo **info_ptr = reinterpret_cast<AllocInfo **>(origin_start);
-  if (*info_ptr != nullptr) {
+  if (*tag_ptr != 0) {
     __bsan_rc_dec(*tag_ptr, *info_ptr);
   }
 


### PR DESCRIPTION
When we validate an access, we use the `BorTag` as a proxy for the validity of `AllocInfo`. This means that we should also *clear* tags from shadow memory, instead of clearing the `AllocInfo` pointers.