### PR TITLE
One-word Provenance (OWP#2)

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -37,9 +37,9 @@
 using namespace llvm;
 using namespace llvm::PatternMatch;
 
-// Provenance is two words: a borrow tag and
-// a pointer to an allocation metadata object.
-static const unsigned kProvenanceSize = 16;
+// Provenance is one word: a Node* (sentinels 0/1/2 for
+// omnivalid/invalid/wildcard).
+static const unsigned kProvenanceSize = 8;
 static const Align kMinProvAlignment = Align(8);
 
 static cl::opt<bool> ClHandleAsmConservative(
@@ -127,12 +127,10 @@ namespace {
 // Memory map parameters used in application-to-shadow address calculation.
 // Offset = (Addr & ~AndMask) ^ XorMask
 // Shadow = ShadowBase + Offset
-// Origin = OriginBase + Offset
 struct MemoryMapParams {
   uint64_t AndMask;
   uint64_t XorMask;
   uint64_t ShadowBase;
-  uint64_t OriginBase;
 };
 
 } // end anonymous namespace
@@ -142,7 +140,6 @@ static const MemoryMapParams kLinuxX8664MemoryMapParams = {
     0,              // AndMask (not used)
     0x500000000000, // XorMask
     0,              // ShadowBase (not used)
-    0x100000000000, // OriginBase
 };
 
 // aarch64 Linux
@@ -150,7 +147,6 @@ static const MemoryMapParams kLinuxAArch64MemoryMapParams = {
     0,               // AndMask (not used)
     0x0B00000000000, // XorMask
     0,               // ShadowBase (not used)
-    0x0200000000000, // OriginBase
 };
 
 namespace {
@@ -207,8 +203,8 @@ public:
     unsigned PtrSize = M.getDataLayout().getPointerSize();
     IntptrTy = Type::getIntNTy(*C, PtrSize * 8);
 
-    ProvenanceTy = StructType::get(IntptrTy, PtrTy);
-    ProvenanceSize = ConstantInt::get(IntptrTy, 16);
+    ProvenanceTy = PtrTy;
+    ProvenanceSize = ConstantInt::get(IntptrTy, 8);
   }
   bool instrumentModule(Module &M);
   bool instrumentFunction(Function &F, FunctionAnalysisManager &FAM,
@@ -574,23 +570,22 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
 
   BsanFuncRetag = M.getOrInsertFunction(
       BSAN("retag"), AL, IRB.getVoidTy(), PtrTy, IntptrTy, Int8Ty, PtrTy,
-      IntptrTy, PtrTy, IntptrTy, IntptrTy, PtrTy, PtrTy, BoolTy);
+      IntptrTy, PtrTy, IntptrTy, PtrTy, PtrTy, BoolTy);
 
   BsanFuncPopFrame = M.getOrInsertFunction(
       BSAN("pop_frame"), AL, IRB.getVoidTy(), PtrTy, IntptrTy, IntptrTy);
 
   BsanFuncRead = M.getOrInsertFunction(BSAN("read"), AL, IRB.getVoidTy(), PtrTy,
-                                       IntptrTy, IntptrTy, PtrTy, BoolTy);
+                                       IntptrTy, PtrTy, BoolTy);
 
-  BsanFuncWrite =
-      M.getOrInsertFunction(BSAN("write"), AL, IRB.getVoidTy(), PtrTy, IntptrTy,
-                            IntptrTy, PtrTy, BoolTy);
+  BsanFuncWrite = M.getOrInsertFunction(BSAN("write"), AL, IRB.getVoidTy(),
+                                        PtrTy, IntptrTy, PtrTy, BoolTy);
 
   BsanFuncAllocStack =
       M.getOrInsertFunction(BSAN("alloc_stack"), AL, IRB.getVoidTy(), PtrTy,
                             IntptrTy, IntptrTy, PtrTy);
-  BsanFuncDeallocStack = M.getOrInsertFunction(
-      BSAN("dealloc_stack"), AL, IRB.getVoidTy(), PtrTy, IntptrTy, PtrTy);
+  BsanFuncDeallocStack = M.getOrInsertFunction(BSAN("dealloc_stack"), AL,
+                                               IRB.getVoidTy(), PtrTy, PtrTy);
 
   BsanFuncMark = M.getOrInsertFunction(BSAN("mark"), AL, PtrTy, PtrTy);
 
@@ -600,11 +595,11 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   BsanFuncValidateRetval = M.getOrInsertFunction(
       BSAN("validate_retval"), AL, IRB.getVoidTy(), PtrTy, PtrTy, IntptrTy);
 
-  BsanFuncRcInc = M.getOrInsertFunction(BSAN("rc_inc"), AL, IRB.getVoidTy(),
-                                        IntptrTy, PtrTy);
+  BsanFuncRcInc =
+      M.getOrInsertFunction(BSAN("rc_inc"), AL, IRB.getVoidTy(), PtrTy);
 
-  BsanFuncRcDec = M.getOrInsertFunction(BSAN("rc_dec"), AL, IRB.getVoidTy(),
-                                        IntptrTy, PtrTy);
+  BsanFuncRcDec =
+      M.getOrInsertFunction(BSAN("rc_dec"), AL, IRB.getVoidTy(), PtrTy);
 
   BsanFuncMemCpy = M.getOrInsertFunction(BSAN("memcpy"), AL, IRB.getVoidTy(),
                                          PtrTy, PtrTy, IntptrTy);
@@ -625,8 +620,8 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   BsanFuncDestroyStackSlot = M.getOrInsertFunction(BSAN("destroy_stack_slot"),
                                                    AL, IRB.getVoidTy(), PtrTy);
 
-  BsanFuncExposeProv = M.getOrInsertFunction(BSAN("expose_prov"), AL,
-                                             IRB.getVoidTy(), IntptrTy, PtrTy);
+  BsanFuncExposeProv =
+      M.getOrInsertFunction(BSAN("expose_prov"), AL, IRB.getVoidTy(), PtrTy);
 
   EHPersonality Pers = getDefaultEHPersonality(TargetTriple);
   DefaultPersonalityFn =
@@ -648,22 +643,19 @@ void BorrowSanitizer::createUserspaceApi(Module &M,
 
 namespace {
 
-// A pointer's provenance value.
+// A pointer's provenance value: a single Node* IR value.
 //
-// Each pointer has provenance, indicating its permission to access
-// a memory location.
+// Sentinels (inttoptr of 0/1/2): omnivalid / invalid / wildcard.
+// Concrete values are real Node* pointers; tag lives on the Node.
 class Provenance {
 public:
-  Value *Tag = nullptr;
-  Value *Info = nullptr;
+  Value *Node = nullptr;
   ElementCount Elems = ElementCount::getFixed(1);
   Provenance() {}
-  Provenance(Value *Tag, Value *Info) : Tag(Tag), Info(Info) {}
-  Provenance(Value *Tag, Value *Info, ElementCount Elems)
-      : Tag(Tag), Info(Info), Elems(Elems) {}
+  Provenance(Value *Node) : Node(Node) {}
+  Provenance(Value *Node, ElementCount Elems) : Node(Node), Elems(Elems) {}
   bool operator==(const Provenance &Other) const {
-    return this->Tag == Other.Tag && this->Info == Other.Info &&
-           this->Elems == Other.Elems;
+    return this->Node == Other.Node && this->Elems == Other.Elems;
   }
   bool operator!=(const Provenance &Other) const { return !(*this == Other); }
 
@@ -672,6 +664,8 @@ public:
                               ElementCount Elems = ElementCount::getFixed(1));
   static Provenance wildcard(BorrowSanitizer &BS,
                              ElementCount Elems = ElementCount::getFixed(1));
+  static Provenance invalid(BorrowSanitizer &BS,
+                            ElementCount Elems = ElementCount::getFixed(1));
 };
 
 struct ProvenanceKey {
@@ -724,30 +718,30 @@ public:
 
 void Provenance::addIncoming(BasicBlock *IncomingBlock,
                              Provenance &IncomingProv) {
-  assert(isa<PHINode>(this->Tag));
-  PHINode *TagNode = cast<PHINode>(this->Tag);
-
-  assert(isa<PHINode>(this->Info));
-  PHINode *InfoNode = cast<PHINode>(this->Info);
-
-  TagNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Tag);
-  InfoNode->setIncomingValueForBlock(IncomingBlock, IncomingProv.Info);
+  assert(isa<PHINode>(this->Node));
+  PHINode *NodePhi = cast<PHINode>(this->Node);
+  NodePhi->setIncomingValueForBlock(IncomingBlock, IncomingProv.Node);
 }
 
 Provenance Provenance::omnivalid(BorrowSanitizer &BS, ElementCount Elems) {
   if (Elems.isScalar()) {
-    Value *Zero = ConstantInt::get(BS.IntptrTy, 0);
-    Value *InvalidPtr = ConstantPointerNull::get(BS.PtrTy);
-    return Provenance(Zero, InvalidPtr, Elems);
+    return Provenance(ConstantPointerNull::get(BS.PtrTy), Elems);
+  }
+  report_fatal_error("Vector provenance is not supported yet");
+}
+
+Provenance Provenance::invalid(BorrowSanitizer &BS, ElementCount Elems) {
+  if (Elems.isScalar()) {
+    Constant *One = ConstantInt::get(BS.IntptrTy, 1);
+    return Provenance(ConstantExpr::getIntToPtr(One, BS.PtrTy), Elems);
   }
   report_fatal_error("Vector provenance is not supported yet");
 }
 
 Provenance Provenance::wildcard(BorrowSanitizer &BS, ElementCount Elems) {
   if (Elems.isScalar()) {
-    Value *Two = ConstantInt::get(BS.IntptrTy, 2);
-    Value *InvalidPtr = ConstantPointerNull::get(BS.PtrTy);
-    return Provenance(Two, InvalidPtr, Elems);
+    Constant *Two = ConstantInt::get(BS.IntptrTy, 2);
+    return Provenance(ConstantExpr::getIntToPtr(Two, BS.PtrTy), Elems);
   }
   report_fatal_error("Vector provenance is not supported yet");
 }
@@ -1278,11 +1272,11 @@ private:
   ///
   ///     Offset = (Addr & ~AndMask) ^ XorMask
   ///
-  /// getShadowOriginPtr turns this into the shadow and origin pointers by
-  /// adding ShadowBase and OriginBase respectively. When `Alignment` cannot be
-  /// shown to be at least kMinProvAlignment, the offset is additionally rounded
-  /// down to a provenance-slot (kMinProvAlignment) boundary, so sub-slot
-  /// addresses map to the slot that holds their provenance.
+  /// getShadowPtr turns this into the shadow Node* slot by adding ShadowBase.
+  /// When `Alignment` cannot be shown to be at least kMinProvAlignment, the
+  /// offset is additionally rounded down to a provenance-slot
+  /// (kMinProvAlignment) boundary, so sub-slot addresses map to the slot that
+  /// holds their provenance.
   Value *getShadowPtrOffset(Value *Addr, IRBuilder<> &IRB,
                             MaybeAlign Alignment) {
     Type *IntptrTy = ptrToIntPtrType(Addr->getType());
@@ -1302,9 +1296,9 @@ private:
     return OffsetLong;
   }
 
-  std::pair<Value *, Value *>
-  getShadowOriginPtr(IRBuilder<> &IRB, Value *Addr,
-                     MaybeAlign Alignment = kMinProvAlignment) {
+  // Shadow stores a single Node* provenance word.
+  Value *getShadowPtr(IRBuilder<> &IRB, Value *Addr,
+                      MaybeAlign Alignment = kMinProvAlignment) {
     VectorType *VectTy = dyn_cast<VectorType>(Addr->getType());
     if (!VectTy) {
       assert(Addr->getType()->isPointerTy());
@@ -1318,18 +1312,8 @@ private:
       ShadowLong =
           IRB.CreateAdd(ShadowLong, constToIntPtr(IntptrTy, ShadowBase));
     }
-    Value *ShadowPtr = IRB.CreateIntToPtr(
-        ShadowLong, getPtrToShadowPtrType(IntptrTy, BS.IntptrTy));
-
-    Value *OriginLong = ShadowOffset;
-    uint64_t OriginBase = BS.MapParams->OriginBase;
-    if (OriginBase != 0)
-      OriginLong =
-          IRB.CreateAdd(OriginLong, constToIntPtr(IntptrTy, OriginBase));
-    Value *OriginPtr = IRB.CreateIntToPtr(
-        OriginLong, getPtrToShadowPtrType(IntptrTy, BS.PtrTy));
-
-    return std::make_pair(ShadowPtr, OriginPtr);
+    return IRB.CreateIntToPtr(ShadowLong,
+                              getPtrToShadowPtrType(IntptrTy, BS.PtrTy));
   }
 
   Provenance loadProvenanceFromShadow(
@@ -1337,10 +1321,8 @@ private:
       ElementCount Elems = ElementCount::getFixed(1),
       AtomicOrdering Ordering = AtomicOrdering::NotAtomic) {
     if (Elems.isScalar()) {
-      Value *TagPtr, *InfoPtr;
-      std::tie(TagPtr, InfoPtr) = getShadowOriginPtr(IRB, Base, Alignment);
-      Provenance Prov =
-          loadProvenanceAlignedPairwise(IRB, TagPtr, InfoPtr, Ordering);
+      Value *ShadowPtr = getShadowPtr(IRB, Base, Alignment);
+      Provenance Prov = loadProvenanceAligned(IRB, ShadowPtr, Ordering);
       Value *Slot = allocStackSlot(IRB, false);
       storeProvenance(IRB, Prov, Slot);
       return Prov;
@@ -1351,13 +1333,7 @@ private:
   Provenance loadProvenance(IRBuilder<> &IRB, Value *Src,
                             ElementCount Elems = ElementCount::getFixed(1)) {
     if (Elems.isScalar()) {
-      Value *ZeroIdx = ConstantInt::get(IRB.getInt64Ty(), 0);
-      Value *TagPtr = Src;
-      Value *InfoPtr =
-          IRB.CreateGEP(BS.ProvenanceTy, Src,
-                        {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 1)});
-      return loadProvenanceAlignedPairwise(IRB, TagPtr, InfoPtr,
-                                           AtomicOrdering::NotAtomic);
+      return loadProvenanceAligned(IRB, Src, AtomicOrdering::NotAtomic);
     }
     report_fatal_error("Vector provenance is not supported yet");
   }
@@ -1412,6 +1388,10 @@ private:
     if (Provenance *Prov = BaseProvMap.find(Key)) {
       return *Prov;
     }
+    // Null pointer constants carry invalid provenance.
+    if (isa<ConstantPointerNull>(Key.V)) {
+      return Provenance::invalid(BS);
+    }
     if (Argument *Arg = dyn_cast<Argument>(Key.V)) {
       // We always need to load the provenance for arguments right at the
       // beginning of the function. Otherwise, subsequent function calls could
@@ -1447,12 +1427,7 @@ private:
     if (Prov.Elems.isVector()) {
       report_fatal_error("Vector provenance is not supported yet");
     }
-    Value *ZeroIdx = ConstantInt::get(IRB.getInt64Ty(), 0);
-    Value *TagPtr = Base;
-    Value *InfoPtr =
-        IRB.CreateGEP(BS.ProvenanceTy, Base,
-                      {ZeroIdx, ConstantInt::get(IRB.getInt32Ty(), 1)});
-    storeProvenanceAlignedPairwise(IRB, TagPtr, InfoPtr, Prov, Ordering);
+    storeProvenanceAligned(IRB, Base, Prov, Ordering);
   }
 
   // Stores a provenance value into shadow memory, starting at the given object
@@ -1466,50 +1441,42 @@ private:
     if (Prov.Elems.isVector()) {
       report_fatal_error("Vectors are not supported.");
     } else {
-      Value *TagPtr, *InfoPtr;
-      std::tie(TagPtr, InfoPtr) = getShadowOriginPtr(IRB, ObjAddr, Alignment);
-      storeProvenanceWithReferenceCount(IRB, TagPtr, InfoPtr, Prov, Ordering);
+      Value *ShadowPtr = getShadowPtr(IRB, ObjAddr, Alignment);
+      storeProvenanceWithReferenceCount(IRB, ShadowPtr, Prov, Ordering);
     }
   }
 
-  // Loads a provenance value into shadow memory pairwise at the specified
-  // addresses. Each address must be aligned to the wordsize.
-  Provenance loadProvenanceAlignedPairwise(IRBuilder<> &IRB, Value *TagPtr,
-                                           Value *InfoPtr,
-                                           AtomicOrdering Ordering) {
-    LoadInst *Tag =
-        IRB.CreateAlignedLoad(BS.IntptrTy, TagPtr, kMinProvAlignment);
-    Tag->setAtomic(Ordering);
-    LoadInst *Info =
-        IRB.CreateAlignedLoad(BS.PtrTy, InfoPtr, kMinProvAlignment);
-    Info->setAtomic(Ordering);
-    return Provenance(Tag, Info);
+  // Loads a single Node* provenance word.
+  Provenance loadProvenanceAligned(IRBuilder<> &IRB, Value *SlotPtr,
+                                   AtomicOrdering Ordering) {
+    LoadInst *Node =
+        IRB.CreateAlignedLoad(BS.PtrTy, SlotPtr, kMinProvAlignment);
+    Node->setAtomic(Ordering);
+    return Provenance(Node);
   }
 
-  void storeProvenanceWithReferenceCount(IRBuilder<> &IRB, Value *TagPtr,
-                                         Value *InfoPtr, Provenance Prov,
+  // One-word shadow store with per-Node* RC. CRT no-ops sentinel pointers.
+  // Stack-slot stores use `storeProvenance` instead (GC roots, no RC).
+  void storeProvenanceWithReferenceCount(IRBuilder<> &IRB, Value *SlotPtr,
+                                         Provenance Prov,
                                          AtomicOrdering Ordering) {
+    // Increment first in case source and destination are the same Node*:
+    // decrementing first can hit zero and let GC reclaim before we store.
+    if (Prov != Provenance::omnivalid(BS)) {
+      IRB.CreateCall(BS.BsanFuncRcInc, {Prov.Node});
+    }
     // We only decrement on nonatomic loads. This leaks provenance exposed to
     // atomic operations, which is necessary to support them without locking.
     if (Ordering == AtomicOrdering::NotAtomic) {
-      Provenance Old =
-          loadProvenanceAlignedPairwise(IRB, TagPtr, InfoPtr, Ordering);
-      IRB.CreateCall(BS.BsanFuncRcDec, {Old.Tag, Old.Info});
+      Provenance Old = loadProvenanceAligned(IRB, SlotPtr, Ordering);
+      IRB.CreateCall(BS.BsanFuncRcDec, {Old.Node});
     }
-    if (Prov != Provenance::omnivalid(BS)) {
-      IRB.CreateCall(BS.BsanFuncRcInc, {Prov.Tag, Prov.Info});
-    }
-    storeProvenanceAlignedPairwise(IRB, TagPtr, InfoPtr, Prov, Ordering);
+    storeProvenanceAligned(IRB, SlotPtr, Prov, Ordering);
   }
 
-  // Stores a provenance value into shadow memory pairwise at the specified
-  // addresses. Each address must be aligned to the word size.
-  void storeProvenanceAlignedPairwise(IRBuilder<> &IRB, Value *TagPtr,
-                                      Value *InfoPtr, Provenance Prov,
-                                      AtomicOrdering Ordering) {
-    IRB.CreateAlignedStore(Prov.Tag, TagPtr, kMinProvAlignment)
-        ->setAtomic(Ordering);
-    IRB.CreateAlignedStore(Prov.Info, InfoPtr, kMinProvAlignment)
+  void storeProvenanceAligned(IRBuilder<> &IRB, Value *SlotPtr, Provenance Prov,
+                              AtomicOrdering Ordering) {
+    IRB.CreateAlignedStore(Prov.Node, SlotPtr, kMinProvAlignment)
         ->setAtomic(Ordering);
   }
 
@@ -1704,10 +1671,9 @@ private:
     Value *ImArrayLen = getLayoutArrayLength(RI.ImArray);
     Value *PinArrayLen = getLayoutArrayLength(RI.PinArray);
     Value *Slot = allocStackSlot(IRB, RI.isProtected());
-    IRB.CreateCall(BS.BsanFuncRetag,
-                   {SrcAddr, RI.Size, RI.Perms, RI.ImArray, ImArrayLen,
-                    RI.PinArray, PinArrayLen, SrcProv.Tag, SrcProv.Info, Slot,
-                    IRB.getInt1(false)});
+    IRB.CreateCall(BS.BsanFuncRetag, {SrcAddr, RI.Size, RI.Perms, RI.ImArray,
+                                      ImArrayLen, RI.PinArray, PinArrayLen,
+                                      SrcProv.Node, Slot, IRB.getInt1(false)});
     Provenance RetaggedProv = loadProvenance(IRB, Slot);
     storeProvenanceToShadow(IRB, Operand, RetaggedProv);
   }
@@ -1720,10 +1686,9 @@ private:
       Value *ImArrayLen = getLayoutArrayLength(RI.ImArray);
       Value *PinArrayLen = getLayoutArrayLength(RI.PinArray);
       Value *Dest = allocStackSlot(IRB, RI.isProtected());
-      IRB.CreateCall(BS.BsanFuncRetag,
-                     {Ptr, RI.Size, RI.Perms, RI.ImArray, ImArrayLen,
-                      RI.PinArray, PinArrayLen, Prov->Tag, Prov->Info, Dest,
-                      IRB.getInt1(false)});
+      IRB.CreateCall(BS.BsanFuncRetag, {Ptr, RI.Size, RI.Perms, RI.ImArray,
+                                        ImArrayLen, RI.PinArray, PinArrayLen,
+                                        Prov->Node, Dest, IRB.getInt1(false)});
       setProvenance(&CB, loadProvenance(IRB, Dest));
     }
   }
@@ -2011,17 +1976,14 @@ private:
   Provenance createScalarProvenancePHI(IRBuilder<> &IRB,
                                        iterator_range<pred_iterator> Blocks) {
     unsigned NumIncoming = std::distance(Blocks.begin(), Blocks.end());
-    PHINode *TagNode = IRB.CreatePHI(BS.IntptrTy, NumIncoming, "_bsphi_tag");
-    TagNode->dropDbgRecords();
-    PHINode *InfoNode = IRB.CreatePHI(BS.PtrTy, NumIncoming, "_bsphi_info");
-    InfoNode->dropDbgRecords();
+    PHINode *NodePhi = IRB.CreatePHI(BS.PtrTy, NumIncoming, "_bsphi_node");
+    NodePhi->dropDbgRecords();
 
     Provenance Omni = Provenance::omnivalid(BS);
     for (BasicBlock *BB : Blocks) {
-      TagNode->addIncoming(Omni.Tag, BB);
-      InfoNode->addIncoming(Omni.Info, BB);
+      NodePhi->addIncoming(Omni.Node, BB);
     }
-    return Provenance(TagNode, InfoNode);
+    return Provenance(NodePhi);
   }
 
   Provenance createProvenancePHI(IRBuilder<> &IRB, ProvenanceField Comp,
@@ -2057,9 +2019,8 @@ private:
   }
 
   Provenance createAllocaMetadata(IRBuilder<> &IRB) {
-    Value *Tag = newBorrowTag(IRB);
-    Value *Info = IRB.CreateCall(BS.BsanFuncReserveStackSlot, {});
-    return Provenance(Tag, Info);
+    Value *Node = IRB.CreateCall(BS.BsanFuncReserveStackSlot, {});
+    return Provenance(Node);
   }
 
   void initAllocaMetadata(IRBuilder<> &IRB, AllocaInst *AI, Provenance Prov) {
@@ -2069,15 +2030,15 @@ private:
 
   void initAllocaMetadata(IRBuilder<> &IRB, Value *Addr, Value *Size,
                           Provenance Prov) {
-    IRB.CreateCall(BS.BsanFuncAllocStack, {Addr, Size, Prov.Tag, Prov.Info});
+    Value *Tag = newBorrowTag(IRB);
+    IRB.CreateCall(BS.BsanFuncAllocStack, {Addr, Size, Tag, Prov.Node});
   }
 
   void instrumentLifetimeStart(IntrinsicInst &II) {
     if (auto *AI = findAllocaForValue(II.getArgOperand(0), true)) {
       if (auto Prov = getProvenance(II.getParent(), AI)) {
         IRBuilder<> IRB(&II);
-        IRB.CreateCall(BS.BsanFuncDeallocStack,
-                       {AI, (*Prov).Tag, (*Prov).Info});
+        IRB.CreateCall(BS.BsanFuncDeallocStack, {AI, (*Prov).Node});
         initAllocaMetadata(IRB, AI, *Prov);
       }
     }
@@ -2087,8 +2048,7 @@ private:
     if (auto *AI = findAllocaForValue(II.getArgOperand(0), true)) {
       if (auto Prov = getProvenance(II.getParent(), AI)) {
         IRBuilder<> IRB(&II);
-        IRB.CreateCall(BS.BsanFuncDeallocStack,
-                       {AI, (*Prov).Tag, (*Prov).Info});
+        IRB.CreateCall(BS.BsanFuncDeallocStack, {AI, (*Prov).Node});
       }
     }
   }
@@ -2125,15 +2085,15 @@ private:
       // SafeStack-safe allocas are never instrumented, so any access that
       // reaches here needs the full borrow-tracking check (`checked = false`).
       // The runtime retains the unchecked fast path for future use.
-      IRB.CreateCall(BS.BsanFuncRead, {Ptr, Size, (*Prov).Tag, (*Prov).Info,
-                                       IRB.getInt1(false)});
+      IRB.CreateCall(BS.BsanFuncRead,
+                     {Ptr, Size, (*Prov).Node, IRB.getInt1(false)});
     }
   }
 
   void insertWriteCheck(IRBuilder<> &IRB, Value *Ptr, Value *Size) {
     if (auto Prov = getProvenance(IRB.GetInsertBlock(), Ptr)) {
-      IRB.CreateCall(BS.BsanFuncWrite, {Ptr, Size, (*Prov).Tag, (*Prov).Info,
-                                        IRB.getInt1(false)});
+      IRB.CreateCall(BS.BsanFuncWrite,
+                     {Ptr, Size, (*Prov).Node, IRB.getInt1(false)});
     }
   }
 
@@ -2260,8 +2220,7 @@ private:
     const uint64_t SlotSize = kMinProvAlignment.value();
     uint64_t AlignedBytes = alignTo(Bytes, SlotSize);
 
-    Value *TagPtr, *InfoPtr;
-    std::tie(TagPtr, InfoPtr) = getShadowOriginPtr(IRB, Base, Alignment);
+    Value *ShadowPtr = getShadowPtr(IRB, Base, Alignment);
 
     const uint64_t MaxInlineSlots = 8;
     uint64_t NumSlots = AlignedBytes / SlotSize;
@@ -2269,9 +2228,8 @@ private:
     if (NumSlots <= MaxInlineSlots) {
       for (uint64_t I = 0; I < NumSlots; ++I) {
         Value *Idx = ConstantInt::get(BS.IntptrTy, I * SlotSize);
-        Value *SlotTagPtr = ptradd(IRB, TagPtr, Idx);
-        Value *SlotInfoPtr = ptradd(IRB, InfoPtr, Idx);
-        storeProvenanceWithReferenceCount(IRB, SlotTagPtr, SlotInfoPtr,
+        Value *SlotPtr = ptradd(IRB, ShadowPtr, Idx);
+        storeProvenanceWithReferenceCount(IRB, SlotPtr,
                                           Provenance::omnivalid(BS), Ordering);
       }
     } else {
@@ -2290,7 +2248,7 @@ private:
   void visitPtrToIntInst(PtrToIntInst &I) {
     if (auto Prov = getProvenance(I.getParent(), I.getPointerOperand())) {
       IRBuilder<> IRB(&I);
-      IRB.CreateCall(BS.BsanFuncExposeProv, {(*Prov).Tag, (*Prov).Info});
+      IRB.CreateCall(BS.BsanFuncExposeProv, {(*Prov).Node});
     }
   }
 
@@ -2402,15 +2360,13 @@ private:
         Provenance ProvR =
             assertProvenanceScalar(BB, {SI.getFalseValue(), Idx});
 
-        Value *Tag, *Info;
+        Value *Node;
         if (ProvL != ProvR) {
-          Tag = IRB.CreateSelect(SI.getCondition(), ProvL.Tag, ProvR.Tag);
-          Info = IRB.CreateSelect(SI.getCondition(), ProvL.Info, ProvR.Info);
+          Node = IRB.CreateSelect(SI.getCondition(), ProvL.Node, ProvR.Node);
         } else {
-          Tag = ProvL.Tag;
-          Info = ProvL.Info;
+          Node = ProvL.Node;
         }
-        setProvenance({&SI, Idx}, Provenance(Tag, Info));
+        setProvenance({&SI, Idx}, Provenance(Node));
       }
     }
   }

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -335,22 +335,24 @@ void __bsan_free_buffer(char *buf, uptr size) {
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_retag_impl(void *object_addr, uptr access_size, u8 flags,
                        const uptr im_data[2], uptr im_len,
-                       const uptr pin_data[2], uptr pin_len, BorTag bor_tag,
-                       AllocInfo *alloc_info, void *dest, Span pc,
-                       bool checked);
+                       const uptr pin_data[2], uptr pin_len, Node *node,
+                       void *dest, Span pc, bool checked);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_retag(void *object_addr, uptr access_size, u8 flags,
                   const uptr im_data[2], uptr im_len, const uptr pin_data[2],
-                  uptr pin_len, BorTag bor_tag, AllocInfo *alloc_info,
-                  void *dest, bool checked) {
+                  uptr pin_len, Node *node, void *dest, bool checked) {
+  const bool known = ProvIsKnown(node);
+  if (!bsan_inited || bsan_init_running || !known) {
+    *(Provenance *)(dest) = known ? node : OMNIVALID;
+    return;
+  }
   if (__bsan_retag_impl) {
     GET_SPAN;
     InterceptorBarrier Barrier;
     Provenance prov;
     __bsan_retag_impl(object_addr, access_size, flags, im_data, im_len,
-                      pin_data, pin_len, bor_tag, alloc_info, &prov, span,
-                      checked);
+                      pin_data, pin_len, node, &prov, span, checked);
     HANDLE_ERROR;
     *(Provenance *)(dest) = prov;
     // A retag mints a fresh provenance value with no references yet; record it
@@ -361,55 +363,68 @@ void __bsan_retag(void *object_addr, uptr access_size, u8 flags,
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_read_impl(void *ptr, uptr access_size, BorTag bor_tag,
-                      AllocInfo *alloc_info, Span pc, bool checked);
+void __bsan_read_impl(void *ptr, uptr access_size, Node *node, Span pc,
+                      bool checked);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_read(void *ptr, uptr access_size, BorTag bor_tag,
-                 AllocInfo *alloc_info, bool checked) {
+void __bsan_read(void *ptr, uptr access_size, Node *node, bool checked) {
+  // Skip before init, and skip unaligned shadow noise (not a sentinel / Node*).
+  if (!bsan_inited || bsan_init_running || !ProvIsKnown(node)) {
+    return;
+  }
   if (__bsan_read_impl) {
     GET_SPAN;
     InterceptorBarrier Barrier;
-    __bsan_read_impl(ptr, access_size, bor_tag, alloc_info, span, checked);
+    __bsan_read_impl(ptr, access_size, node, span, checked);
     HANDLE_ERROR;
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_write_impl(void *ptr, uptr access_size, BorTag bor_tag,
-                       AllocInfo *alloc_info, Span pc, bool checked);
+void __bsan_write_impl(void *ptr, uptr access_size, Node *node, Span pc,
+                       bool checked);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_write(void *ptr, uptr access_size, BorTag bor_tag,
-                  AllocInfo *alloc_info, bool checked) {
+void __bsan_write(void *ptr, uptr access_size, Node *node, bool checked) {
+  if (!bsan_inited || bsan_init_running || !ProvIsKnown(node)) {
+    return;
+  }
   if (__bsan_write_impl) {
     GET_SPAN;
     InterceptorBarrier Barrier;
-    __bsan_write_impl(ptr, access_size, bor_tag, alloc_info, span, checked);
+    __bsan_write_impl(ptr, access_size, node, span, checked);
     HANDLE_ERROR;
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-bool __bsan_rc_inc_impl(BorTag Tag, AllocInfo *Info);
+bool __bsan_rc_inc_impl(Node *node);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_rc_inc(BorTag Tag, AllocInfo *Info) {
+void __bsan_rc_inc(Node *node) {
+  // Shadow can be touched while copying libc structs during very early
+  // init (before `bsan_inited`). Skip RC until the runtime is ready.
+  if (!bsan_inited || bsan_init_running || !ProvIsConcrete(node)) {
+    return;
+  }
   if (__bsan_rc_inc_impl) {
     InterceptorBarrier Barrier;
-    __bsan_rc_inc_impl(Tag, Info);
+    __bsan_rc_inc_impl(node);
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-bool __bsan_rc_dec_impl(BorTag Tag, AllocInfo *Info);
+bool __bsan_rc_dec_impl(Node *node);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_rc_dec(BorTag Tag, AllocInfo *Info) {
+void __bsan_rc_dec(Node *node) {
+  if (!bsan_inited || bsan_init_running || !ProvIsConcrete(node)) {
+    return;
+  }
   if (__bsan_rc_dec_impl) {
     InterceptorBarrier Barrier;
-    if (__bsan_rc_dec_impl(Tag, Info)) {
-      CurrentThread()->AcquireProvenance({Tag, Info});
+    if (__bsan_rc_dec_impl(node)) {
+      CurrentThread()->AcquireProvenance(node);
     }
   }
 }
@@ -418,10 +433,10 @@ SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_shadow_clear(void *dest, uptr size) { ClearShadow(dest, size); }
 
 SANITIZER_WEAK_ATTRIBUTE
-AllocInfo *__bsan_reserve_stack_slot_impl();
+Node *__bsan_reserve_stack_slot_impl();
 
 SANITIZER_INTERFACE_ATTRIBUTE
-AllocInfo *__bsan_reserve_stack_slot() {
+Node *__bsan_reserve_stack_slot() {
   if (__bsan_reserve_stack_slot_impl) {
     InterceptorBarrier Barrier;
     return __bsan_reserve_stack_slot_impl();
@@ -430,10 +445,10 @@ AllocInfo *__bsan_reserve_stack_slot() {
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_destroy_stack_slot_impl(AllocInfo *slot);
+void __bsan_destroy_stack_slot_impl(Node *slot);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_destroy_stack_slot(AllocInfo *slot) {
+void __bsan_destroy_stack_slot(Node *slot) {
   if (__bsan_destroy_stack_slot_impl) {
     InterceptorBarrier Barrier;
     __bsan_destroy_stack_slot_impl(slot);
@@ -441,66 +456,77 @@ void __bsan_destroy_stack_slot(AllocInfo *slot) {
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-AllocInfo *__bsan_alloc_impl(void *base_addr, uptr size, BorTag bor_tag,
-                             Span pc);
+BorTag __bsan_node_tag_impl(Node *node);
+
+// Prefer the Rust RT when linked. CRT-only builds fall back to reading the
+// first word of Node (BorTag), which #[repr(C)] guarantees.
+SANITIZER_INTERFACE_ATTRIBUTE
+BorTag __bsan_node_tag(Node *node) {
+  if (__bsan_node_tag_impl) {
+    return __bsan_node_tag_impl(node);
+  }
+  return *reinterpret_cast<BorTag *>(node);
+}
+
+SANITIZER_WEAK_ATTRIBUTE
+Node *__bsan_alloc_impl(void *base_addr, uptr size, BorTag bor_tag, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-AllocInfo *__bsan_alloc(void *base_addr, uptr size, BorTag bor_tag, Span pc) {
+Node *__bsan_alloc(void *base_addr, uptr size, BorTag bor_tag, Span pc) {
   if (__bsan_alloc_impl) {
     InterceptorBarrier Barrier;
-    AllocInfo *info = __bsan_alloc_impl(base_addr, size, bor_tag, pc);
-    CurrentThread()->AcquireProvenance({bor_tag, info});
-    return info;
+    Node *node = __bsan_alloc_impl(base_addr, size, bor_tag, pc);
+    CurrentThread()->AcquireProvenance(node);
+    return node;
   } else {
     return nullptr;
   }
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void
-__bsan_dealloc(void *ptr, BorTag bor_tag, AllocInfo *alloc_info, Span pc,
-               bool checked) {}
+__bsan_dealloc(void *ptr, Node *node, Span pc, bool checked) {}
 
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_alloc_stack_impl(void *base_addr, uptr size, BorTag bor_tag,
-                             AllocInfo *alloc_info, Span pc);
+                             Node *node, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_alloc_stack(void *base_addr, uptr size, BorTag bor_tag,
-                        AllocInfo *alloc_info) {
+                        Node *node) {
   if (__bsan_alloc_stack_impl) {
     GET_SPAN;
     InterceptorBarrier Barrier;
-    __bsan_alloc_stack_impl(base_addr, size, bor_tag, alloc_info, span);
+    __bsan_alloc_stack_impl(base_addr, size, bor_tag, node, span);
     HANDLE_ERROR;
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_dealloc_stack_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc);
+void __bsan_dealloc_stack_impl(Node *node, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_dealloc_stack(void *ptr, BorTag bor_tag, AllocInfo *alloc_info) {
+void __bsan_dealloc_stack(void *ptr, Node *node) {
   if (__bsan_dealloc_stack_impl) {
     GET_SPAN;
     InterceptorBarrier Barrier;
-    __bsan_dealloc_stack_impl(bor_tag, alloc_info, span);
+    __bsan_dealloc_stack_impl(node, span);
     HANDLE_ERROR;
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_expose_prov_impl(BorTag bor_tag, AllocInfo *alloc_info);
+void __bsan_expose_prov_impl(Node *node);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_expose_prov(BorTag bor_tag, AllocInfo *alloc_info) {
+void __bsan_expose_prov(Node *node) {
   if (__bsan_expose_prov_impl) {
     InterceptorBarrier Barrier;
-    __bsan_expose_prov_impl(bor_tag, alloc_info);
+    __bsan_expose_prov_impl(node);
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_protector_end_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc);
+void __bsan_protector_end_impl(Node *node, Span pc);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_pop_frame(const Provenance *frame_start, uptr prot,
@@ -512,58 +538,56 @@ void __bsan_pop_frame(const Provenance *frame_start, uptr prot,
     for (uptr i = 0; i < prot + alloca_vec_size; i++) {
       const Provenance prov = frame_start[i];
       if (i < prot) {
-        __bsan_protector_end_impl(prov.tag, prov.info, span);
+        __bsan_protector_end_impl(prov, span);
       } else {
-        __bsan_dealloc_stack_impl(prov.tag, prov.info, span);
-        __bsan_destroy_stack_slot_impl(prov.info);
+        __bsan_dealloc_stack_impl(prov, span);
+        __bsan_destroy_stack_slot_impl(prov);
       }
     }
   }
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_print(BorTag bor_tag, AllocInfo *alloc_info) {}
+void __bsan_print(Node *node) {}
 
 SANITIZER_INTERFACE_ATTRIBUTE void __bsan_debug_print(void *ptr) {
   Provenance *slot = GetParamSlot(0);
   InterceptorBarrier barrier;
-  __bsan_print(slot->tag, slot->info);
+  __bsan_print(*slot);
 }
 
-SANITIZER_WEAK_ATTRIBUTE
-void __bsan_print_borrow_state(BorTag bor_tag, AllocInfo *alloc_info) {}
+SANITIZER_WEAK_ATTRIBUTE void __bsan_print_borrow_state(Node *node) {}
 
 void __bsan_debug_print_borrow_state(void *ptr) {
   Provenance *slot = GetParamSlot(0);
   InterceptorBarrier barrier;
-  __bsan_print_borrow_state(slot->tag, slot->info);
+  __bsan_print_borrow_state(*slot);
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_tree_size(BorTag bor_tag, AllocInfo *alloc_info) {}
+void __bsan_tree_size(Node *node) {}
 
 void __bsan_debug_tree_size(void *ptr) {
   Provenance *slot = GetParamSlot(0);
   InterceptorBarrier barrier;
-  __bsan_tree_size(slot->tag, slot->info);
+  __bsan_tree_size(*slot);
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_snapshot(BorTag bor_tag, AllocInfo *alloc_info) {}
+void __bsan_snapshot(Node *node) {}
 
 void __bsan_debug_snapshot(void *ptr) {
   Provenance *slot = GetParamSlot(0);
   InterceptorBarrier barrier;
-  __bsan_snapshot(slot->tag, slot->info);
+  __bsan_snapshot(*slot);
 }
 
-SANITIZER_WEAK_ATTRIBUTE void __bsan_print_diff(BorTag bor_tag,
-                                                AllocInfo *alloc_info) {}
+SANITIZER_WEAK_ATTRIBUTE void __bsan_print_diff(Node *node) {}
 
 void __bsan_debug_print_diff(void *ptr) {
   Provenance *slot = GetParamSlot(0);
   InterceptorBarrier barrier;
-  __bsan_print_diff(slot->tag, slot->info);
+  __bsan_print_diff(*slot);
 }
 
 // Asks the global state to run the garbage collector. Any thread may call this;

--- a/bsan-rt/llvm-wrapper/bsan.h
+++ b/bsan-rt/llvm-wrapper/bsan.h
@@ -34,21 +34,42 @@ using __sanitizer::Vector;
 typedef uptr Span;
 typedef uptr BorTag;
 
-struct AllocInfo;
+struct Node;
 
-struct Provenance {
-  BorTag tag;
-  AllocInfo *info;
-};
+// One-word provenance: a single Node*.
+//
+// Sentinel scheme (do not dereference these addresses):
+//   nullptr / (Node*)0  = empty / omnivalid
+//   (Node*)1            = invalid
+//   (Node*)2            = wildcard
+// Concrete values are real Node* (child or root). Tag lives on Node;
+// ZCT / prune read it via __bsan_node_tag when needed.
+typedef Node *Provenance;
+
+const Provenance OMNIVALID = nullptr;
+const Provenance INVALID_PROV = (Node *)(uptr)1;
+const Provenance WILDCARD_PROV = (Node *)(uptr)2;
+
+// Heap Node* are at least 8-byte aligned. Addresses 0/1/2 are sentinels;
+// other unaligned values are garbage (e.g. early std_detect shadow noise).
+static constexpr uptr kMinProvAlignment = 8;
+
+inline bool ProvIsOmnivalid(Provenance p) { return p == nullptr; }
+inline bool ProvIsInvalid(Provenance p) { return (uptr)p == 1; }
+inline bool ProvIsWildcard(Provenance p) { return (uptr)p == 2; }
+inline bool ProvIsConcrete(Provenance p) {
+  return (uptr)p > 2 && ((uptr)p % kMinProvAlignment) == 0;
+}
+// Sentinel or aligned Node*. Rejects unaligned garbage in shadow slots.
+inline bool ProvIsKnown(Provenance p) {
+  return ProvIsOmnivalid(p) || ProvIsInvalid(p) || ProvIsWildcard(p) ||
+         ProvIsConcrete(p);
+}
 
 struct AtExitRecord {
   void (*func)(void *arg);
   void *arg;
 };
-
-const Provenance OMNIVALID = {0, nullptr};
-
-static constexpr uptr kMinProvAlignment = 8;
 
 extern SANITIZER_INTERFACE_ATTRIBUTE THREADLOCAL Provenance
     *__bsan_shadow_stack;

--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -32,14 +32,13 @@ void GlobalContext::MergeZeroCounts(const uptr, BsanThread *const &thread,
   // If the thread is not in the middle of updating its zero
   // count table, then we can drain its contents for garbage collection.
   if (!thread->ZctBusy()) {
-    // Move every unreachable value into the pending set, keeping the reachable
-    // ones in this thread's zero count table for a future collection.
-    thread->zero_count_set_.retainIf([&](AllocInfo *info, BorTag tag) -> bool {
-      Provenance prov = {tag, info};
-      if (snap->live->contains(prov)) {
+    // Move unreachable tags into pending; keep live ones in this thread's ZCT.
+    // Match on the ZCT entry's tag under its Node* key.
+    thread->zero_count_set_.retainIf([&](Node *node, BorTag tag) -> bool {
+      if (snap->live->contains(node, tag)) {
         return true;
       }
-      global_ctx()->pending_.insert(prov);
+      global_ctx()->pending_.insertTag(node, tag);
       return false;
     });
     // Record the current generation as the last one
@@ -70,13 +69,11 @@ void GlobalContext::SnapshotCallback(const SuspendedThreadsList &, void *arg) {
 
 void GlobalContext::CollectGarbage(Snapshot &snap) {
   InternalMmapVector<RetiredAlloc> filtered;
-  // Eject all retired allocation metadata objects
-  // that are confirmed to be unreachable as of the
-  // current minimum generation.
+  // Eject retired RootNode slots unreachable as of snap.min_drained.
   for (uptr i = 0; i < quarantine_.size(); ++i) {
     RetiredAlloc retired = quarantine_[i];
     if (retired.retire_gen <= snap.min_drained) {
-      __bsan_eject(retired.info);
+      __bsan_eject(retired.node);
     } else {
       // If we can't eject this object yet, then
       // make sure it stays in quarantine.
@@ -87,14 +84,14 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
 
   // A pending set of unpruned tags
   ConcreteProvenanceSet still_pending;
-  pending_.drain([&](AllocInfo *info, BorTagSet &tags) {
+  pending_.drain([&](Node *node, BorTagSet &tags) {
     // If `__bsan_prune` returns true, then the allocation's tree is empty;
     // every single tag was pruned.
-    if (__bsan_prune(info, tags.data(), tags.size())) {
+    if (__bsan_prune(node, tags.data(), tags.size())) {
       if (snap.min_drained == snap.gen) {
-        __bsan_eject(info);
+        __bsan_eject(node);
       } else {
-        quarantine_.push_back({info, snap.gen});
+        quarantine_.push_back({node, snap.gen});
       }
     } else {
       // The Rust core zeroes out every tag that no longer needs tracking.
@@ -103,7 +100,7 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
       const BorTag *retained = tags.data();
       for (uptr i = 0; i < tags.size(); ++i) {
         if (retained[i] != 0) {
-          still_pending.insert({retained[i], info});
+          still_pending.insertTag(node, retained[i]);
         }
       }
     }

--- a/bsan-rt/llvm-wrapper/bsan_global.h
+++ b/bsan-rt/llvm-wrapper/bsan_global.h
@@ -27,7 +27,7 @@ public:
 // be stored within a thread's zero count table.
 struct RetiredAlloc {
   // A non-null pointer to the allocation.
-  AllocInfo *info;
+  Node *node;
   // The generation when it was retired.
   uptr retire_gen;
 };

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -91,7 +91,7 @@ INTERCEPTOR(void *, malloc, SIZE_T size) {
   if (!already_in_scope && INST_CALLER(malloc)) {
     Provenance *RetSlot = GetRetValSlot(0);
     BorTag Tag = NewBorTag();
-    *RetSlot = {Tag, __bsan_alloc(ptr, size, Tag, span)};
+    *RetSlot = __bsan_alloc(ptr, size, Tag, span);
   }
   return ptr;
 }
@@ -114,7 +114,7 @@ INTERCEPTOR(void, free, void *ptr) {
   InterceptorBarrier barrier;
   if (!already_in_scope && INST_CALLER(free)) {
     Provenance *slot = GetParamSlot(0);
-    __bsan_dealloc(ptr, slot->tag, slot->info, span, false);
+    __bsan_dealloc(ptr, *slot, span, false);
     HANDLE_ERROR_PC_BP(pc, bp);
   }
   return bsan_deallocate(ptr);
@@ -130,7 +130,7 @@ INTERCEPTOR(void *, calloc, SIZE_T nmemb, SIZE_T size) {
   if (!already_in_scope && INST_CALLER(calloc)) {
     Provenance *RetSlot = GetRetValSlot(0);
     BorTag Tag = NewBorTag();
-    *RetSlot = {Tag, __bsan_alloc(ptr, nmemb * size, Tag, span)};
+    *RetSlot = __bsan_alloc(ptr, nmemb * size, Tag, span);
   }
   return ptr;
 }
@@ -144,31 +144,30 @@ INTERCEPTOR(void *, realloc, void *ptr, SIZE_T size) {
   bool is_inst = !already_in_scope && INST_CALLER(realloc);
   if (is_inst) {
     Provenance *slot = GetParamSlot(0);
-    __bsan_dealloc(ptr, slot->tag, slot->info, span, false);
+    __bsan_dealloc(ptr, *slot, span, false);
     HANDLE_ERROR_PC_BP(pc, bp);
   }
   void *nptr = bsan_realloc(ptr, size);
   if (is_inst) {
     Provenance *RetSlot = GetRetValSlot(0);
     BorTag Tag = NewBorTag();
-    *RetSlot = {Tag, __bsan_alloc(nptr, size, Tag, span)};
+    *RetSlot = __bsan_alloc(nptr, size, Tag, span);
   }
   return nptr;
 }
 
 static Provenance BsanAllocateMeta(void *ptr, SIZE_T size, uptr span) {
   BorTag tag = NewBorTag();
-  AllocInfo *info = __bsan_alloc(ptr, size, tag, span);
-  return {tag, info};
+  return __bsan_alloc(ptr, size, tag, span);
 }
 
 static void *BsanAllocateMetaIntoStack(void *ptr, SIZE_T size, bool is_inst,
                                        uptr span, uptr slot_idx) {
   if (is_inst) {
     Provenance *slot = GetRetValSlot(slot_idx);
-    Provenance prov = BsanAllocateMeta(ptr, size, span);
+    // Single alloc: `__bsan_alloc` already records the root in the ZCT.
+    // Shadow-stack slots are GC roots and do not take an RC reference.
     *slot = BsanAllocateMeta(ptr, size, span);
-    CurrentThread()->AcquireProvenance(prov);
   } else {
     ClearSlot(slot_idx);
   }

--- a/bsan-rt/llvm-wrapper/bsan_interface_internal.h
+++ b/bsan-rt/llvm-wrapper/bsan_interface_internal.h
@@ -25,10 +25,16 @@ SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_shadow_clear(void *dest, uptr size);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_rc_dec(BorTag Tag, AllocInfo *Info);
+void __bsan_rc_dec(Node *node);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_rc_inc(BorTag Tag, AllocInfo *Info);
+void __bsan_rc_inc(Node *node);
+
+// Tag of a concrete Node*. Must not be called on provenance sentinels.
+// Prefer __bsan_node_tag_impl (Rust RT); CRT fallback reads Node::tag first
+// word.
+SANITIZER_INTERFACE_ATTRIBUTE
+BorTag __bsan_node_tag(Node *node);
 
 SANITIZER_INTERFACE_ATTRIBUTE
 u32 __bsan_symbolize_pc(uptr pc, char *file_buf, uptr file_buf_len, u32 *line,
@@ -38,39 +44,30 @@ SANITIZER_INTERFACE_ATTRIBUTE
 uptr __bsan_read_file(const char *path, char **file_buf, uptr *file_buf_len);
 
 SANITIZER_WEAK_ATTRIBUTE
-AllocInfo *__bsan_alloc(void *base_addr, uptr size, BorTag bor_tag, Span pc);
+Node *__bsan_alloc(void *base_addr, uptr size, BorTag bor_tag, Span pc);
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_dealloc(void *ptr, BorTag bor_tag, AllocInfo *alloc_info, Span pc,
-                    bool checked);
+void __bsan_dealloc(void *ptr, Node *node, Span pc, bool checked);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_read(void *ptr, uptr access_size, BorTag bor_tag,
-                 AllocInfo *alloc_info, bool checked);
+void __bsan_read(void *ptr, uptr access_size, Node *node, bool checked);
 
 SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_write(void *ptr, uptr access_size, BorTag bor_tag,
-                  AllocInfo *alloc_info, bool checked);
-
-// Records a zero-count (alloc_info, bor_tag) pair in the zero-count table.
-// Called by the Rust core when a node's reference count reaches zero.
-SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_release(BorTag bor_tag, AllocInfo *alloc_info);
+void __bsan_write(void *ptr, uptr access_size, Node *node, bool checked);
 
 // Requests a garbage collection. Any thread may call this.
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_request_gc();
 
-// Prunes a list of nodes from a tree that correspond to the tags in the list.
-// Returns true if every tag has been pruned, indicating that the allocation
-// metadata object can also be reclaimed.
+// Prunes tags from the tree rooted at `node`.
+// Returns true if the tree is empty afterward (caller may eject the RootNode).
 SANITIZER_WEAK_ATTRIBUTE
-bool __bsan_prune(AllocInfo *Info, BorTag *tags, uptr len);
+bool __bsan_prune(Node *node, BorTag *tags, uptr len);
 
-// Frees an `AllocInfo` object. The pointer must be nonnull and unreachable
-// in shadow memory.
+// Frees a root Node / RootNode slot. The pointer must be nonnull and
+// unreachable in shadow memory.
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_eject(AllocInfo *Info);
+void __bsan_eject(Node *node);
 
 } // extern "C"
 

--- a/bsan-rt/llvm-wrapper/bsan_set.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_set.cpp
@@ -59,39 +59,73 @@ void BorTagSet::destroy() {
 }
 
 void ConcreteProvenanceSet::insert(Provenance prov) {
-  if (prov.info != nullptr) {
-    set_[prov.info].insert(prov.tag);
+  if (!ProvIsConcrete(prov)) {
+    return;
   }
+  insertTag(prov, __bsan_node_tag(prov));
+}
+
+void ConcreteProvenanceSet::insertTag(Node *node, BorTag tag) {
+  if (!ProvIsConcrete(node)) {
+    return;
+  }
+  set_[node].insert(tag);
 }
 
 void ConcreteProvenanceSet::remove(Provenance prov) {
-  if (prov.info == nullptr) {
+  if (!ProvIsConcrete(prov)) {
     return;
   }
   // Only erase the tag; leave the (possibly now-empty) tag set in place. Erase
   // shifts in place and never frees, so this takes no allocator lock and is
   // safe to run while the world is stopped.
-  if (auto *tags = find(prov.info)) {
-    tags->erase(prov.tag);
+  if (auto *tags = find(prov)) {
+    tags->erase(__bsan_node_tag(prov));
   }
 }
 
 void ConcreteProvenanceSet::clear() {
-  set_.forEach([](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
+  set_.forEach([](DenseMap<Node *, BorTagSet>::value_type &KV) {
     KV.second.clear();
     return true;
   });
 }
 
 bool ConcreteProvenanceSet::contains(Provenance prov) {
-  if (auto *tags = find(prov.info)) {
-    return tags->contains(prov.tag);
+  if (!ProvIsConcrete(prov)) {
+    return false;
+  }
+  return contains(prov, __bsan_node_tag(prov));
+}
+
+bool ConcreteProvenanceSet::contains(Node *node, BorTag tag) {
+  if (!ProvIsConcrete(node)) {
+    return false;
+  }
+  if (auto *tags = find(node)) {
+    return tags->contains(tag);
   }
   return false;
 }
 
+BorTagSet *ConcreteProvenanceSet::find(Node *node) {
+  if (!ProvIsConcrete(node)) {
+    return nullptr;
+  }
+  auto *KV = set_.find(node);
+  return KV ? &KV->second : nullptr;
+}
+
+const BorTagSet *ConcreteProvenanceSet::find(Node *node) const {
+  if (!ProvIsConcrete(node)) {
+    return nullptr;
+  }
+  const auto *KV = set_.find(node);
+  return KV ? &KV->second : nullptr;
+}
+
 ConcreteProvenanceSet::~ConcreteProvenanceSet() {
-  set_.forEach([](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
+  set_.forEach([](DenseMap<Node *, BorTagSet>::value_type &KV) {
     KV.second.destroy();
     return true;
   });

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -73,16 +73,20 @@ public:
 
   void insert(Provenance Prov);
   void remove(Provenance Prov);
+  // Insert (node, tag) without reading node->tag (GC re-queue).
+  void insertTag(Node *node, BorTag tag);
 
   void clear();
   bool contains(Provenance prov);
+  // Explicit tag (MergeZeroCounts keeps node and tag separate).
+  bool contains(Node *node, BorTag tag);
 
   void swap(ConcreteProvenanceSet &other) { set_.swap(other.set_); }
 
   // Removes all entries from the set, after executing the
   // given callback for each allocation.
   template <typename Fn> void drain(Fn visit) {
-    set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
+    set_.forEach([&](DenseMap<Node *, BorTagSet>::value_type &KV) {
       visit(KV.first, KV.second);
       KV.second.destroy();
       set_.erase(KV.first);
@@ -92,29 +96,22 @@ public:
 
   // Retain only the provenance values that satisfy the given predicate.
   template <typename Fn> void retainIf(Fn retain) {
-    set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
-      AllocInfo *info = KV.first;
-      KV.second.retainIf([&](BorTag tag) { return retain(info, tag); });
+    set_.forEach([&](DenseMap<Node *, BorTagSet>::value_type &KV) {
+      Node *node = KV.first;
+      KV.second.retainIf([&](BorTag tag) { return retain(node, tag); });
       if (KV.second.size() == 0) {
         KV.second.destroy();
-        set_.erase(info);
+        set_.erase(node);
       }
       return true;
     });
   }
 
-  BorTagSet *find(AllocInfo *Info) {
-    auto *KV = set_.find(Info);
-    return KV ? &KV->second : nullptr;
-  }
-
-  const BorTagSet *find(AllocInfo *Info) const {
-    const auto *KV = set_.find(Info);
-    return KV ? &KV->second : nullptr;
-  }
+  BorTagSet *find(Node *node);
+  const BorTagSet *find(Node *node) const;
 
 private:
-  DenseMap<AllocInfo *, BorTagSet> set_;
+  DenseMap<Node *, BorTagSet> set_;
 };
 
 } // namespace __bsan

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -20,20 +20,9 @@ static void CheckMemoryLayout() {
     CHECK(addr_is_type((start + end) / 2, type));
     CHECK(addr_is_type(end - 1, type));
     if (type == MappingDesc::APP) {
-      uptr addr = start;
-      CHECK(MEM_IS_SHADOW(MEM_TO_SHADOW(addr)));
-      CHECK(MEM_IS_ORIGIN(MEM_TO_ORIGIN(addr)));
-      CHECK_EQ(MEM_TO_ORIGIN(addr), SHADOW_TO_ORIGIN(MEM_TO_SHADOW(addr)));
-
-      addr = (start + end) / 2;
-      CHECK(MEM_IS_SHADOW(MEM_TO_SHADOW(addr)));
-      CHECK(MEM_IS_ORIGIN(MEM_TO_ORIGIN(addr)));
-      CHECK_EQ(MEM_TO_ORIGIN(addr), SHADOW_TO_ORIGIN(MEM_TO_SHADOW(addr)));
-
-      addr = end - 1;
-      CHECK(MEM_IS_SHADOW(MEM_TO_SHADOW(addr)));
-      CHECK(MEM_IS_ORIGIN(MEM_TO_ORIGIN(addr)));
-      CHECK_EQ(MEM_TO_ORIGIN(addr), SHADOW_TO_ORIGIN(MEM_TO_SHADOW(addr)));
+      CHECK(MEM_IS_SHADOW(MEM_TO_SHADOW(start)));
+      CHECK(MEM_IS_SHADOW(MEM_TO_SHADOW((start + end) / 2)));
+      CHECK(MEM_IS_SHADOW(MEM_TO_SHADOW(end - 1)));
     }
     prev_end = end;
   }
@@ -78,7 +67,7 @@ static bool ProtectMemoryRange(uptr beg, uptr size, const char *name) {
   return true;
 }
 
-static bool InitShadow(bool init_origins, bool dry_run) {
+static bool InitShadow(bool dry_run) {
   // Let user know mapping parameters first.
   VPrintf(1, "bsan_init %p\n", (void *)&__bsan_init);
   for (unsigned i = 0; i < kMemoryLayoutSize; ++i)
@@ -86,7 +75,7 @@ static bool InitShadow(bool init_origins, bool dry_run) {
             kMemoryLayout[i].end - 1);
 
   // Verify the memory layout is internally consistent and that the
-  // application-to-shadow/origin mappings stay within their regions.
+  // application-to-shadow mappings stay within their regions.
   CheckMemoryLayout();
 
   if (!MEM_IS_APP(&__bsan_init)) {
@@ -109,10 +98,8 @@ static bool InitShadow(bool init_origins, bool dry_run) {
     if (start >= maxVirtualAddress)
       continue;
 
-    bool map = type == MappingDesc::SHADOW ||
-               (init_origins && type == MappingDesc::ORIGIN);
-    bool protect = type == MappingDesc::INVALID ||
-                   (!init_origins && type == MappingDesc::ORIGIN);
+    bool map = type == MappingDesc::SHADOW;
+    bool protect = type == MappingDesc::INVALID;
     CHECK(!(map && protect));
     if (!map && !protect) {
       CHECK(type == MappingDesc::APP || type == MappingDesc::ALLOCATOR);
@@ -148,7 +135,7 @@ static bool InitShadow(bool init_origins, bool dry_run) {
   return true;
 }
 
-static void ReportUnavailableMemoryRegions(bool init_origins) {
+static void ReportUnavailableMemoryRegions() {
   const uptr maxVirtualAddress = GetMaxUserVirtualAddress();
   for (unsigned i = 0; i < kMemoryLayoutSize; ++i) {
     uptr start = kMemoryLayout[i].start;
@@ -159,10 +146,8 @@ static void ReportUnavailableMemoryRegions(bool init_origins) {
     if (start >= maxVirtualAddress)
       continue;
 
-    bool map = type == MappingDesc::SHADOW ||
-               (init_origins && type == MappingDesc::ORIGIN);
-    bool protect = type == MappingDesc::INVALID ||
-                   (!init_origins && type == MappingDesc::ORIGIN);
+    bool map = type == MappingDesc::SHADOW;
+    bool protect = type == MappingDesc::INVALID;
     if (!map && !protect) {
       if (type == MappingDesc::ALLOCATOR)
         CheckMemoryRangeAvailability(start, size, true, kMemoryLayout[i].name);
@@ -174,11 +159,10 @@ static void ReportUnavailableMemoryRegions(bool init_origins) {
 
 namespace __bsan {
 bool InitShadowWithReExec() {
-  bool init_origins = true;
   // Start with dry run: check layout is ok, but don't print warnings because
   // warning messages will cause tests to fail (even if we successfully re-exec
   // after the warning).
-  bool success = InitShadow(init_origins, true);
+  bool success = InitShadow(true);
   if (!success) {
 #if SANITIZER_LINUX
     // Perhaps ASLR entropy is too high. If ASLR is enabled, re-exec without it.
@@ -195,13 +179,13 @@ bool InitShadowWithReExec() {
       ReExec();
     }
 #endif
-    ReportUnavailableMemoryRegions(init_origins);
+    ReportUnavailableMemoryRegions();
     return false;
   }
 
   // The earlier dry run didn't actually map or protect anything. Run again in
   // non-dry run mode.
-  return InitShadow(init_origins, false);
+  return InitShadow(false);
 }
 
 static void AlignPtr8(uptr addr, uptr &aligned_addr) {
@@ -231,30 +215,25 @@ void CopyAligned(void *dest, const void *src, uptr size) {
   internal_memcpy((void *)d_aligned, (const void *)s_aligned, s_size);
 }
 
+// Copy/move one 8-byte shadow provenance slot (Node*).
+// Invariant: shadow holds N ⇔ N.refcount accounts for that slot.
 ALWAYS_INLINE static void UpdateShadowSlot(uptr d_aligned, uptr s_aligned,
                                            uptr offset) {
   uptr d_shadow = MEM_TO_SHADOW(d_aligned);
-  uptr d_origin = MEM_TO_ORIGIN(d_aligned);
   uptr s_shadow = MEM_TO_SHADOW(s_aligned);
-  uptr s_origin = MEM_TO_ORIGIN(s_aligned);
 
-  AllocInfo **dest_info = reinterpret_cast<AllocInfo **>(d_origin + offset);
-  AllocInfo **source_info = reinterpret_cast<AllocInfo **>(s_origin + offset);
+  Provenance *dest = reinterpret_cast<Provenance *>(d_shadow + offset);
+  Provenance *source = reinterpret_cast<Provenance *>(s_shadow + offset);
 
-  BorTag *dest_tag = reinterpret_cast<BorTag *>(d_shadow + offset);
-  BorTag *source_tag = reinterpret_cast<BorTag *>(s_shadow + offset);
+  Provenance src = *source;
 
-  BorTag src_tag = *source_tag;
-  AllocInfo *src_info = *source_info;
+  // Inc before dec: same Node* in src and dest must not hit zero mid-update.
+  if (ProvIsConcrete(src))
+    __bsan_rc_inc(src);
+  if (ProvIsConcrete(*dest))
+    __bsan_rc_dec(*dest);
 
-  if (*dest_info != nullptr)
-    __bsan_rc_dec(*dest_tag, *dest_info);
-
-  if (src_info != nullptr)
-    __bsan_rc_inc(src_tag, src_info);
-
-  *dest_tag = src_tag;
-  *dest_info = src_info;
+  *dest = src;
 }
 
 void CopyShadow(void *dest, const void *src, uptr size) {
@@ -314,19 +293,16 @@ void ClearShadow(void *dest, uptr size) {
   AlignRange8((uptr)dest, size, d_aligned, d_size);
 
   uptr shadow_start = MEM_TO_SHADOW(d_aligned);
-  uptr origin_start = MEM_TO_ORIGIN(d_aligned);
 
   const uptr step = kMinProvAlignment;
 
   for (uptr offset = 0; offset < d_size; offset += step) {
-    BorTag *tag_ptr = reinterpret_cast<BorTag *>(shadow_start + offset);
-    AllocInfo **info_ptr =
-        reinterpret_cast<AllocInfo **>(origin_start + offset);
+    Provenance *slot = reinterpret_cast<Provenance *>(shadow_start + offset);
 
-    if (*info_ptr != nullptr) {
-      __bsan_rc_dec(*tag_ptr, *info_ptr);
-      *info_ptr = nullptr;
+    if (ProvIsConcrete(*slot)) {
+      __bsan_rc_dec(*slot);
     }
+    *slot = OMNIVALID;
   }
 }
 
@@ -336,20 +312,14 @@ void WriteShadow(void *dest, Provenance prov) {
   uptr d_aligned, d_size;
   AlignRange8((uptr)dest, 8, d_aligned, d_size);
   uptr shadow_start = MEM_TO_SHADOW(d_aligned);
-  uptr origin_start = MEM_TO_ORIGIN(d_aligned);
 
-  BorTag *tag_ptr = reinterpret_cast<BorTag *>(shadow_start);
-  AllocInfo **info_ptr = reinterpret_cast<AllocInfo **>(origin_start);
-  if (*info_ptr != nullptr) {
-    __bsan_rc_dec(*tag_ptr, *info_ptr);
-  }
+  Provenance *slot = reinterpret_cast<Provenance *>(shadow_start);
+  // Inc before dec: same Node* must not hit zero mid-update.
+  if (ProvIsConcrete(prov))
+    __bsan_rc_inc(prov);
+  if (ProvIsConcrete(*slot))
+    __bsan_rc_dec(*slot);
 
-  *info_ptr = prov.info;
-  *tag_ptr = prov.tag;
-
-  // The written provenance now holds a reference from this shadow slot.
-  if (prov.info != nullptr) {
-    __bsan_rc_inc(prov.tag, prov.info);
-  }
+  *slot = prov;
 }
 } // namespace __bsan

--- a/bsan-rt/llvm-wrapper/bsan_shadow.h
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.h
@@ -4,7 +4,7 @@
 
 using namespace __sanitizer;
 
-struct Provenance;
+struct Node;
 
 struct MappingDesc {
   uptr start;
@@ -14,7 +14,6 @@ struct MappingDesc {
     ALLOCATOR = 2,
     APP = 4,
     SHADOW = 8,
-    ORIGIN = 16,
   } type;
   const char *name;
 };
@@ -25,25 +24,22 @@ struct MappingDesc {
 // - 0x0a00000000000-0x0b00000000000: 48-bits PIE program segments
 //   Ideally, this would extend to 0x0c00000000000 (2^45 bytes - the
 //   maximum ASLR region for 48-bit VMA) but it is too hard to fit in
-//   the larger app/shadow/origin regions.
+//   the larger app/shadow regions.
 // - 0x0e00000000000-0x1000000000000: 48-bits libraries segments
+// Former ORIGIN ranges (second-word AllocInfo*) are reserved INVALID under OWP.
 const MappingDesc kMemoryLayout[] = {
     {0X0000000000000, 0X0100000000000, MappingDesc::APP, "app-10-13"},
     {0X0100000000000, 0X0200000000000, MappingDesc::SHADOW, "shadow-14"},
-    {0X0200000000000, 0X0300000000000, MappingDesc::INVALID, "invalid"},
-    {0X0300000000000, 0X0400000000000, MappingDesc::ORIGIN, "origin-14"},
+    {0X0200000000000, 0X0400000000000, MappingDesc::INVALID, "invalid"},
     {0X0400000000000, 0X0600000000000, MappingDesc::SHADOW, "shadow-15"},
-    {0X0600000000000, 0X0800000000000, MappingDesc::ORIGIN, "origin-15"},
-    {0X0800000000000, 0X0A00000000000, MappingDesc::INVALID, "invalid"},
+    {0X0600000000000, 0X0A00000000000, MappingDesc::INVALID, "invalid"},
     {0X0A00000000000, 0X0B00000000000, MappingDesc::APP, "app-14"},
     {0X0B00000000000, 0X0C00000000000, MappingDesc::SHADOW, "shadow-10-13"},
-    {0X0C00000000000, 0X0D00000000000, MappingDesc::INVALID, "invalid"},
-    {0X0D00000000000, 0X0E00000000000, MappingDesc::ORIGIN, "origin-10-13"},
+    {0X0C00000000000, 0X0E00000000000, MappingDesc::INVALID, "invalid"},
     {0x0E00000000000, 0x0E40000000000, MappingDesc::ALLOCATOR, "allocator"},
     {0X0E40000000000, 0X1000000000000, MappingDesc::APP, "app-15"},
 };
 #define MEM_TO_SHADOW(mem) ((uptr)mem ^ 0xB00000000000ULL)
-#define SHADOW_TO_ORIGIN(shadow) (((uptr)(shadow)) + 0x200000000000ULL)
 
 const uptr kAllocatorSpace = 0xE00000000000ULL;
 const uptr kAllocatorSpaceSize = 0x40000000000ULL; // 4T.
@@ -54,23 +50,20 @@ const uptr kAllocatorSpaceSize = 0x40000000000ULL; // 4T.
 // PIE and ASLR: main executable and DSOs at 0x7f0000000000
 // non-PIE: main executable below 0x100000000, DSOs at 0x7f0000000000
 // Heap at 0x700000000000.
+// Former ORIGIN ranges are reserved INVALID under OWP.
 const MappingDesc kMemoryLayout[] = {
     {0x000000000000ULL, 0x010000000000ULL, MappingDesc::APP, "app-1"},
     {0x010000000000ULL, 0x100000000000ULL, MappingDesc::SHADOW, "shadow-2"},
-    {0x100000000000ULL, 0x110000000000ULL, MappingDesc::INVALID, "invalid"},
-    {0x110000000000ULL, 0x200000000000ULL, MappingDesc::ORIGIN, "origin-2"},
+    {0x100000000000ULL, 0x200000000000ULL, MappingDesc::INVALID, "invalid"},
     {0x200000000000ULL, 0x300000000000ULL, MappingDesc::SHADOW, "shadow-3"},
-    {0x300000000000ULL, 0x400000000000ULL, MappingDesc::ORIGIN, "origin-3"},
-    {0x400000000000ULL, 0x500000000000ULL, MappingDesc::INVALID, "invalid"},
+    {0x300000000000ULL, 0x500000000000ULL, MappingDesc::INVALID, "invalid"},
     {0x500000000000ULL, 0x510000000000ULL, MappingDesc::SHADOW, "shadow-1"},
     {0x510000000000ULL, 0x600000000000ULL, MappingDesc::APP, "app-2"},
-    {0x600000000000ULL, 0x610000000000ULL, MappingDesc::ORIGIN, "origin-1"},
-    {0x610000000000ULL, 0x700000000000ULL, MappingDesc::INVALID, "invalid"},
+    {0x600000000000ULL, 0x700000000000ULL, MappingDesc::INVALID, "invalid"},
     {0x700000000000ULL, 0x740000000000ULL, MappingDesc::ALLOCATOR, "allocator"},
     {0x740000000000ULL, 0x800000000000ULL, MappingDesc::APP, "app-3"}};
 
 #define MEM_TO_SHADOW(mem) (((uptr)(mem)) ^ 0x500000000000ULL)
-#define SHADOW_TO_ORIGIN(mem) (((uptr)(mem)) + 0x100000000000ULL)
 
 const uptr kAllocatorSpace = 0x700000000000ULL;
 const uptr kAllocatorSpaceSize = 0x40000000000ULL; // 4T.
@@ -80,8 +73,6 @@ const uptr kAllocatorSpaceSize = 0x40000000000ULL; // 4T.
 #endif
 
 const uptr kMemoryLayoutSize = sizeof(kMemoryLayout) / sizeof(kMemoryLayout[0]);
-
-#define MEM_TO_ORIGIN(mem) (SHADOW_TO_ORIGIN(MEM_TO_SHADOW((mem))))
 
 #ifndef __clang__
 __attribute__((optimize("unroll-loops")))
@@ -102,14 +93,13 @@ inline bool addr_is_type(uptr addr, int mapping_types) {
 #define MEM_IS_APP(mem)                                                        \
   (addr_is_type((uptr)(mem), MappingDesc::APP | MappingDesc::ALLOCATOR))
 #define MEM_IS_SHADOW(mem) addr_is_type((uptr)(mem), MappingDesc::SHADOW)
-#define MEM_IS_ORIGIN(mem) addr_is_type((uptr)(mem), MappingDesc::ORIGIN)
 
 namespace __bsan {
 bool InitShadowWithReExec();
 void CopyShadow(void *dest, const void *src, uptr size);
 void MoveShadow(void *dest, const void *src, uptr size);
 void ClearShadow(void *dest, uptr size);
-void WriteShadow(void *dest, Provenance prov);
+void WriteShadow(void *dest, Node *prov);
 } // namespace __bsan
 
 #endif

--- a/bsan-rt/src/borrow_tracker.rs
+++ b/bsan-rt/src/borrow_tracker.rs
@@ -1,8 +1,10 @@
 // Components in this library were ported from Miri and then modified by our team.
+use core::cell::Cell;
+use core::mem::offset_of;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 
-use spin::MutexGuard;
+use spin::{Mutex, MutexGuard};
 
 use crate::errors::{UBInfo, UBResult};
 use crate::helpers::{AllocRange, Size};
@@ -10,31 +12,117 @@ use crate::sanitizer_common::Span;
 use crate::tree_borrows::data_structures::{AccessType, DedupRangeMap};
 use crate::tree_borrows::diagnostics::AccessCause;
 use crate::tree_borrows::perms::{AccessKind, Permission};
-use crate::tree_borrows::tree::LocationState;
+use crate::tree_borrows::tree::{BorrowState, LocationState, Node};
 use crate::tree_borrows::{AllocState, AllocStateImpl, IdempotentForeignAccess, NewPermission};
-use crate::{AllocInfo, BorTag, GlobalCtx, Provenance, RetagFlags, RetagInfo};
+use crate::{AllocId, BorTag, GlobalCtx, Provenance, RetagFlags, RetagInfo};
 
-// A reference to an instance of `AllocInfo`
+/// Heap-allocated root: inline [`Node`] plus shared borrow state.
+///
+/// Stack slots (`on_stack`) stay off the free list until `destroy_stack_slot`.
+#[repr(C)]
+pub(crate) struct RootNode {
+    pub(crate) node: Node,
+    pub(crate) alloc_id: Cell<AllocId>,
+    pub(crate) base_addr: Cell<Size>,
+    pub(crate) size: Cell<Size>,
+    pub(crate) state: Mutex<BorrowState>,
+    pub(crate) free_list_next: Option<NonNull<RootNode>>,
+    /// Only frame teardown may return this slot to the free list.
+    pub(crate) on_stack: bool,
+}
+
+impl RootNode {
+    pub(crate) fn invalid() -> Self {
+        Self {
+            node: Node::new_root(BorTag::invalid(), Span::dummy()),
+            alloc_id: Cell::new(AllocId::invalid()),
+            base_addr: Cell::new(Size::ZERO),
+            size: Cell::new(Size::ZERO),
+            state: Mutex::new(BorrowState::None),
+            free_list_next: None,
+            on_stack: false,
+        }
+    }
+
+    /// Reserved stack slot (`BorrowState::None`) owned by the frame until destroy.
+    pub(crate) fn invalid_stack() -> Self {
+        let mut root = Self::invalid();
+        root.on_stack = true;
+        root
+    }
+
+    pub(crate) fn new(base_addr: Size, size: Size, bor_tag: BorTag, span: Span) -> Self {
+        Self {
+            node: Node::new_root(bor_tag, span),
+            alloc_id: Cell::new(AllocId::default()),
+            base_addr: Cell::new(base_addr),
+            size: Cell::new(size),
+            state: Mutex::new(BorrowState::new(bor_tag, size, span)),
+            free_list_next: None,
+            on_stack: false,
+        }
+    }
+
+    /// Points `node.state` at this slot's mutex. Must be called after the `RootNode` is placed
+    /// at a stable address (heap alloc / in-place write).
+    pub(crate) unsafe fn wire_state(this: NonNull<RootNode>) {
+        unsafe {
+            let state_ptr = NonNull::from(&(*this.as_ptr()).state);
+            (*this.as_ptr()).node.state = state_ptr;
+        }
+    }
+
+    /// Recovers the enclosing [`RootNode`] from any node that shares its `state` mutex.
+    pub(crate) unsafe fn from_node(node: NonNull<Node>) -> NonNull<RootNode> {
+        let state_ptr = unsafe { node.as_ref().state.as_ptr() };
+        let root = (state_ptr as usize).wrapping_sub(offset_of!(RootNode, state)) as *mut RootNode;
+        unsafe { NonNull::new_unchecked(root) }
+    }
+
+    pub(crate) fn node_ptr(this: NonNull<RootNode>) -> NonNull<Node> {
+        unsafe { NonNull::from(&(*this.as_ptr()).node) }
+    }
+
+    #[cfg(feature = "debug")]
+    pub(crate) fn summarize(&self) -> crate::NodeSummary {
+        crate::NodeSummary::Valid {
+            alloc_id: self.alloc_id.get(),
+            base_addr: self.base_addr.get(),
+            size: self.size.get(),
+        }
+    }
+}
+
+/// Pointer to a tree [`Node`] (root or child) for a live allocation.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(transparent)]
-pub struct AllocInfoPtr(NonNull<AllocInfo>);
+pub struct NodePtr(NonNull<Node>);
 
-// A pointer to an instance of `AllocInfo`.
-impl AllocInfoPtr {
+impl NodePtr {
     /// # Safety
-    /// This instance of `AllocInfo` must represent a valid, non-freed allocation.
-    /// Otherwise, the contents of its base address will be initialized with the next
-    /// pointer in a free list.
-    pub unsafe fn range(&self) -> AllocRange {
-        AllocRange { start: unsafe { self.base_addr() }, size: self.size.get() }
+    /// The node must belong to a valid, non-freed allocation.
+    pub(crate) unsafe fn range(&self) -> AllocRange {
+        let root = unsafe { RootNode::from_node(self.0).as_ref() };
+        AllocRange { start: root.base_addr.get(), size: root.size.get() }
     }
 
     /// # Safety
-    /// This instance of `AllocInfo` must represent a valid, non-freed allocation.
-    /// Otherwise, the contents of its base address will be initialized with the next
-    /// pointer in a free list.
-    pub unsafe fn base_addr(&self) -> Size {
-        unsafe { self.free_or_addr.get().base_addr }
+    /// The node must belong to a valid, non-freed allocation.
+    pub(crate) unsafe fn base_addr(&self) -> Size {
+        unsafe { RootNode::from_node(self.0).as_ref().base_addr.get() }
+    }
+
+    pub(crate) fn alloc_id(&self) -> AllocId {
+        unsafe { RootNode::from_node(self.0).as_ref().alloc_id.get() }
+    }
+
+    pub(crate) fn size(&self) -> Size {
+        unsafe { RootNode::from_node(self.0).as_ref().size.get() }
+    }
+
+    pub(crate) fn root_node_ptr(&self) -> NonNull<Node> {
+        let root = unsafe { RootNode::from_node(self.0) };
+        RootNode::node_ptr(root)
     }
 
     fn tree<'b>(self) -> UBResult<TreeGuard<'b>> {
@@ -42,132 +130,95 @@ impl AllocInfoPtr {
     }
 
     fn tree_opt<'b>(self) -> Option<TreeGuard<'b>> {
-        let info: &'b AllocInfo = unsafe { self.0.as_ref() };
-        let tree = info.tree.lock();
-        if tree.is_none() {
-            None
+        let state = unsafe { self.0.as_ref().state.as_ref() }.lock();
+        if state.is_live() {
+            Some(unsafe { TreeGuard::new(state) })
         } else {
-            // Safety: the tree contains a valid instance now.
-            Some(unsafe { TreeGuard::new(tree) })
+            None
+        }
+    }
+
+    /// Removes dead tags from the allocation's borrow state.
+    /// Returns `true` when the tree is empty and the `RootNode` may be ejected.
+    ///
+    /// Stack roots never report empty: the frame owns the slot until
+    /// `destroy_stack_slot`, so GC must not eject them even if all tags were pruned.
+    pub(crate) fn prune_dead_tags(self, dead_tags: &mut [BorTag]) -> bool {
+        let on_stack = unsafe { RootNode::from_node(self.0).as_ref().on_stack };
+        match self.tree_opt() {
+            Some(mut tree) => {
+                let empty = tree.remove_dead_tags(dead_tags);
+                empty && !on_stack
+            }
+            None => {
+                dead_tags.fill(BorTag::omnivalid());
+                false
+            }
         }
     }
 }
 
-impl Deref for AllocInfoPtr {
-    type Target = AllocInfo;
-
-    fn deref(&self) -> &Self::Target {
-        unsafe { self.0.as_ref() }
-    }
-}
-
-impl From<NonNull<AllocInfo>> for AllocInfoPtr {
-    fn from(value: NonNull<AllocInfo>) -> Self {
+impl From<NonNull<Node>> for NodePtr {
+    fn from(value: NonNull<Node>) -> Self {
         Self(value)
     }
 }
 
-// A guard over the `Tree` for an allocation.
+// A guard over the borrow state for an allocation.
 #[derive(Debug)]
-struct TreeGuard<'b>(MutexGuard<'b, Option<AllocStateImpl>>);
+struct TreeGuard<'b>(MutexGuard<'b, BorrowState>);
 
 impl<'b> TreeGuard<'b> {
     /// # Safety
-    /// The inner `Option` must always contain `AllocStateImpl`.
+    /// The inner state must be live (`Uninit` or `Init`).
     #[must_use]
     #[inline]
-    unsafe fn new(value: MutexGuard<'b, Option<AllocStateImpl>>) -> Self {
-        debug_assert!(value.is_some());
+    unsafe fn new(value: MutexGuard<'b, BorrowState>) -> Self {
+        debug_assert!(value.is_live());
         Self(value)
     }
 
-    //
     #[inline]
-    fn take(&mut self) -> AllocStateImpl {
-        // Safety: the inner `Option` must always contain a value.
-        unsafe { self.0.take().unwrap_unchecked() }
+    fn take(&mut self) -> BorrowState {
+        core::mem::replace(&mut *self.0, BorrowState::None)
     }
 }
 
 impl Deref for TreeGuard<'_> {
-    type Target = AllocStateImpl;
-    fn deref(&self) -> &AllocStateImpl {
-        self.0.as_ref().unwrap()
+    type Target = BorrowState;
+    fn deref(&self) -> &BorrowState {
+        &self.0
     }
 }
 
 impl DerefMut for TreeGuard<'_> {
-    fn deref_mut(&mut self) -> &mut AllocStateImpl {
-        self.0.as_mut().unwrap()
+    fn deref_mut(&mut self) -> &mut BorrowState {
+        &mut self.0
     }
 }
 
 #[derive(Debug)]
-pub struct BorrowTracker<'a> {
+pub(crate) struct BorrowTracker<'a> {
     bor_tag: BorTag,
-    alloc_info: AllocInfoPtr,
+    node: NodePtr,
     range: AllocRange,
     tree: TreeGuard<'a>,
 }
 
 impl<'b> BorrowTracker<'b> {
-    /// # Safety
-    /// The caller must provide concrete provenance whose allocation metadata is
-    /// valid and live.
-    #[allow(dead_code)]
-    pub unsafe fn for_alloc_unchecked<T, F>(prov: Provenance, f: F) -> UBResult<T>
-    where
-        F: FnOnce(Self) -> UBResult<T>,
-        T: Default,
-    {
-        debug_assert!(!prov.alloc_info.is_null());
-        let alloc_info: AllocInfoPtr = unsafe { NonNull::new_unchecked(prov.alloc_info).into() };
-        let tree = alloc_info.tree()?;
-        let size = alloc_info.size.get();
-        let range = AllocRange { start: Size::ZERO, size };
-        f(Self { tree, bor_tag: prov.bor_tag, alloc_info, range })
-    }
-
-    pub fn for_alloc<T, F>(prov: Provenance, f: F) -> UBResult<T>
-    where
-        F: FnOnce(Self) -> UBResult<T>,
-        T: Default,
-    {
-        if prov.bor_tag == BorTag::omnivalid() || prov.bor_tag.is_wildcard() {
-            // Only concrete provenance values have `AllocInfo` that we can
-            // access directly. This API is intended to have an affect in this case,
-            // so we also skip wildcard provenance.
-            Ok(T::default())
-        } else if prov.bor_tag == BorTag::invalid() {
-            Err(UBInfo::UseAfterFree)
-        } else {
-            // Safety:
-            // Our instrumentation pass guarantees that if a pointer's
-            // provenance is non-null and not omnivalid, then it will contain
-            // valid allocation info pointer.
-            debug_assert!(!prov.alloc_info.is_null());
-            let alloc_info: AllocInfoPtr =
-                unsafe { NonNull::new_unchecked(prov.alloc_info).into() };
-            let tree = alloc_info.tree()?;
-            let size = alloc_info.size.get();
-            let range = AllocRange { start: Size::ZERO, size };
-            f(Self { tree, bor_tag: prov.bor_tag, alloc_info, range })
-        }
-    }
-
-    pub fn for_alloc_weak<T, F>(prov: Provenance, f: F) -> T
+    pub(crate) fn for_alloc_weak<T, F>(prov: Provenance, f: F) -> T
     where
         F: FnOnce(Self) -> T,
         T: Default,
     {
-        if !prov.bor_tag.is_concrete() {
+        if !prov.is_concrete() {
             return T::default();
         }
-        let alloc_info: AllocInfoPtr = unsafe { NonNull::new_unchecked(prov.alloc_info).into() };
-        if let Some(tree) = alloc_info.tree_opt() {
-            let size = alloc_info.size.get();
+        let node: NodePtr = unsafe { NonNull::new_unchecked(prov.node()).into() };
+        if let Some(tree) = node.tree_opt() {
+            let size = node.size();
             let range = AllocRange { start: Size::ZERO, size };
-            f(Self { tree, bor_tag: prov.bor_tag, alloc_info, range })
+            f(Self { tree, bor_tag: prov.tag(), node, range })
         } else {
             T::default()
         }
@@ -176,7 +227,7 @@ impl<'b> BorrowTracker<'b> {
     /// # Safety
     /// The caller must provide concrete provenance whose allocation metadata is
     /// valid and live, and `start..start + access_size` must be in-bounds.
-    pub unsafe fn for_access_unchecked<T, F>(
+    pub(crate) unsafe fn for_access_unchecked<T, F>(
         _: &GlobalCtx,
         prov: Provenance,
         start: Size,
@@ -187,19 +238,17 @@ impl<'b> BorrowTracker<'b> {
         F: FnOnce(Self) -> UBResult<T>,
         T: Default,
     {
-        let alloc_info: AllocInfoPtr = unsafe { NonNull::new_unchecked(prov.alloc_info).into() };
-        let alloc_size = alloc_info.size.get();
-        let base_addr = unsafe { alloc_info.base_addr() };
+        let node: NodePtr = unsafe { NonNull::new_unchecked(prov.node()).into() };
+        let alloc_size = node.size();
+        let base_addr = unsafe { node.base_addr() };
         let offset = Size::from_bytes(start.bytes().wrapping_sub(base_addr.bytes()));
-        let tree = alloc_info.tree()?;
+        let tree = node.tree()?;
 
         let range = AllocRange { start: offset, size: access_size.unwrap_or(alloc_size) };
-        f(Self { tree, bor_tag: prov.bor_tag, alloc_info, range })
+        f(Self { tree, bor_tag: prov.tag(), node, range })
     }
 
-    /// # Safety
-    /// Takes in provenance pointer that is checked via debug_asserts
-    pub fn for_access<T, F>(
+    pub(crate) fn for_access<T, F>(
         global_ctx: &GlobalCtx,
         prov: Provenance,
         start: Size,
@@ -210,16 +259,20 @@ impl<'b> BorrowTracker<'b> {
         F: FnOnce(Self) -> UBResult<T>,
         T: Default,
     {
-        if prov.bor_tag == BorTag::omnivalid() {
+        // Omnivalid or unaligned shadow garbage (not a sentinel / Node*).
+        if !prov.is_invalid() && !prov.is_wildcard() && !prov.is_concrete() {
             Ok(T::default())
-        } else if prov.bor_tag == BorTag::invalid() {
+        } else if prov.is_invalid() {
             if access_size == Some(Size::ZERO) {
                 Ok(T::default())
             } else {
                 Err(UBInfo::UseAfterFree)
             }
         } else {
-            let alloc_info: AllocInfoPtr = if prov.bor_tag.is_wildcard() {
+            // Keep the provenance tag (wildcard stays wildcard even after
+            // resolving an exposed Node*); do not use the resolved node's tag.
+            let bor_tag = prov.tag();
+            let node: NodePtr = if prov.is_wildcard() {
                 let size = access_size.unwrap_or(Size::ZERO);
                 let range = AllocRange { start, size };
                 if let Some(exposed) = global_ctx.get_exposed_provenance(range) {
@@ -233,26 +286,26 @@ impl<'b> BorrowTracker<'b> {
                     return Ok(T::default());
                 }
             } else {
-                debug_assert!(!prov.alloc_info.is_null());
-                unsafe { NonNull::new_unchecked(prov.alloc_info).into() }
+                debug_assert!(prov.is_concrete());
+                unsafe { NonNull::new_unchecked(prov.node()).into() }
             };
 
-            let alloc_id = alloc_info.alloc_id.get();
-            let alloc_size = alloc_info.size.get();
-            let base_addr = unsafe { alloc_info.base_addr() };
+            let alloc_id = node.alloc_id();
+            let alloc_size = node.size();
+            let base_addr = unsafe { node.base_addr() };
             let access_size = access_size.unwrap_or(alloc_size);
             let is_sized_access = access_size != Size::ZERO;
 
             // If there is no tree for this allocation, then this is a UAF,
             // unless this is a zero-sized access.
-            let Some(tree) = alloc_info.tree_opt() else {
+            let Some(tree) = node.tree_opt() else {
                 return if is_sized_access { Err(UBInfo::UseAfterFree) } else { Ok(T::default()) };
             };
 
             // If the tree does not contain the borrow tag that we are using to
             // validate the access, then this is also a UAF, unless this is a
             // zero-sized access, or we have a wildcard tag.
-            if !tree.contains_tag(prov.bor_tag) && prov.bor_tag.is_concrete() {
+            if !tree.contains_tag(bor_tag) && bor_tag.is_concrete() {
                 return if is_sized_access { Err(UBInfo::UseAfterFree) } else { Ok(T::default()) };
             }
 
@@ -270,17 +323,17 @@ impl<'b> BorrowTracker<'b> {
             }
 
             let range = AllocRange { start: offset, size: access_size };
-            f(Self { tree, bor_tag: prov.bor_tag, alloc_info, range })
+            f(Self { tree, bor_tag, node, range })
         }
     }
 
-    pub fn retag(
+    pub(crate) fn retag(
         &mut self,
         global_ctx: &GlobalCtx,
         retag_info: RetagInfo<'_>,
         span: Span,
     ) -> UBResult<Provenance> {
-        let alloc_id = self.alloc_info.alloc_id.get();
+        let alloc_id = self.node.alloc_id();
         let parent_tag = self.bor_tag;
         let new_tag = BorTag::default();
         // A wildcard parent is never present in the tree: retagging it adds
@@ -367,7 +420,7 @@ impl<'b> BorrowTracker<'b> {
         }
 
         // base offset should be the offset, from zero, where the retag is taking place within the allocation.
-        self.tree.new_child(
+        let child = self.tree.new_child(
             base_offset,
             parent_tag,
             new_tag,
@@ -375,33 +428,22 @@ impl<'b> BorrowTracker<'b> {
             new_perm.outside_perm,
             protected,
             span,
+            self.node.root_node_ptr(),
         )?;
 
-        Ok(Provenance { alloc_info: self.alloc_info.0.as_ptr(), bor_tag: new_tag })
+        Ok(Provenance::from_node(child.as_ptr()))
     }
 
-    pub fn protector_end(&mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
+    pub(crate) fn protector_end(&mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
         self.tree.perform_protector_end_access(
             self.bor_tag,
             &global_ctx.protected_tags(),
-            self.alloc_info.alloc_id.get(),
+            self.node.alloc_id(),
             span,
         )
     }
 
-    /// Increments the reference count, returning `true` if the count went from
-    /// zero to one.
-    pub fn increment(&self) -> UBResult<bool> {
-        Ok(self.tree.increment(self.bor_tag))
-    }
-
-    /// Decrements the reference count, returning `true` if the count reached
-    /// zero.
-    pub fn decrement(&self) -> UBResult<bool> {
-        Ok(self.tree.decrement(self.bor_tag))
-    }
-
-    pub fn access(
+    pub(crate) fn access(
         &mut self,
         global_ctx: &GlobalCtx,
         access_kind: AccessKind,
@@ -413,37 +455,39 @@ impl<'b> BorrowTracker<'b> {
             access_kind,
             AccessCause::Explicit(access_kind),
             &global_ctx.protected_tags(),
-            self.alloc_info.alloc_id.get(),
+            self.node.alloc_id(),
             span,
         )
     }
 
-    pub fn dealloc(mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
-        self.tree.take().dealloc(
+    pub(crate) fn dealloc(mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
+        let mut taken = self.tree.take();
+        taken.dealloc(
             self.bor_tag,
             self.range,
             &global_ctx.protected_tags(),
-            self.alloc_info.alloc_id.get(),
+            self.node.alloc_id(),
             span,
         )?;
-        let range = unsafe { self.alloc_info.range() };
+        let range = unsafe { self.node.range() };
         global_ctx.remove_exposed_provenance(range, true);
         Ok(())
     }
 
-    pub fn expose_tag(&mut self, global_ctx: &GlobalCtx) -> UBResult<()> {
+    pub(crate) fn expose_tag(&mut self, global_ctx: &GlobalCtx) -> UBResult<()> {
         let tag = self.bor_tag;
-        let range = unsafe { self.alloc_info.range() };
+        let range = unsafe { self.node.range() };
 
         // Ranges in the mapping must be non-empty, and a wildcard access can
         // never resolve to a zero-sized allocation anyway.
         if range.size > Size::ZERO {
             let mut exposed = global_ctx.exposed_provenance_mut();
             if let AccessType::Empty(pos) = exposed.access_type(range) {
-                exposed.insert_at_pos(pos, range, self.alloc_info);
+                exposed.insert_at_pos(pos, range, self.node);
             }
         }
 
+        self.tree.ensure_init(self.node.root_node_ptr());
         if self.tree.contains_tag(tag) {
             let protected = global_ctx.protected_tags().get_protector_kind(tag).is_some();
             self.tree.expose_tag(tag, protected);
@@ -451,21 +495,21 @@ impl<'b> BorrowTracker<'b> {
         Ok(())
     }
 
-    pub fn debug_take_snapshot(&self, ctx: &GlobalCtx) {
-        ctx.take_snapshot(self.alloc_info.alloc_id.get(), self.tree.clone());
+    pub(crate) fn debug_take_snapshot(&self, ctx: &GlobalCtx) {
+        ctx.take_snapshot(self.node.alloc_id(), self.tree.clone());
     }
 
-    pub fn debug_print_diff(&self, ctx: &GlobalCtx) {
-        ctx.with_snapshot(self.alloc_info.alloc_id.get(), |old_tree: &AllocStateImpl| {
+    pub(crate) fn debug_print_diff(&self, ctx: &GlobalCtx) {
+        ctx.with_snapshot(self.node.alloc_id(), |old_tree: &AllocStateImpl| {
             self.tree.print_tree_diff(old_tree, &ctx.protected_tags());
         });
     }
 
-    pub fn debug_print_tree(&self, ctx: &GlobalCtx, show_unnamed: bool) {
+    pub(crate) fn debug_print_tree(&self, ctx: &GlobalCtx, show_unnamed: bool) {
         self.tree.print_tree(&ctx.protected_tags(), show_unnamed);
     }
 
-    pub fn debug_tree_size(&self) -> usize {
+    pub(crate) fn debug_tree_size(&self) -> usize {
         self.tree.node_count()
     }
 }

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -10,6 +10,7 @@ use crate::errors::{ErrorFormatContext, UBInfo};
 use crate::helpers::FxHashMap;
 use crate::memory::Heap;
 use crate::tree_borrows::data_structures::{AccessType, RangeObjectMap};
+use crate::tree_borrows::tree::Node;
 use crate::tree_borrows::{AllocStateImpl, ProtectorKind};
 use crate::*;
 
@@ -63,20 +64,20 @@ impl<'a> Deref for ProtectedTagsRef<'a> {
     }
 }
 
-pub struct ExposedProvenanceRef<'a>(RwLockReadGuard<'a, RangeObjectMap<AllocInfoPtr>>);
+pub struct ExposedProvenanceRef<'a>(RwLockReadGuard<'a, RangeObjectMap<NodePtr>>);
 
 impl<'a> Deref for ExposedProvenanceRef<'a> {
-    type Target = RangeObjectMap<AllocInfoPtr>;
+    type Target = RangeObjectMap<NodePtr>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-pub struct ExposedProvenanceRefMut<'a>(RwLockWriteGuard<'a, RangeObjectMap<AllocInfoPtr>>);
+pub struct ExposedProvenanceRefMut<'a>(RwLockWriteGuard<'a, RangeObjectMap<NodePtr>>);
 
 impl<'a> Deref for ExposedProvenanceRefMut<'a> {
-    type Target = RangeObjectMap<AllocInfoPtr>;
+    type Target = RangeObjectMap<NodePtr>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -100,9 +101,9 @@ impl<'a> DerefMut for ExposedProvenanceRefMut<'a> {
 /// of unsafety throughout the library.
 pub struct GlobalCtx {
     protected_tags: RwLock<ProtectedTags>,
-    alloc_metadata_map: Heap<AllocInfo>,
+    alloc_metadata_map: Heap<RootNode>,
     snapshots: RwLock<FxHashMap<AllocId, AllocStateImpl>>,
-    exposed_provenance: RwLock<RangeObjectMap<AllocInfoPtr>>,
+    exposed_provenance: RwLock<RangeObjectMap<NodePtr>>,
 }
 
 impl GlobalCtx {
@@ -115,12 +116,15 @@ impl GlobalCtx {
         }
     }
 
-    pub(crate) fn create_alloc_info(&self, info: AllocInfo) -> NonNull<AllocInfo> {
-        self.alloc_metadata_map.alloc(info)
+    pub(crate) fn create_root_node(&self, info: RootNode) -> NonNull<Node> {
+        let root = self.alloc_metadata_map.alloc(info);
+        unsafe { RootNode::wire_state(root) };
+        RootNode::node_ptr(root)
     }
 
-    pub(crate) unsafe fn destroy_alloc_info(&self, ptr: NonNull<AllocInfo>) {
-        unsafe { self.alloc_metadata_map.dealloc(ptr) }
+    pub(crate) unsafe fn destroy_root_node(&self, node: NonNull<Node>) {
+        let root = unsafe { RootNode::from_node(node) };
+        unsafe { self.alloc_metadata_map.dealloc(root) }
     }
 
     pub fn protected_tags<'a>(&'a self) -> ProtectedTagsRef<'a> {
@@ -140,7 +144,7 @@ impl GlobalCtx {
         ExposedProvenanceRefMut(self.exposed_provenance.write())
     }
 
-    pub fn get_exposed_provenance(&self, range: AllocRange) -> Option<AllocInfoPtr> {
+    pub fn get_exposed_provenance(&self, range: AllocRange) -> Option<NodePtr> {
         // A zero-sized lookup (e.g. a deallocation, where the size of the access
         // is determined by the allocation) still needs to resolve the allocation
         // containing its start address, so we widen it to a single byte.

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -7,7 +7,6 @@
 
 #[macro_use]
 extern crate alloc;
-use core::cell::Cell;
 use core::ffi::c_void;
 use core::fmt::Debug;
 #[cfg(not(test))]
@@ -18,7 +17,6 @@ use core::{fmt, ptr, slice};
 
 mod borrow_tracker;
 use libc_print::std_name::*;
-use spin::Mutex;
 mod tree_borrows;
 
 mod global;
@@ -33,8 +31,7 @@ mod memory;
 use crate::helpers::{AllocRange, Size};
 use crate::sanitizer_common::Span;
 use crate::tree_borrows::perms::AccessKind;
-use crate::tree_borrows::tree::AllocStateImpl;
-use crate::tree_borrows::AllocState;
+use crate::tree_borrows::tree::Node;
 
 #[thread_local]
 #[unsafe(no_mangle)]
@@ -46,23 +43,23 @@ struct DebugSummary {
     op: &'static str,
     ptr: usize,
     bor_tag: BorTag,
-    info: AllocInfoSummary,
+    info: NodeSummary,
 }
 
 #[cfg(feature = "debug")]
 impl fmt::Display for DebugSummary {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.info {
-            AllocInfoSummary::Omnivalid => {
+            NodeSummary::Omnivalid => {
                 write!(f, "[{}] 0x{:x} @{:?} -> (omnivalid)", self.op, self.ptr, self.bor_tag)
             }
-            AllocInfoSummary::Wildcard => {
+            NodeSummary::Wildcard => {
                 write!(f, "[{}] 0x{:x} @{:?} -> (wildcard)", self.op, self.ptr, self.bor_tag)
             }
-            AllocInfoSummary::Null => {
+            NodeSummary::Null => {
                 write!(f, "[{}] 0x{:x} @{:?} -> (null)", self.op, self.ptr, self.bor_tag)
             }
-            AllocInfoSummary::Valid { alloc_id, base_addr, size } => write!(
+            NodeSummary::Valid { alloc_id, base_addr, size } => write!(
                 f,
                 "[{}] 0x{:x} @{:?} -> ({:?}, {:?}, {:?})",
                 self.op, self.ptr, self.bor_tag, alloc_id, base_addr, size
@@ -72,17 +69,25 @@ impl fmt::Display for DebugSummary {
 }
 
 macro_rules! debug_bsan {
-    ($op:literal, $p:ident, $bor_tag:ident, $alloc_info:expr) => {
+    ($op:literal, $p:ident, $prov:expr) => {
         #[cfg(feature = "debug")]
         {
             #[allow(unused_unsafe)]
-            let info = match $bor_tag.0 {
-                0 => AllocInfoSummary::Omnivalid,
-                1 => AllocInfoSummary::Null,
-                2 => AllocInfoSummary::Wildcard,
-                _ => unsafe { &*$alloc_info }.summarize(),
+            let prov: Provenance = $prov;
+            let bor_tag = prov.tag();
+            let info = if prov.is_omnivalid() {
+                NodeSummary::Omnivalid
+            } else if prov.is_invalid() {
+                NodeSummary::Null
+            } else if prov.is_wildcard() {
+                NodeSummary::Wildcard
+            } else {
+                unsafe {
+                    let root = RootNode::from_node(NonNull::new_unchecked(prov.node()));
+                    root.as_ref().summarize()
+                }
             };
-            let summary = DebugSummary { op: $op, ptr: 0, bor_tag: $bor_tag, info };
+            let summary = DebugSummary { op: $op, ptr: 0, bor_tag, info };
             libc_print::std_name::println!("{}", summary);
         }
     };
@@ -211,85 +216,97 @@ impl fmt::Debug for BorTag {
     }
 }
 
-#[repr(C)]
+/// One-word provenance: a single [`Node`] pointer.
+///
+/// Sentinel scheme (do not dereference):
+/// - null / address 0 = empty / omnivalid
+/// - address 1 = invalid
+/// - address 2 = wildcard
+///
+/// Concrete values are real `Node*` (child or root). Tag lives on [`Node`].
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct Provenance {
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-}
+pub struct Provenance(*mut Node);
 
 unsafe impl Sync for Provenance {}
 unsafe impl Send for Provenance {}
 
-#[derive(Clone, Copy)]
-pub(crate) union FreeListOrAddr {
-    pub base_addr: Size,
-    pub free_list_next: Option<NonNull<AllocInfo>>,
-}
-
-impl Debug for FreeListOrAddr {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:x}", unsafe { self.base_addr.bytes() })
+impl Provenance {
+    #[inline]
+    pub const fn omnivalid() -> Self {
+        Self(ptr::null_mut())
     }
-}
 
-/// Every allocation is associated with a "lock" object, which is an instance of `AllocInfo`.
-/// Provenance is the "key" to this lock. To validate a memory access, we compare the allocation ID
-/// of a pointer's provenance with the value stored in its corresponding `AllocInfo` object. If the values
-/// do not match, then the access is invalid. If they do match, then we proceed to validate the access against
-/// the tree for the allocation.
-#[repr(C)]
-pub struct AllocInfo {
-    alloc_id: Cell<AllocId>,
-    free_or_addr: Cell<FreeListOrAddr>,
-    size: Cell<Size>,
-    tree: Mutex<Option<AllocStateImpl>>,
-}
+    #[inline]
+    #[allow(clippy::manual_dangling_ptr)] // intentional sentinel addr 1, not a dangling tip
+    pub const fn invalid() -> Self {
+        Self(1 as *mut Node)
+    }
 
-impl AllocInfo {
-    fn invalid() -> Self {
-        AllocInfo {
-            alloc_id: Cell::new(AllocId::invalid()),
-            free_or_addr: Cell::new(FreeListOrAddr { base_addr: Size::ZERO }),
-            size: Cell::new(Size::ZERO),
-            tree: Mutex::default(),
+    #[inline]
+    #[allow(clippy::manual_dangling_ptr)] // intentional sentinel addr 2, not a dangling tip
+    pub const fn wildcard() -> Self {
+        Self(2 as *mut Node)
+    }
+
+    #[inline]
+    pub fn from_node(node: *mut Node) -> Self {
+        Self(node)
+    }
+
+    #[inline]
+    pub fn node(self) -> *mut Node {
+        self.0
+    }
+
+    #[inline]
+    pub fn is_omnivalid(self) -> bool {
+        self.0.is_null()
+    }
+
+    #[inline]
+    pub fn is_invalid(self) -> bool {
+        self.0 as usize == 1
+    }
+
+    #[inline]
+    pub fn is_wildcard(self) -> bool {
+        self.0 as usize == 2
+    }
+
+    /// Concrete heap `Node*` are 8-byte aligned (same as CRT `kMinProvAlignment`).
+    /// Unaligned addresses above the sentinel range are not concrete.
+    #[inline]
+    pub fn is_concrete(self) -> bool {
+        let addr = self.0 as usize;
+        addr > 2 && addr.is_multiple_of(8)
+    }
+
+    /// Tag for this provenance: sentinel tags for 0/1/2, else `node.tag`.
+    #[inline]
+    pub fn tag(self) -> BorTag {
+        if self.is_omnivalid() {
+            BorTag::omnivalid()
+        } else if self.is_invalid() {
+            BorTag::invalid()
+        } else if self.is_wildcard() {
+            BorTag::wildcard()
+        } else if !self.is_concrete() {
+            BorTag::omnivalid()
+        } else {
+            unsafe { (*self.0).tag }
         }
     }
-
-    fn new(base_addr: Size, size: Size, bor_tag: BorTag, span: Span) -> Self {
-        Self {
-            alloc_id: Cell::new(AllocId::default()),
-            free_or_addr: Cell::new(FreeListOrAddr { base_addr }),
-            size: Cell::new(size),
-            tree: Mutex::new(Some(AllocStateImpl::new(bor_tag, size, span))),
-        }
-    }
-
-    #[cfg(feature = "debug")]
-    fn summarize(&self) -> AllocInfoSummary {
-        AllocInfoSummary::Valid {
-            alloc_id: self.alloc_id,
-            base_addr: self.base_addr,
-            size: self.size,
-        }
-    }
 }
 
-/// A shallow version of `AllocInfo`, for use in debug logging.
+/// A shallow version of root-node metadata, for use in debug logging.
 #[cfg(feature = "debug")]
 #[derive(Debug)]
-pub(crate) enum AllocInfoSummary {
+pub(crate) enum NodeSummary {
     Omnivalid,
-    /// When Prov is wildcard, AllocInfo is invalid
     Wildcard,
-    /// When Prov is null, AllocInfo is invalid
     Null,
-    /// When Prov is valid, only drop the tree_lock field
-    Valid {
-        alloc_id: AllocId,
-        base_addr: FreeListAddrUnion,
-        size: Size,
-    },
+    Valid { alloc_id: AllocId, base_addr: Size, size: Size },
 }
 
 /// Initializes the global state of the runtime library.
@@ -346,15 +363,25 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
     im_len: usize,
     pin_data: Option<NonNull<[Size; 2]>>,
     pin_len: usize,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
+    node: *mut Node,
     dest: NonNull<Provenance>,
     pc: Span,
     checked: bool,
 ) {
-    debug_bsan!("retag", object_addr, bor_tag, alloc_info);
+    let prov = Provenance::from_node(node);
+    debug_bsan!("retag", ptr, prov);
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
+
+    // Sentinels and unaligned shadow noise must not go through
+    // `for_access_unchecked` (derefs Node*). Omnivalid/invalid: pass through.
+    // Unaligned garbage: treat as omnivalid. Wildcard still resolves below.
+    if !prov.is_concrete() && !prov.is_wildcard() {
+        let out =
+            if prov.is_omnivalid() || prov.is_invalid() { prov } else { Provenance::omnivalid() };
+        unsafe { dest.write(out) };
+        return;
+    }
+
     let opt_slice = |opt_ptr: Option<NonNull<[Size; 2]>>, len| -> Option<_> {
         opt_ptr.map(|ptr| unsafe { slice::from_raw_parts(ptr.as_ptr(), len) })
     };
@@ -366,7 +393,7 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
         pin_layout: opt_slice(pin_data, pin_len),
     };
 
-    let prov = if checked {
+    let prov = if checked && prov.is_concrete() {
         unsafe {
             BorrowTracker::for_access_unchecked(
                 ctx,
@@ -391,9 +418,10 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_protector_end_impl(bor_tag: BorTag, alloc_info: *mut AllocInfo, pc: Span) {
+extern "C" fn __bsan_protector_end_impl(node: *mut Node, pc: Span) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
+    let prov = Provenance::from_node(node);
+    let bor_tag = prov.tag();
     BorrowTracker::for_alloc_weak(prov, |mut bt| {
         let _ = bt.protector_end(ctx, pc);
     });
@@ -407,14 +435,13 @@ extern "C" fn __bsan_protector_end_impl(bor_tag: BorTag, alloc_info: *mut AllocI
 unsafe extern "C-unwind" fn __bsan_read_impl(
     ptr: *mut c_void,
     access_size: Size,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
+    node: *mut Node,
     pc: Span,
     checked: bool,
 ) {
-    debug_bsan!("read", ptr, bor_tag, alloc_info);
+    let prov = Provenance::from_node(node);
+    debug_bsan!("read", ptr, prov);
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
     if checked {
         unsafe {
             BorrowTracker::for_access_unchecked(
@@ -438,14 +465,13 @@ unsafe extern "C-unwind" fn __bsan_read_impl(
 unsafe extern "C-unwind" fn __bsan_write_impl(
     ptr: *mut c_void,
     access_size: Size,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
+    node: *mut Node,
     pc: Span,
     checked: bool,
 ) {
-    debug_bsan!("write", ptr, bor_tag, alloc_info);
+    let prov = Provenance::from_node(node);
+    debug_bsan!("write", ptr, prov);
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
     if checked {
         unsafe {
             BorrowTracker::for_access_unchecked(
@@ -464,37 +490,31 @@ unsafe extern "C-unwind" fn __bsan_write_impl(
     .unwrap_or_else(|err| ctx.handle_error(err, pc));
 }
 
-// Registers a heap allocation of size `size`, storing its provenance in the return pointer.
+// Registers a heap allocation of size `size`, returning a pointer to the inline root node.
 #[unsafe(no_mangle)]
 unsafe extern "C-unwind" fn __bsan_alloc_impl(
     base_addr: *mut c_void,
     size: Size,
     bor_tag: BorTag,
     pc: Span,
-) -> NonNull<AllocInfo> {
+) -> NonNull<Node> {
     let ctx = unsafe { global_ctx() };
     let range = AllocRange { start: Size::from_addr(base_addr), size };
     ctx.removing_exposed_provenance(range, false, || {
         #[allow(clippy::let_and_return)]
-        let alloc_info =
-            ctx.create_alloc_info(AllocInfo::new(Size::from_addr(base_addr), size, bor_tag, pc));
-        debug_bsan!("alloc", base_addr, bor_tag, alloc_info.as_ptr());
-        alloc_info
+        let node =
+            ctx.create_root_node(RootNode::new(Size::from_addr(base_addr), size, bor_tag, pc));
+        debug_bsan!("alloc", base_addr, Provenance::from_node(node.as_ptr()));
+        node
     })
 }
 
 /// Deregisters a heap allocation
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_dealloc(
-    ptr: *mut c_void,
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-    pc: Span,
-    checked: bool,
-) {
-    debug_bsan!("dealloc", ptr, bor_tag, alloc_info);
+extern "C" fn __bsan_dealloc(ptr: *mut c_void, node: *mut Node, pc: Span, checked: bool) {
+    let prov = Provenance::from_node(node);
+    debug_bsan!("dealloc", ptr, prov);
     let ctx = unsafe { global_ctx() };
-    let prov: Provenance = Provenance { bor_tag, alloc_info };
 
     if checked {
         unsafe {
@@ -509,65 +529,62 @@ extern "C" fn __bsan_dealloc(
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_dealloc_stack_impl(
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-    span: Span,
-) {
-    debug_bsan!("dealloc", ptr, bor_tag, alloc_info);
+unsafe extern "C-unwind" fn __bsan_dealloc_stack_impl(node: *mut Node, span: Span) {
+    let prov = Provenance::from_node(node);
+    debug_bsan!("dealloc", node, prov);
     let ctx = unsafe { global_ctx() };
-    let prov: Provenance = Provenance { bor_tag, alloc_info };
     BorrowTracker::for_alloc_weak(prov, |bt| {
         let _ = bt.dealloc(ctx, span);
     });
 }
 
-/// Increments the reference count associated with a provenance value.
+/// Increments the reference count on a concrete `Node*`.
 ///
 /// Returns `true` if the count transitioned from zero to one.
+/// Atomic on the named node; does not take the allocation mutex.
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_rc_inc_impl(
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) -> bool {
-    // A null `alloc_info` denotes an empty/cleared shadow slot (e.g. one whose
-    // info was nulled by `ClearShadow` while a stale tag lingered). There is no
-    // allocation to deref, so there is nothing to count.
-    if alloc_info.is_null() {
+unsafe extern "C-unwind" fn __bsan_rc_inc_impl(node: *mut Node) -> bool {
+    let prov = Provenance::from_node(node);
+    if !prov.is_concrete() {
         return false;
     }
-    let prov = Provenance { bor_tag, alloc_info };
-    BorrowTracker::for_alloc(prov, |bt| bt.increment()).unwrap_or(false)
+    unsafe { (*node).refcount.increment() }
 }
 
-/// Decrements the reference count associated with a provenance value.
+/// Decrements the reference count on a concrete `Node*`.
 ///
 /// Returns `true` if the count reached zero.
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_rc_dec_impl(
-    bor_tag: BorTag,
-    alloc_info: *mut AllocInfo,
-) -> bool {
-    // See `__bsan_rc_inc_impl`: a null `alloc_info` is an empty shadow slot with
-    // no live reference to release.
-    if alloc_info.is_null() {
+unsafe extern "C-unwind" fn __bsan_rc_dec_impl(node: *mut Node) -> bool {
+    let prov = Provenance::from_node(node);
+    if !prov.is_concrete() {
         return false;
     }
-    let prov = Provenance { bor_tag, alloc_info };
-    BorrowTracker::for_alloc(prov, |bt| bt.decrement()).unwrap_or(false)
+    unsafe { (*node).refcount.decrement() }
 }
 
-/// Reserves a stack slot for allocation metadata.
+/// Tag of a concrete [`Node`]. Must not be called on provenance sentinels.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_reserve_stack_slot_impl() -> NonNull<AllocInfo> {
-    unsafe { global_ctx().create_alloc_info(AllocInfo::invalid()) }
+unsafe extern "C" fn __bsan_node_tag_impl(node: *mut Node) -> BorTag {
+    unsafe { (*node).tag }
+}
+
+/// Reserves a stack slot for a [`RootNode`].
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __bsan_reserve_stack_slot_impl() -> NonNull<Node> {
+    unsafe { global_ctx().create_root_node(RootNode::invalid_stack()) }
 }
 
 #[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_destroy_stack_slot_impl(slot: NonNull<AllocInfo>) {
+unsafe extern "C" fn __bsan_destroy_stack_slot_impl(slot: NonNull<Node>) {
     let ctx = unsafe { global_ctx() };
     unsafe {
-        ctx.destroy_alloc_info(slot);
+        let root = RootNode::from_node(slot);
+        debug_assert!((*root.as_ptr()).on_stack);
+        // Clear borrow state, then return the slot to the free list.
+        drop(root.replace(RootNode::invalid_stack()));
+        RootNode::wire_state(root);
+        ctx.destroy_root_node(slot);
     }
 }
 
@@ -577,15 +594,20 @@ unsafe extern "C" fn __bsan_alloc_stack_impl(
     base_addr: *mut c_void,
     size: Size,
     bor_tag: BorTag,
-    alloc_info: NonNull<AllocInfo>,
+    node: NonNull<Node>,
     pc: Span,
 ) {
-    debug_bsan!("alloc_stack", base_addr, bor_tag, alloc_info.as_ptr());
+    debug_bsan!("alloc_stack", base_addr, Provenance::from_node(node.as_ptr()));
     let global_ctx = unsafe { global_ctx() };
     let start = Size::from_addr(base_addr);
     let range = AllocRange { start, size };
     global_ctx.removing_exposed_provenance(range, false, || unsafe {
-        alloc_info.write(AllocInfo::new(start, size, bor_tag, pc));
+        let root = RootNode::from_node(node);
+        let on_stack = (*root.as_ptr()).on_stack;
+        let mut fresh = RootNode::new(start, size, bor_tag, pc);
+        fresh.on_stack = on_stack;
+        root.write(fresh);
+        RootNode::wire_state(root);
     });
 }
 
@@ -593,9 +615,9 @@ unsafe extern "C" fn __bsan_alloc_stack_impl(
 /// pointer-to-integer cast), so that it can later be recovered when an
 /// integer is cast back to a pointer with wildcard provenance.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_expose_prov_impl(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+unsafe extern "C" fn __bsan_expose_prov_impl(node: *mut Node) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
+    let prov = Provenance::from_node(node);
     BorrowTracker::for_alloc_weak(prov, |mut bt| {
         let _ = bt.expose_tag(ctx);
     });
@@ -603,76 +625,67 @@ unsafe extern "C" fn __bsan_expose_prov_impl(bor_tag: BorTag, alloc_info: *mut A
 
 /// Prunes a series of nodes that are identified by the list of borrow tags.
 #[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_prune(
-    alloc_info: NonNull<AllocInfo>,
-    bor_tags: *mut BorTag,
-    len: usize,
-) -> bool {
-    let alloc: AllocInfoPtr = alloc_info.into();
+unsafe extern "C" fn __bsan_prune(node: NonNull<Node>, bor_tags: *mut BorTag, len: usize) -> bool {
     let dead_tags = unsafe { slice::from_raw_parts_mut(bor_tags, len) };
-    match alloc.tree.lock().as_mut() {
-        Some(tree) => tree.remove_dead_tags(dead_tags),
-        None => {
-            // The tree is already deallocated, so we can zero out dead_tags
-            dead_tags.fill(BorTag::omnivalid());
-            false
-        }
-    }
+    NodePtr::from(node).prune_dead_tags(dead_tags)
 }
 
-/// Deallocates an instance of [AllocInfo]. This instance must
-/// be unreachable from any provenance value in shadow memory.
+
+/// Frees a [`RootNode`] recovered from any node in the allocation.
+/// Must be unreachable from shadow. Stack roots are ignored (frame owns the slot
+/// until [`__bsan_destroy_stack_slot_impl`]).
 #[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_eject(alloc_info: NonNull<AllocInfo>) {
+unsafe extern "C" fn __bsan_eject(node: NonNull<Node>) {
     let ctx = unsafe { global_ctx() };
     unsafe {
-        // # Safety
-        // Normally, we would have to lock the instance prior
-        // to deallocating it. However, we can assume that it is no
-        // longer reachable in shadow memory, so it is not subject
-        // to races (at least, until it's been returned to the bump
-        // allocator by `destroy_alloc_info`).
-        drop(alloc_info.replace(AllocInfo::invalid()));
-        ctx.destroy_alloc_info(alloc_info);
+        // Unreachable from shadow, so safe until returned to the bump allocator.
+        let root = RootNode::from_node(node);
+        if (*root.as_ptr()).on_stack {
+            return;
+        }
+        drop(root.replace(RootNode::invalid()));
+        // Stale locks must see `BorrowState::None`, not a dangling mutex.
+        RootNode::wire_state(root);
+        ctx.destroy_root_node(RootNode::node_ptr(root));
     }
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_print(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
-    let prov = Provenance { bor_tag, alloc_info };
+extern "C" fn __bsan_print(node: *mut Node) {
+    let prov = Provenance::from_node(node);
     crate::println!("{prov:?}");
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_print_borrow_state(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_print_borrow_state(node: *mut Node) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
+    let prov = Provenance::from_node(node);
     BorrowTracker::for_alloc_weak(prov, |bt| {
         bt.debug_print_tree(ctx, false);
     });
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_tree_size(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
-    let prov = Provenance { bor_tag, alloc_info };
+extern "C" fn __bsan_tree_size(node: *mut Node) {
+    let prov = Provenance::from_node(node);
     BorrowTracker::for_alloc_weak(prov, |bt| {
         crate::println!("Tree size: {}", bt.debug_tree_size());
     });
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_snapshot(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_snapshot(node: *mut Node) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
+    let prov = Provenance::from_node(node);
     BorrowTracker::for_alloc_weak(prov, |bt| {
         bt.debug_take_snapshot(ctx);
     });
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn __bsan_print_diff(bor_tag: BorTag, alloc_info: *mut AllocInfo) {
+extern "C" fn __bsan_print_diff(node: *mut Node) {
     let ctx = unsafe { global_ctx() };
-    let prov = Provenance { bor_tag, alloc_info };
+    let prov = Provenance::from_node(node);
     BorrowTracker::for_alloc_weak(prov, |bt| bt.debug_print_diff(ctx));
 }
 

--- a/bsan-rt/src/memory/heap.rs
+++ b/bsan-rt/src/memory/heap.rs
@@ -195,7 +195,7 @@ mod test {
     use std::thread;
 
     use super::*;
-    use crate::AllocInfo;
+    use crate::RootNode;
 
     #[repr(align(8))]
     #[derive(Default)]
@@ -257,7 +257,7 @@ mod test {
     }
 
     #[test]
-    fn heapable_alloc_info() {
-        assert!(AllocInfo::is_heapable());
+    fn heapable_root_node() {
+        assert!(RootNode::is_heapable());
     }
 }

--- a/bsan-rt/src/memory/mod.rs
+++ b/bsan-rt/src/memory/mod.rs
@@ -13,7 +13,7 @@ use core::ptr::{self, NonNull};
 pub use heap::*;
 use libc::{pthread_attr_destroy, pthread_attr_init, pthread_attr_t, rlimit, _SC_PAGESIZE};
 
-use crate::{AllocInfo, BorTag};
+use crate::{BorTag, RootNode};
 
 pub const BSAN_PROT_FLAGS: i32 = libc::PROT_READ | libc::PROT_WRITE;
 #[cfg(not(miri))]
@@ -94,14 +94,14 @@ pub(crate) unsafe trait WordAligned: Sized {
         mem::align_of::<Self>() == mem::align_of::<usize>()
     }
 }
-unsafe impl WordAligned for AllocInfo {}
+unsafe impl WordAligned for RootNode {}
 unsafe impl WordAligned for BorTag {}
 
 /// # Safety
-/// Values of type `AllocInfo` can fit within the size of a heap chunk.
-unsafe impl Heapable for AllocInfo {
-    fn next(ptr: *mut AllocInfo) -> *mut Option<NonNull<AllocInfo>> {
-        unsafe { (&raw mut (*((*ptr).free_or_addr).as_ptr()).free_list_next) }
+/// Values of type `RootNode` can fit within the size of a heap chunk.
+unsafe impl Heapable for RootNode {
+    fn next(ptr: *mut RootNode) -> *mut Option<NonNull<RootNode>> {
+        unsafe { &raw mut (*ptr).free_list_next }
     }
 }
 

--- a/bsan-rt/src/tree_borrows/data_structures/unimap.rs
+++ b/bsan-rt/src/tree_borrows/data_structures/unimap.rs
@@ -381,7 +381,7 @@ mod tests {
     #[test]
     fn test_sizes() {
         use crate::tree_borrows::tree::{LocationState, Node};
-        assert_eq!(core::mem::size_of::<Node>(), 160);
+        assert_eq!(core::mem::size_of::<Node>(), 168);
         assert_eq!(core::mem::size_of::<LocationState>(), 3);
         #[cfg(feature = "smallvec-valmap")]
         {

--- a/bsan-rt/src/tree_borrows/diagnostics.rs
+++ b/bsan-rt/src/tree_borrows/diagnostics.rs
@@ -7,7 +7,7 @@ use core::ops::Range;
 use super::perms::{AccessKind, PermTransition, Permission, ProtectorKind};
 use super::tree::{node_ptr_from_map, node_tag, EagerTree, LocationState};
 use crate::helpers::AllocRange;
-use crate::tree_borrows::LazyTree;
+use crate::tree_borrows::BorrowState;
 use crate::{eprintln, *};
 
 /// Cause of an access: either a real access or one
@@ -964,26 +964,29 @@ impl EagerTree {
     }
 }
 
-impl LazyTree {
+impl BorrowState {
     pub fn print_tree(&self, protected_tags: &ProtectedTagsRef<'_>, show_unnamed: bool) {
         match self {
-            LazyTree::Init(tree) => tree.print_tree(protected_tags, show_unnamed),
-            LazyTree::Uninit { root_tag, size, span, .. } => {
+            BorrowState::None => {}
+            BorrowState::Init(tree) => tree.print_tree(protected_tags, show_unnamed),
+            BorrowState::Uninit { root_tag, size, span, .. } => {
                 EagerTree::new(*root_tag, *size, *span).print_tree(protected_tags, show_unnamed)
             }
         }
     }
 
-    pub fn print_tree_diff(&self, old_tree: &LazyTree, protected_tags: &ProtectedTagsRef<'_>) {
+    pub fn print_tree_diff(&self, old_tree: &BorrowState, protected_tags: &ProtectedTagsRef<'_>) {
         let self_tree = match self {
-            LazyTree::Init(t) => t.clone(),
-            LazyTree::Uninit { root_tag, size, span, .. } => {
+            BorrowState::None => return,
+            BorrowState::Init(t) => t.clone(),
+            BorrowState::Uninit { root_tag, size, span, .. } => {
                 EagerTree::new(*root_tag, *size, *span)
             }
         };
         let old_tree = match old_tree {
-            LazyTree::Init(t) => t.clone(),
-            LazyTree::Uninit { root_tag, size, span, .. } => {
+            BorrowState::None => return,
+            BorrowState::Init(t) => t.clone(),
+            BorrowState::Uninit { root_tag, size, span, .. } => {
                 EagerTree::new(*root_tag, *size, *span)
             }
         };

--- a/bsan-rt/src/tree_borrows/mod.rs
+++ b/bsan-rt/src/tree_borrows/mod.rs
@@ -19,7 +19,7 @@ pub use foreign_access_skipping::IdempotentForeignAccess;
 pub use perms::*;
 
 use self::perms::Permission;
-pub use self::tree::{AllocState, AllocStateImpl, LazyTree};
+pub use self::tree::{AllocState, AllocStateImpl, BorrowState};
 
 type GlobalState = ProtectedTags;
 

--- a/bsan-rt/src/tree_borrows/refcount.rs
+++ b/bsan-rt/src/tree_borrows/refcount.rs
@@ -1,9 +1,6 @@
 use core::sync::atomic::{fence, AtomicUsize, Ordering};
 
 /// A thread-safe reference count with correct atomic ordering semantics.
-// TODO: remove `allow(dead_code)` once the `__bsan_rc_inc`/`__bsan_rc_dec`
-// endpoints (lib.rs) actually drive this type.
-#[allow(dead_code)]
 #[derive(Debug)]
 #[repr(transparent)]
 pub struct RefCount(AtomicUsize);
@@ -15,15 +12,8 @@ impl Clone for RefCount {
     }
 }
 
-#[allow(dead_code)]
 impl RefCount {
     /// Creates a new `RefCount` initialized to 0.
-    ///
-    /// A freshly minted tag has no references yet: it is reachable only as a
-    /// root (live on a shadow stack) until a reference to it is written into
-    /// shadow *memory*, at which point [`Self::increment`] raises the count.
-    /// The runtime records every fresh tag in its thread's zero-count table as
-    /// a collection candidate (see `__bsan_retag`/`__bsan_alloc`).
     pub fn new() -> Self {
         Self(AtomicUsize::new(0))
     }
@@ -50,29 +40,6 @@ impl RefCount {
             true
         } else {
             false
-        }
-    }
-
-    /// Increments the reference count **without** atomic synchronization,
-    /// returning `true` if the count transitioned from zero to one.
-    pub fn increment_nonatomic(&self) -> bool {
-        unsafe {
-            let count = self.0.as_ptr();
-            debug_assert!(*count <= usize::MAX / 2, "RefCount overflow");
-            let was_zero = *count == 0;
-            *count += 1;
-            was_zero
-        }
-    }
-
-    /// Decrements the reference count **without** atomic synchronization,
-    /// returning `true` if the count reached zero.
-    pub fn decrement_nonatomic(&self) -> bool {
-        unsafe {
-            let count = self.0.as_ptr();
-            debug_assert!(*count > 0, "RefCount decremented below zero");
-            *count -= 1;
-            *count == 0
         }
     }
 

--- a/bsan-rt/src/tree_borrows/tree.rs
+++ b/bsan-rt/src/tree_borrows/tree.rs
@@ -796,8 +796,10 @@ impl EagerTree {
             // Node has exactly one child
             else if let Some(child_tag) = self.can_be_replaced_by_single_child_dead(tag) {
                 // Replace a node with its only child, if it is a root then we promote the child
-                // to a root
+                // to a root. Update the back-edge before the forward edge (same order as
+                // `remove_useless_children`) so the tree is never transiently inconsistent.
                 let child_ptr = node_ptr_from_map(&self.nodes, child_tag);
+                self.node_mut(child_tag).parent = parent;
                 match parent {
                     Some(parent_ptr) => {
                         let parent_tag = node_tag(parent_ptr);
@@ -810,7 +812,6 @@ impl EagerTree {
                         self.roots[pos] = child_tag;
                     }
                 }
-                self.node_mut(child_tag).parent = parent;
                 self.remove_useless_node(tag);
                 *entry = BorTag::omnivalid();
             }

--- a/bsan-rt/src/tree_borrows/tree.rs
+++ b/bsan-rt/src/tree_borrows/tree.rs
@@ -17,6 +17,7 @@ use core::ptr::NonNull;
 use core::{cmp, fmt, mem};
 
 use smallvec::SmallVec;
+use spin::Mutex;
 
 use super::data_structures::DedupRangeMap;
 use super::diagnostics::{
@@ -40,7 +41,7 @@ use crate::*;
 compile_error!("Only one of the following features can be selected: 'lazy', 'eager'");
 
 #[cfg(feature = "lazy")]
-pub type AllocStateImpl = LazyTree;
+pub type AllocStateImpl = BorrowState;
 
 #[cfg(feature = "eager")]
 pub type AllocStateImpl = EagerTree;
@@ -356,11 +357,22 @@ pub struct EagerTree {
     ///
     /// Has array size 2 because that still ensures the minimum size for SmallVec.
     pub(super) roots: SmallVec<[BorTag; 2]>,
+    /// Shared allocation-level borrow state mutex (same pointer as every `Node.state`).
+    pub(super) state: NonNull<Mutex<BorrowState>>,
+    /// When `Some`, this pointer is the inline root inside a `RootNode` and must not be
+    /// `Box`-deallocated. Test-only trees built via [`EagerTree::new`] leave this `None`.
+    inline_root: Option<NonNull<Node>>,
 }
 
 /// A node in the borrow tree. Each node is uniquely identified by a tag via
 /// the `nodes` map of `Tree`.
 #[derive(Debug)]
+/// A node in a Tree Borrows tree (root or child).
+///
+/// `#[repr(C)]` keeps `tag` first so the CRT `__bsan_node_tag` fallback
+/// (`*(BorTag*)node`) is sound when the Rust RT is not linked. Prefer
+/// `__bsan_node_tag_impl` when the RT is present.
+#[repr(C)]
 pub struct Node {
     /// The tag of this node.
     pub tag: BorTag,
@@ -381,11 +393,35 @@ pub struct Node {
     default_initial_idempotent_foreign_access: IdempotentForeignAccess,
     /// Whether a wildcard access could happen through this node.
     pub is_exposed: bool,
-    /// Number of live references to this node. Always accessed under the
-    /// allocation's tree `Mutex`.
+    /// Live shadow-slot references to this node (atomic; no tree mutex).
     pub refcount: RefCount,
+    /// Points at the allocation's shared [`BorrowState`] mutex (interior of the `RootNode`).
+    pub state: NonNull<Mutex<BorrowState>>,
     /// Some extra information useful only for debugging purposes.
     pub debug_info: NodeDebugInfo,
+}
+
+impl Node {
+    /// Builds the inline root node for a fresh allocation. `state` is wired after the
+    /// enclosing [`RootNode`] is placed in the heap.
+    pub(crate) fn new_root(tag: BorTag, span: Span) -> Self {
+        let root_default_perm = Permission::new_disabled();
+        Self {
+            tag,
+            parent: None,
+            children: SmallVec::default(),
+            default_initial_perm: root_default_perm,
+            default_initial_idempotent_foreign_access: IdempotentForeignAccess::None,
+            is_exposed: false,
+            refcount: RefCount::new(),
+            state: NonNull::dangling(),
+            debug_info: {
+                let mut debug_info = NodeDebugInfo::new(tag, root_default_perm, span);
+                debug_info.add_name("root of the allocation");
+                debug_info
+            },
+        }
+    }
 }
 
 impl EagerTree {
@@ -400,6 +436,9 @@ impl EagerTree {
 
 impl EagerTree {
     /// Create a new tree, with only a root pointer.
+    ///
+    /// Test/debug helper: the root is heap-allocated and freed with the tree (`inline_root` is
+    /// `None`). Production allocations use [`EagerTree::from_inline_root`] instead.
     pub fn new(root_tag: BorTag, size: Size, span: Span) -> Self {
         // The root has `Disabled` as the default permission,
         // so that any access out of bounds is invalid.
@@ -413,6 +452,7 @@ impl EagerTree {
             default_initial_idempotent_foreign_access: IdempotentForeignAccess::None,
             is_exposed: false,
             refcount: RefCount::new(),
+            state: NonNull::dangling(),
             debug_info: {
                 let mut debug_info = NodeDebugInfo::new(root_tag, root_default_perm, span);
                 // name the root so that all allocations contain one named pointer
@@ -421,6 +461,22 @@ impl EagerTree {
             },
         };
         let root_ptr = alloc_node(root_node);
+        Self::from_root_ptr(root_ptr, size, NonNull::dangling(), None)
+    }
+
+    /// Builds a tree around an existing inline root node (owned by a `RootNode`).
+    pub(crate) fn from_inline_root(root_ptr: NonNull<Node>, size: Size) -> Self {
+        let state = unsafe { root_ptr.as_ref().state };
+        Self::from_root_ptr(root_ptr, size, state, Some(root_ptr))
+    }
+
+    fn from_root_ptr(
+        root_ptr: NonNull<Node>,
+        size: Size,
+        state: NonNull<Mutex<BorrowState>>,
+        inline_root: Option<NonNull<Node>>,
+    ) -> Self {
+        let root_tag = unsafe { root_ptr.as_ref().tag };
         let locations = {
             let mut perms = FxHashMap::default();
             // We manually set it to `Unique` on all in-bounds positions.
@@ -439,13 +495,21 @@ impl EagerTree {
         };
         let mut nodes = NodeMap::default();
         nodes.insert(root_tag, root_ptr);
-        Self { roots: SmallVec::from_slice(&[root_tag]), nodes, locations }
+        Self { roots: SmallVec::from_slice(&[root_tag]), nodes, locations, state, inline_root }
     }
 }
 
 impl Drop for EagerTree {
     fn drop(&mut self) {
+        // Snapshot/debug trees (`inline_root == None`) own every boxed node and free them.
+        // Production trees wrap an inline root inside a `RootNode`: child boxes may still be
+        // named by shadow provenance, so they are freed only by `remove_useless_node` after
+        // RC hits 0 — never here.
+        let standalone = self.inline_root.is_none();
         for (_, ptr) in self.nodes.drain() {
+            if !standalone {
+                continue;
+            }
             dealloc_node(ptr);
         }
     }
@@ -465,6 +529,7 @@ impl Clone for EagerTree {
                     .default_initial_idempotent_foreign_access,
                 is_exposed: old.is_exposed,
                 refcount: old.refcount.clone(),
+                state: old.state,
                 debug_info: old.debug_info.clone(),
             });
             nodes.insert(tag, new_ptr);
@@ -489,7 +554,8 @@ impl Clone for EagerTree {
                 loc.perms.insert(new_ptr, state);
             }
         }
-        Self { nodes, locations, roots: self.roots.clone() }
+        // Clones are fully owned heaps (snapshots); nothing is inline.
+        Self { nodes, locations, roots: self.roots.clone(), state: self.state, inline_root: None }
     }
 }
 
@@ -635,11 +701,10 @@ impl EagerTree {
         Some(child_idx)
     }
 
-    /// Properly removes a node.
-    /// The node to be removed should not otherwise be usable. It also
-    /// should have no children, but this is not checked, so that nodes
-    /// whose children were rotated somewhere else can be deleted without
-    /// having to first modify them to clear that array.
+    /// Unlinks `tag` from the node map and frees its box when it is not the
+    /// inline root. Production child boxes are freed only through this path,
+    /// and only after the GC caller has checked `refcount == 0` and unlinked
+    /// the node from its parent (see `remove_useless_children_dead`).
     fn remove_useless_node(&mut self, tag: BorTag) {
         let Some(ptr) = self.nodes.remove(&tag) else {
             return;
@@ -648,7 +713,9 @@ impl EagerTree {
             loc.perms.remove(&ptr);
             loc.exposed_cache.remove(tag);
         }
-        dealloc_node(ptr);
+        if self.inline_root != Some(ptr) {
+            dealloc_node(ptr);
+        }
     }
 
     /// Traverses the entire tree looking for useless tags.
@@ -1152,7 +1219,7 @@ impl LocationTree {
 }
 
 impl Node {
-    pub fn default_location_state(&self) -> LocationState {
+    pub(crate) fn default_location_state(&self) -> LocationState {
         LocationState::new_non_accessed(
             self.default_initial_perm,
             self.default_initial_idempotent_foreign_access,
@@ -1160,29 +1227,37 @@ impl Node {
     }
 }
 
-/// A tree that is lazily initialized: starts as `Uninit` (storing only the root tag, size, and
-/// span needed to construct the real `Tree` on demand), and transitions to `Init` the first
-/// time a child is added via `new_child`. All operations on a single-node tree short-circuit
-/// without ever allocating the underlying `Tree`.
+/// Allocation-level borrow state: starts empty or uninitialized, and transitions to
+/// `Init` the first time a child is added via `new_child`. All operations on a
+/// single-node tree short-circuit without ever allocating the underlying `EagerTree`.
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub enum LazyTree {
-    Uninit { root_tag: BorTag, size: Size, span: Span, refcount: RefCount },
+pub enum BorrowState {
+    /// Allocation metadata has been freed or not yet installed.
+    None,
+    Uninit {
+        root_tag: BorTag,
+        size: Size,
+        span: Span,
+    },
     Init(EagerTree),
 }
 
-impl LazyTree {
+impl BorrowState {
     pub fn new(root_tag: BorTag, size: Size, span: Span) -> Self {
-        LazyTree::Uninit { root_tag, size, span, refcount: RefCount::new() }
+        BorrowState::Uninit { root_tag, size, span }
     }
 
-    /// Forces the tree into the `Init` state, constructing the underlying `Tree` if needed.
-    fn ensure_init(&mut self) {
-        if let LazyTree::Uninit { root_tag, size, span, refcount } = self {
-            let mut tree = EagerTree::new(*root_tag, *size, *span);
-            tree.node_mut(*root_tag).refcount = refcount.clone();
-            *self = LazyTree::Init(tree);
+    /// Forces the tree into the `Init` state around the given inline root node.
+    pub(crate) fn ensure_init(&mut self, root: NonNull<Node>) {
+        if let BorrowState::Uninit { size, .. } = *self {
+            let tree = EagerTree::from_inline_root(root, size);
+            *self = BorrowState::Init(tree);
         }
+    }
+
+    pub(crate) fn is_live(&self) -> bool {
+        !matches!(self, BorrowState::None)
     }
 }
 
@@ -1212,8 +1287,6 @@ impl AccessRelatedness {
 pub trait AllocState: Clone {
     fn contains_tag(&self, tag: BorTag) -> bool;
     fn node_count(&self) -> usize;
-    fn increment(&self, tag: BorTag) -> bool;
-    fn decrement(&self, tag: BorTag) -> bool;
     fn new_child(
         &mut self,
         base_offset: Size,
@@ -1223,7 +1296,8 @@ pub trait AllocState: Clone {
         outside_perm: Permission,
         protected: bool,
         span: Span,
-    ) -> UBResult<()>;
+        root: NonNull<Node>,
+    ) -> UBResult<NonNull<Node>>;
     fn perform_access(
         &mut self,
         tag: BorTag,
@@ -1256,17 +1330,19 @@ pub trait AllocState: Clone {
     fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool;
 }
 
-impl AllocState for LazyTree {
+impl AllocState for BorrowState {
     fn contains_tag(&self, tag: BorTag) -> bool {
         match self {
-            LazyTree::Uninit { root_tag, .. } => *root_tag == tag,
-            LazyTree::Init(tree) => tree.nodes.contains_key(&tag),
+            BorrowState::None => false,
+            BorrowState::Uninit { root_tag, .. } => *root_tag == tag,
+            BorrowState::Init(tree) => tree.nodes.contains_key(&tag),
         }
     }
     fn node_count(&self) -> usize {
         match self {
-            LazyTree::Uninit { .. } => 1,
-            LazyTree::Init(tree) => tree.nodes.len(),
+            BorrowState::None => 0,
+            BorrowState::Uninit { .. } => 1,
+            BorrowState::Init(tree) => tree.nodes.len(),
         }
     }
     fn new_child(
@@ -1278,9 +1354,10 @@ impl AllocState for LazyTree {
         outside_perm: Permission,
         protected: bool,
         span: Span,
-    ) -> UBResult<()> {
-        self.ensure_init();
-        let LazyTree::Init(tree) = self else { unreachable!() };
+        root: NonNull<Node>,
+    ) -> UBResult<NonNull<Node>> {
+        self.ensure_init(root);
+        let BorrowState::Init(tree) = self else { unreachable!() };
         tree.new_child(
             base_offset,
             parent_tag,
@@ -1302,8 +1379,8 @@ impl AllocState for LazyTree {
         span: Span,
     ) -> UBResult<()> {
         match self {
-            LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.perform_access(
+            BorrowState::None | BorrowState::Uninit { .. } => Ok(()),
+            BorrowState::Init(tree) => tree.perform_access(
                 tag,
                 access_range,
                 access_kind,
@@ -1323,8 +1400,8 @@ impl AllocState for LazyTree {
         span: Span,
     ) -> UBResult<()> {
         match self {
-            LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.dealloc(tag, access_range, global, alloc_id, span),
+            BorrowState::None | BorrowState::Uninit { .. } => Ok(()),
+            BorrowState::Init(tree) => tree.dealloc(tag, access_range, global, alloc_id, span),
         }
     }
     fn perform_protector_end_access(
@@ -1335,51 +1412,37 @@ impl AllocState for LazyTree {
         span: Span,
     ) -> UBResult<()> {
         match self {
-            LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.perform_protector_end_access(tag, global, alloc_id, span),
+            BorrowState::None | BorrowState::Uninit { .. } => Ok(()),
+            BorrowState::Init(tree) => {
+                tree.perform_protector_end_access(tag, global, alloc_id, span)
+            }
         }
     }
     fn expose_tag(&mut self, tag: BorTag, protected: bool) {
-        self.ensure_init();
-        if let LazyTree::Init(tree) = self {
+        // Caller must `ensure_init` first (see BorrowTracker::expose_tag).
+        if let BorrowState::Init(tree) = self {
             tree.expose_tag(tag, protected);
         }
     }
     fn remove_unreachable_tags(&mut self, live_tags: &FxHashSet<BorTag>) {
-        if let LazyTree::Init(tree) = self {
+        if let BorrowState::Init(tree) = self {
             tree.remove_unreachable_tags(live_tags);
         }
     }
     fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
         match self {
-            LazyTree::Init(tree) => tree.remove_dead_tags(dead_tags),
-            LazyTree::Uninit { root_tag, refcount, .. } => {
-                // A tree in the Uninit state only has a single node (the root). If
-                // this node is in the dead list with a zero reference count, then the
-                // tree is dead and the associated AllocInfo metadata can be freed.
-                let root_is_dead = refcount.get() == 0 && dead_tags.contains(root_tag);
+            BorrowState::None => {
+                dead_tags.fill(BorTag::omnivalid());
+                false
+            }
+            BorrowState::Init(tree) => tree.remove_dead_tags(dead_tags),
+            BorrowState::Uninit { root_tag, .. } => {
+                // Uninit has only the root. If it is in the dead list, the RootNode may be freed.
+                // Refcount lives on the inline Node; ZCT insert already saw RC==0.
+                let root_is_dead = dead_tags.contains(root_tag);
                 dead_tags.fill(BorTag::omnivalid());
                 root_is_dead
             }
-        }
-    }
-    fn increment(&self, tag: BorTag) -> bool {
-        match self {
-            LazyTree::Uninit { root_tag, refcount, .. } => {
-                // In the Uninit state the only node is the root, we add an debug_assert instead
-                debug_assert!(*root_tag == tag);
-                refcount.increment_nonatomic()
-            }
-            LazyTree::Init(tree) => tree.increment(tag),
-        }
-    }
-    fn decrement(&self, tag: BorTag) -> bool {
-        match self {
-            LazyTree::Uninit { root_tag, refcount, .. } => {
-                debug_assert!(*root_tag == tag);
-                refcount.decrement_nonatomic()
-            }
-            LazyTree::Init(tree) => tree.decrement(tag),
         }
     }
 }
@@ -1400,7 +1463,81 @@ impl AllocState for EagerTree {
         outside_perm: Permission,
         protected: bool,
         span: Span,
+        _root: NonNull<Node>,
+    ) -> UBResult<NonNull<Node>> {
+        EagerTree::new_child(
+            self,
+            base_offset,
+            parent_tag,
+            new_tag,
+            inside_perms,
+            outside_perm,
+            protected,
+            span,
+        )
+    }
+    fn perform_access(
+        &mut self,
+        tag: BorTag,
+        access_range: AllocRange,
+        access_kind: AccessKind,
+        access_cause: AccessCause,
+        global: &GlobalState,
+        alloc_id: AllocId,
+        span: Span,
     ) -> UBResult<()> {
+        EagerTree::perform_access(
+            self,
+            tag,
+            access_range,
+            access_kind,
+            access_cause,
+            global,
+            alloc_id,
+            span,
+        )
+    }
+    fn dealloc(
+        &mut self,
+        tag: BorTag,
+        access_range: AllocRange,
+        global: &GlobalState,
+        alloc_id: AllocId,
+        span: Span,
+    ) -> UBResult<()> {
+        EagerTree::dealloc(self, tag, access_range, global, alloc_id, span)
+    }
+    fn perform_protector_end_access(
+        &mut self,
+        tag: BorTag,
+        global: &GlobalState,
+        alloc_id: AllocId,
+        span: Span,
+    ) -> UBResult<()> {
+        EagerTree::perform_protector_end_access(self, tag, global, alloc_id, span)
+    }
+    fn expose_tag(&mut self, tag: BorTag, protected: bool) {
+        EagerTree::expose_tag(self, tag, protected)
+    }
+    fn remove_unreachable_tags(&mut self, live_tags: &FxHashSet<BorTag>) {
+        EagerTree::remove_unreachable_tags(self, live_tags)
+    }
+    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
+        EagerTree::remove_dead_tags(self, dead_tags)
+    }
+}
+
+impl EagerTree {
+    pub(super) fn new_child(
+        &mut self,
+        base_offset: Size,
+        parent_tag: BorTag,
+        new_tag: BorTag,
+        inside_perms: DedupRangeMap<LocationState>,
+        outside_perm: Permission,
+        protected: bool,
+        span: Span,
+    ) -> UBResult<NonNull<Node>> {
         let parent_ptr = if parent_tag.is_wildcard() {
             None
         } else {
@@ -1418,6 +1555,7 @@ impl AllocState for EagerTree {
             default_initial_idempotent_foreign_access: default_strongest_idempotent,
             is_exposed: false,
             refcount: RefCount::new(),
+            state: self.state,
             debug_info: NodeDebugInfo::new(new_tag, outside_perm, span),
         });
         self.nodes.insert(new_tag, new_ptr);
@@ -1450,9 +1588,10 @@ impl AllocState for EagerTree {
             self.update_idempotent_foreign_access_after_retag(parent_tag, min_sifa);
         }
 
-        Ok(())
+        Ok(new_ptr)
     }
-    fn perform_access(
+
+    pub(super) fn perform_access(
         &mut self,
         tag: BorTag,
         access_range: AllocRange,
@@ -1490,7 +1629,8 @@ impl AllocState for EagerTree {
         }
         Ok(())
     }
-    fn dealloc(
+
+    pub(super) fn dealloc(
         &mut self,
         tag: BorTag,
         access_range: AllocRange,
@@ -1562,7 +1702,8 @@ impl AllocState for EagerTree {
         }
         Ok(())
     }
-    fn perform_protector_end_access(
+
+    pub(super) fn perform_protector_end_access(
         &mut self,
         tag: BorTag,
         global: &GlobalState,
@@ -1616,31 +1757,34 @@ impl AllocState for EagerTree {
         Ok(())
     }
 
-    fn expose_tag(&mut self, tag: BorTag, protected: bool) {
-        EagerTree::expose_tag(self, tag, protected);
-    }
-
-    fn remove_unreachable_tags(&mut self, live_tags: &FxHashSet<BorTag>) {
+    pub(super) fn remove_unreachable_tags(&mut self, live_tags: &FxHashSet<BorTag>) {
         for i in 0..(self.roots.len()) {
             self.remove_useless_children(self.roots[i], live_tags);
         }
         self.locations.merge_adjacent_thorough();
     }
-    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
+
+    pub(super) fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
         self.remove_useless_children_dead(dead_tags);
         self.locations.merge_adjacent_thorough();
         self.roots.is_empty()
     }
-    fn increment(&self, tag: BorTag) -> bool {
+
+    /// Tag-keyed RC helpers for unit tests. Production RC goes through
+    /// `__bsan_rc_inc/dec` on the stored `Node*` directly.
+    #[cfg(test)]
+    pub(super) fn increment(&self, tag: BorTag) -> bool {
         self.nodes
             .get(&tag)
-            .map(|ptr| unsafe { ptr.as_ref().refcount.increment_nonatomic() })
+            .map(|ptr| unsafe { ptr.as_ref().refcount.increment() })
             .unwrap_or(false)
     }
-    fn decrement(&self, tag: BorTag) -> bool {
+
+    #[cfg(test)]
+    pub(super) fn decrement(&self, tag: BorTag) -> bool {
         self.nodes
             .get(&tag)
-            .map(|ptr| unsafe { ptr.as_ref().refcount.decrement_nonatomic() })
+            .map(|ptr| unsafe { ptr.as_ref().refcount.decrement() })
             .unwrap_or(false)
     }
 }

--- a/tests/pass/inline_asm.run.stdout
+++ b/tests/pass/inline_asm.run.stdout
@@ -1,1 +1,1 @@
-Provenance { bor_tag: <TAG>(unprotected), alloc_info: 0x0 }
+Provenance(0x2)


### PR DESCRIPTION
## WIP 🚧

- Provenance is `*mut Node` (sentinels 0/1/2); RC is atomic on `Node`.
- Pass/shadow store one 8-byte word; former ORIGIN VA ranges are INVALID.
- Shadow Copy/Move/Clear/Write operate on one `Node*` slot; RC uses inc-before-dec (#283).
- Null pointer constants get invalid provenance (#291).

```rust
pub(crate) struct RootNode {
    pub(crate) node: Node,
    pub(crate) alloc_id: Cell<AllocId>,
    pub(crate) base_addr: Cell<Size>,
    pub(crate) size: Cell<Size>,
    pub(crate) state: Mutex<BorrowState>,
    pub(crate) free_list_next: Option<NonNull<RootNode>>,
    pub(crate) on_stack: bool,
}

pub enum BorrowState {
    None,
    Uninit { root_tag: BorTag, size: Size, span: Span },
    Init(EagerTree),
}
```