### PR TITLE
refactor(#279): rename LazyTree to BorrowState on AllocInfo

### DIFF
--- a/bsan-rt/src/borrow_state.rs
+++ b/bsan-rt/src/borrow_state.rs
@@ -1,0 +1,15 @@
+//! Allocation-level borrow metadata attached to [`crate::AllocInfo`].
+//!
+//! Today this is the old `LazyTree` path under a clearer name: one
+//! [`BorrowState`] per allocation, stored under `AllocInfo`'s mutex.
+//! Provenance remains two-word (`BorTag` + `AllocInfo*`).
+//!
+//! - [`BorrowState::Uninit`]: lazy; root tag / size / span / refcount only.
+//! - [`BorrowState::Tree`]: owns the full [`crate::tree_borrows::tree::EagerTree`].
+//!
+//! [#279](https://github.com/BorrowSanitizer/bsan/issues/279) (one-word provenance)
+//! will turn Heap-allocated metadata into `Uninit | Tree | Node`, make provenance a
+//! single pointer (tag unused), and hand out per-retag `Node` objects. That work
+//! should land in a follow-up PR on top of this rename.
+
+pub use crate::tree_borrows::tree::BorrowState;

--- a/bsan-rt/src/borrow_tracker.rs
+++ b/bsan-rt/src/borrow_tracker.rs
@@ -43,12 +43,12 @@ impl AllocInfoPtr {
 
     fn tree_opt<'b>(self) -> Option<TreeGuard<'b>> {
         let info: &'b AllocInfo = unsafe { self.0.as_ref() };
-        let tree = info.tree.lock();
-        if tree.is_none() {
+        let borrow = info.borrow.lock();
+        if borrow.is_none() {
             None
         } else {
-            // Safety: the tree contains a valid instance now.
-            Some(unsafe { TreeGuard::new(tree) })
+            // Safety: the borrow state contains a valid instance now.
+            Some(unsafe { TreeGuard::new(borrow) })
         }
     }
 }

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -16,10 +16,13 @@ use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{fmt, ptr, slice};
 
+mod borrow_state;
 mod borrow_tracker;
 use libc_print::std_name::*;
 use spin::Mutex;
 mod tree_borrows;
+
+pub use borrow_state::BorrowState;
 
 mod global;
 use global::*;
@@ -237,13 +240,14 @@ impl Debug for FreeListOrAddr {
 /// Provenance is the "key" to this lock. To validate a memory access, we compare the allocation ID
 /// of a pointer's provenance with the value stored in its corresponding `AllocInfo` object. If the values
 /// do not match, then the access is invalid. If they do match, then we proceed to validate the access against
-/// the tree for the allocation.
+/// the [`BorrowState`] attached to this allocation.
 #[repr(C)]
 pub struct AllocInfo {
     alloc_id: Cell<AllocId>,
     free_or_addr: Cell<FreeListOrAddr>,
     size: Cell<Size>,
-    tree: Mutex<Option<AllocStateImpl>>,
+    /// Polymorphic borrow metadata for this allocation (`Uninit` | `Tree`).
+    borrow: Mutex<Option<AllocStateImpl>>,
 }
 
 impl AllocInfo {
@@ -252,7 +256,7 @@ impl AllocInfo {
             alloc_id: Cell::new(AllocId::invalid()),
             free_or_addr: Cell::new(FreeListOrAddr { base_addr: Size::ZERO }),
             size: Cell::new(Size::ZERO),
-            tree: Mutex::default(),
+            borrow: Mutex::default(),
         }
     }
 
@@ -261,7 +265,7 @@ impl AllocInfo {
             alloc_id: Cell::new(AllocId::default()),
             free_or_addr: Cell::new(FreeListOrAddr { base_addr }),
             size: Cell::new(size),
-            tree: Mutex::new(Some(AllocStateImpl::new(bor_tag, size, span))),
+            borrow: Mutex::new(Some(AllocStateImpl::new(bor_tag, size, span))),
         }
     }
 
@@ -610,10 +614,10 @@ unsafe extern "C" fn __bsan_prune(
 ) -> bool {
     let alloc: AllocInfoPtr = alloc_info.into();
     let dead_tags = unsafe { slice::from_raw_parts_mut(bor_tags, len) };
-    match alloc.tree.lock().as_mut() {
-        Some(tree) => tree.remove_dead_tags(dead_tags),
+    match alloc.borrow.lock().as_mut() {
+        Some(borrow) => borrow.remove_dead_tags(dead_tags),
         None => {
-            // The tree is already deallocated, so we can zero out dead_tags
+            // The allocation is already deallocated, so we can zero out dead_tags
             dead_tags.fill(BorTag::omnivalid());
             false
         }

--- a/bsan-rt/src/tree_borrows/diagnostics.rs
+++ b/bsan-rt/src/tree_borrows/diagnostics.rs
@@ -7,7 +7,7 @@ use core::ops::Range;
 use super::perms::{AccessKind, PermTransition, Permission, ProtectorKind};
 use super::tree::{node_ptr_from_map, node_tag, EagerTree, LocationState};
 use crate::helpers::AllocRange;
-use crate::tree_borrows::LazyTree;
+use crate::tree_borrows::BorrowState;
 use crate::{eprintln, *};
 
 /// Cause of an access: either a real access or one
@@ -964,26 +964,26 @@ impl EagerTree {
     }
 }
 
-impl LazyTree {
+impl BorrowState {
     pub fn print_tree(&self, protected_tags: &ProtectedTagsRef<'_>, show_unnamed: bool) {
         match self {
-            LazyTree::Init(tree) => tree.print_tree(protected_tags, show_unnamed),
-            LazyTree::Uninit { root_tag, size, span, .. } => {
+            BorrowState::Tree(tree) => tree.print_tree(protected_tags, show_unnamed),
+            BorrowState::Uninit { root_tag, size, span, .. } => {
                 EagerTree::new(*root_tag, *size, *span).print_tree(protected_tags, show_unnamed)
             }
         }
     }
 
-    pub fn print_tree_diff(&self, old_tree: &LazyTree, protected_tags: &ProtectedTagsRef<'_>) {
+    pub fn print_tree_diff(&self, old_tree: &BorrowState, protected_tags: &ProtectedTagsRef<'_>) {
         let self_tree = match self {
-            LazyTree::Init(t) => t.clone(),
-            LazyTree::Uninit { root_tag, size, span, .. } => {
+            BorrowState::Tree(t) => t.clone(),
+            BorrowState::Uninit { root_tag, size, span, .. } => {
                 EagerTree::new(*root_tag, *size, *span)
             }
         };
         let old_tree = match old_tree {
-            LazyTree::Init(t) => t.clone(),
-            LazyTree::Uninit { root_tag, size, span, .. } => {
+            BorrowState::Tree(t) => t.clone(),
+            BorrowState::Uninit { root_tag, size, span, .. } => {
                 EagerTree::new(*root_tag, *size, *span)
             }
         };

--- a/bsan-rt/src/tree_borrows/mod.rs
+++ b/bsan-rt/src/tree_borrows/mod.rs
@@ -19,7 +19,7 @@ pub use foreign_access_skipping::IdempotentForeignAccess;
 pub use perms::*;
 
 use self::perms::Permission;
-pub use self::tree::{AllocState, AllocStateImpl, LazyTree};
+pub use self::tree::{AllocState, AllocStateImpl, BorrowState};
 
 type GlobalState = ProtectedTags;
 

--- a/bsan-rt/src/tree_borrows/tree.rs
+++ b/bsan-rt/src/tree_borrows/tree.rs
@@ -40,7 +40,7 @@ use crate::*;
 compile_error!("Only one of the following features can be selected: 'lazy', 'eager'");
 
 #[cfg(feature = "lazy")]
-pub type AllocStateImpl = LazyTree;
+pub type AllocStateImpl = BorrowState;
 
 #[cfg(feature = "eager")]
 pub type AllocStateImpl = EagerTree;
@@ -1159,28 +1159,33 @@ impl Node {
     }
 }
 
-/// A tree that is lazily initialized: starts as `Uninit` (storing only the root tag, size, and
-/// span needed to construct the real `Tree` on demand), and transitions to `Init` the first
-/// time a child is added via `new_child`. All operations on a single-node tree short-circuit
-/// without ever allocating the underlying `Tree`.
+/// Allocation-level borrow metadata attached to [`crate::AllocInfo`].
+///
+/// Starts as [`BorrowState::Uninit`] (root tag, size, span, refcount only) and
+/// morphs to [`BorrowState::Tree`] on the first `new_child` / expose. Single-node
+/// accesses short-circuit without building an [`EagerTree`].
+///
+/// Prep for [#279](https://github.com/BorrowSanitizer/bsan/issues/279): this enum
+/// is the named home for allocation borrow state. One-word provenance will add a
+/// Heap-level `Node` kind and stop keying accesses by `BorTag`.
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum LazyTree {
+pub enum BorrowState {
     Uninit { root_tag: BorTag, size: Size, span: Span, refcount: RefCount },
-    Init(EagerTree),
+    Tree(EagerTree),
 }
 
-impl LazyTree {
+impl BorrowState {
     pub fn new(root_tag: BorTag, size: Size, span: Span) -> Self {
-        LazyTree::Uninit { root_tag, size, span, refcount: RefCount::new() }
+        BorrowState::Uninit { root_tag, size, span, refcount: RefCount::new() }
     }
 
-    /// Forces the tree into the `Init` state, constructing the underlying `Tree` if needed.
+    /// Morphs into [`BorrowState::Tree`], constructing the underlying [`EagerTree`] if needed.
     fn ensure_init(&mut self) {
-        if let LazyTree::Uninit { root_tag, size, span, refcount } = self {
+        if let BorrowState::Uninit { root_tag, size, span, refcount } = self {
             let mut tree = EagerTree::new(*root_tag, *size, *span);
             tree.node_mut(*root_tag).refcount = refcount.clone();
-            *self = LazyTree::Init(tree);
+            *self = BorrowState::Tree(tree);
         }
     }
 }
@@ -1255,17 +1260,17 @@ pub trait AllocState: Clone {
     fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool;
 }
 
-impl AllocState for LazyTree {
+impl AllocState for BorrowState {
     fn contains_tag(&self, tag: BorTag) -> bool {
         match self {
-            LazyTree::Uninit { root_tag, .. } => *root_tag == tag,
-            LazyTree::Init(tree) => tree.nodes.contains_key(&tag),
+            BorrowState::Uninit { root_tag, .. } => *root_tag == tag,
+            BorrowState::Tree(tree) => tree.nodes.contains_key(&tag),
         }
     }
     fn node_count(&self) -> usize {
         match self {
-            LazyTree::Uninit { .. } => 1,
-            LazyTree::Init(tree) => tree.nodes.len(),
+            BorrowState::Uninit { .. } => 1,
+            BorrowState::Tree(tree) => tree.nodes.len(),
         }
     }
     fn new_child(
@@ -1279,7 +1284,7 @@ impl AllocState for LazyTree {
         span: Span,
     ) -> UBResult<()> {
         self.ensure_init();
-        let LazyTree::Init(tree) = self else { unreachable!() };
+        let BorrowState::Tree(tree) = self else { unreachable!() };
         tree.new_child(
             base_offset,
             parent_tag,
@@ -1301,8 +1306,8 @@ impl AllocState for LazyTree {
         span: Span,
     ) -> UBResult<()> {
         match self {
-            LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.perform_access(
+            BorrowState::Uninit { .. } => Ok(()),
+            BorrowState::Tree(tree) => tree.perform_access(
                 tag,
                 access_range,
                 access_kind,
@@ -1322,8 +1327,8 @@ impl AllocState for LazyTree {
         span: Span,
     ) -> UBResult<()> {
         match self {
-            LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.dealloc(tag, access_range, global, alloc_id, span),
+            BorrowState::Uninit { .. } => Ok(()),
+            BorrowState::Tree(tree) => tree.dealloc(tag, access_range, global, alloc_id, span),
         }
     }
     fn perform_protector_end_access(
@@ -1334,25 +1339,25 @@ impl AllocState for LazyTree {
         span: Span,
     ) -> UBResult<()> {
         match self {
-            LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.perform_protector_end_access(tag, global, alloc_id, span),
+            BorrowState::Uninit { .. } => Ok(()),
+            BorrowState::Tree(tree) => tree.perform_protector_end_access(tag, global, alloc_id, span),
         }
     }
     fn expose_tag(&mut self, tag: BorTag, protected: bool) {
         self.ensure_init();
-        if let LazyTree::Init(tree) = self {
+        if let BorrowState::Tree(tree) = self {
             tree.expose_tag(tag, protected);
         }
     }
     fn remove_unreachable_tags(&mut self, live_tags: &FxHashSet<BorTag>) {
-        if let LazyTree::Init(tree) = self {
+        if let BorrowState::Tree(tree) = self {
             tree.remove_unreachable_tags(live_tags);
         }
     }
     fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
         match self {
-            LazyTree::Init(tree) => tree.remove_dead_tags(dead_tags),
-            LazyTree::Uninit { root_tag, refcount, .. } => {
+            BorrowState::Tree(tree) => tree.remove_dead_tags(dead_tags),
+            BorrowState::Uninit { root_tag, refcount, .. } => {
                 // A tree in the Uninit state only has a single node (the root). If
                 // this node is in the dead list with a zero reference count, then the
                 // tree is dead and the associated AllocInfo metadata can be freed.
@@ -1364,21 +1369,21 @@ impl AllocState for LazyTree {
     }
     fn increment(&self, tag: BorTag) -> bool {
         match self {
-            LazyTree::Uninit { root_tag, refcount, .. } => {
+            BorrowState::Uninit { root_tag, refcount, .. } => {
                 // In the Uninit state the only node is the root, we add an debug_assert instead
                 debug_assert!(*root_tag == tag);
                 refcount.increment_nonatomic()
             }
-            LazyTree::Init(tree) => tree.increment(tag),
+            BorrowState::Tree(tree) => tree.increment(tag),
         }
     }
     fn decrement(&self, tag: BorTag) -> bool {
         match self {
-            LazyTree::Uninit { root_tag, refcount, .. } => {
+            BorrowState::Uninit { root_tag, refcount, .. } => {
                 debug_assert!(*root_tag == tag);
                 refcount.decrement_nonatomic()
             }
-            LazyTree::Init(tree) => tree.decrement(tag),
+            BorrowState::Tree(tree) => tree.decrement(tag),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Rename `LazyTree`/`Init` to `BorrowState`/`Tree` and store it as `AllocInfo.borrow`, so allocation borrow state has a named home for one-word provenance work.
- Behavior and ABI are unchanged: provenance is still `(BorTag, AllocInfo*)`; AllocInfo remains the only Heap freelist object.
- Does **not** implement [#279](https://github.com/BorrowSanitizer/bsan/issues/279) (Heap `Uninit|Tree|Node`, one-word provenance, unused tag). That is the follow-up on top of this.

## Test plan
- [x] `cargo +bsan test -p bsan_rt --lib` (43 passed)
- [x] `./xb --skip ui --keep-sysroot` (exit 0)
- [ ] Optional: hashbrown-only bench vs ~484× baseline (expect no change)