### PR TITLE
Require matching borrow tags for reference count operations on `LazyTree::Uninit`.

### DIFF
--- a/bsan-rt/src/tree_borrows/refcount.rs
+++ b/bsan-rt/src/tree_borrows/refcount.rs
@@ -70,7 +70,7 @@ impl RefCount {
     pub fn decrement_nonatomic(&self) -> bool {
         unsafe {
             let count = self.0.as_ptr();
-            assert!(*count > 0, "RefCount decremented below zero");
+            debug_assert!(*count > 0, "RefCount decremented below zero");
             *count -= 1;
             *count == 0
         }

--- a/bsan-rt/src/tree_borrows/refcount.rs
+++ b/bsan-rt/src/tree_borrows/refcount.rs
@@ -70,7 +70,7 @@ impl RefCount {
     pub fn decrement_nonatomic(&self) -> bool {
         unsafe {
             let count = self.0.as_ptr();
-            debug_assert!(*count > 0, "RefCount decremented below zero");
+            assert!(*count > 0, "RefCount decremented below zero");
             *count -= 1;
             *count == 0
         }

--- a/bsan-rt/src/tree_borrows/tree.rs
+++ b/bsan-rt/src/tree_borrows/tree.rs
@@ -1253,9 +1253,11 @@ impl AllocState for LazyTree {
     fn increment(&self, tag: BorTag) -> bool {
         match self {
             LazyTree::Uninit { root_tag, refcount, .. } => {
-                // In the Uninit state the only node is the root, we add an debug_assert instead
-                debug_assert!(*root_tag == tag);
-                refcount.increment_nonatomic()
+                if *root_tag == tag {
+                    refcount.increment_nonatomic()
+                } else {
+                    false
+                }
             }
             LazyTree::Init(tree) => tree.increment(tag),
         }
@@ -1263,8 +1265,11 @@ impl AllocState for LazyTree {
     fn decrement(&self, tag: BorTag) -> bool {
         match self {
             LazyTree::Uninit { root_tag, refcount, .. } => {
-                debug_assert!(*root_tag == tag);
-                refcount.decrement_nonatomic()
+                if *root_tag == tag {
+                    refcount.decrement_nonatomic()
+                } else {
+                    false
+                }
             }
             LazyTree::Init(tree) => tree.decrement(tag),
         }


### PR DESCRIPTION
We are seeing reference count underflow due to an issue with `LazyTree::Uninit`. We unconditionally modify reference counts of allocations in this state without checking the borrow tag. Here's how this happens:
```llvm
; Create a stack object, allocating provenance metadata for it.
; We have not retagged it yet, so it will start in `LazyTree::Uninit`.
%x = alloca()
%y = alloca()
call @llvm.lifetime.start(%x)

; Store the provenance for `%x` into shadow memory
store %x, %shadow

; The lifetime of `%x` ends, so we deinitialize its metadata.
; However, a copy of its provenance value remains within the shadow heap. 
call @llvm.lifetime.end(%x);

; The lifetime of `%x` starts back up again. We reuse the same metadata object
; as we did earlier so that we avoid constantly allocating and freeing new objects
; for frequently-allocated stack variables. However, we reinitialize its contents with
; a new `LazyTree::Uninit`, which will have a reference count of 0.
call @llvm.lifetime.start(%x)

; We also start the lifetime for `%y`, and store its provenance into
; the same shadow memory slot that we used for `%x`.
call @llvm.lifetime.start(%y)

; When we store `%y`, we need to decrement the reference count of whatever is
; currently stored in that shadow slot. At the moment, it's a stale provenance
; value with the same `AllocInfo` pointer as `%x`, in `LazyTree::Uninit`. We
; do not check that the borrow tags match, so we decrement the reference count.
; The reference count of `%x` is at zero before the decrement, so it underflows.
store %y, %shadow
```
This PR fixes this issue by turning what was once a `debug_assert!` into a conditional.