### PR TITLE
Ensure reference count increments happen before decrements.

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1489,6 +1489,14 @@ private:
   void storeProvenanceWithReferenceCount(IRBuilder<> &IRB, Value *TagPtr,
                                          Value *InfoPtr, Provenance Prov,
                                          AtomicOrdering Ordering) {
+    // We always need to increment first, in case both the source and
+    // destination are the same provenance value. If we decrement the
+    // provenance in the destination first, then the garbage collector
+    // may see a zero reference count and deinitialize the provenance
+    // that we are about to store.
+    if (Prov != Provenance::omnivalid(BS)) {
+      IRB.CreateCall(BS.BsanFuncRcInc, {Prov.Tag, Prov.Info});
+    }
     // We only decrement on nonatomic loads. This leaks provenance exposed to
     // atomic operations, which is necessary to support them without locking.
     if (Ordering == AtomicOrdering::NotAtomic) {
@@ -1496,9 +1504,7 @@ private:
           loadProvenanceAlignedPairwise(IRB, TagPtr, InfoPtr, Ordering);
       IRB.CreateCall(BS.BsanFuncRcDec, {Old.Tag, Old.Info});
     }
-    if (Prov != Provenance::omnivalid(BS)) {
-      IRB.CreateCall(BS.BsanFuncRcInc, {Prov.Tag, Prov.Info});
-    }
+
     storeProvenanceAlignedPairwise(IRB, TagPtr, InfoPtr, Prov, Ordering);
   }
 

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -246,11 +246,10 @@ ALWAYS_INLINE static void UpdateShadowSlot(uptr d_aligned, uptr s_aligned,
   BorTag src_tag = *source_tag;
   AllocInfo *src_info = *source_info;
 
-  if (*dest_info != nullptr)
-    __bsan_rc_dec(*dest_tag, *dest_info);
-
   if (src_info != nullptr)
     __bsan_rc_inc(src_tag, src_info);
+  if (*dest_info != nullptr)
+    __bsan_rc_dec(*dest_tag, *dest_info);
 
   *dest_tag = src_tag;
   *dest_info = src_info;
@@ -341,16 +340,13 @@ void WriteShadow(void *dest, Provenance prov) {
 
   BorTag *tag_ptr = reinterpret_cast<BorTag *>(shadow_start);
   AllocInfo **info_ptr = reinterpret_cast<AllocInfo **>(origin_start);
-  if (*tag_ptr != 0) {
+
+  if (prov.info != nullptr)
+    __bsan_rc_inc(prov.tag, prov.info);
+  if (*tag_ptr != 0)
     __bsan_rc_dec(*tag_ptr, *info_ptr);
-  }
 
   *info_ptr = prov.info;
   *tag_ptr = prov.tag;
-
-  // The written provenance now holds a reference from this shadow slot.
-  if (prov.info != nullptr) {
-    __bsan_rc_inc(prov.tag, prov.info);
-  }
 }
 } // namespace __bsan

--- a/bsan-rt/llvm-wrapper/bsan_thread.h
+++ b/bsan-rt/llvm-wrapper/bsan_thread.h
@@ -87,16 +87,6 @@ public:
     atomic_store(&zct_busy_, 0, memory_order_release);
   }
 
-  // Removes a provenance value from this thread's zero count table after its
-  // reference count is revived (a zero-to-one transition). If the value was
-  // recorded in another thread's table, this is a no-op here; the stale entry
-  // is still harmless because pruning re-checks `refcount == 0`.
-  void ReleaseProvenance(Provenance Prov) {
-    atomic_store(&zct_busy_, 1, memory_order_release);
-    zero_count_set_.remove(Prov);
-    atomic_store(&zct_busy_, 0, memory_order_release);
-  }
-
   bool ZctBusy() const {
     return atomic_load(&zct_busy_, memory_order_acquire) != 0;
   }


### PR DESCRIPTION
At the moment, when we store a provenance value, we decrement the reference count of the destination before incrementing the reference count of what we're storing there. This is incorrect: if both values are the same, then this could create a window where the garbage collector sees a reference count of zero and deinitializes the provenance that we are trying to store.