### PR TITLE
Key GC cleanup by root Node* (OWP#3)

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -33,7 +33,7 @@ void GlobalContext::MergeZeroCounts(const uptr, BsanThread *const &thread,
   // count table, then we can drain its contents for garbage collection.
   if (!thread->ZctBusy()) {
     // Move unreachable tags into pending; keep live ones in this thread's ZCT.
-    // Match on the ZCT entry's tag under its Node* key.
+    // Keys are alloc roots; match on the ZCT entry's tag, not root.tag.
     thread->zero_count_set_.retainIf([&](Node *node, BorTag tag) -> bool {
       if (snap->live->contains(node, tag)) {
         return true;
@@ -70,6 +70,7 @@ void GlobalContext::SnapshotCallback(const SuspendedThreadsList &, void *arg) {
 void GlobalContext::CollectGarbage(Snapshot &snap) {
   InternalMmapVector<RetiredAlloc> filtered;
   // Eject retired RootNode slots unreachable as of snap.min_drained.
+  // Quarantine / pending keys are already alloc roots.
   for (uptr i = 0; i < quarantine_.size(); ++i) {
     RetiredAlloc retired = quarantine_[i];
     if (retired.retire_gen <= snap.min_drained) {

--- a/bsan-rt/llvm-wrapper/bsan_interface_internal.h
+++ b/bsan-rt/llvm-wrapper/bsan_interface_internal.h
@@ -69,6 +69,11 @@ bool __bsan_prune(Node *node, BorTag *tags, uptr len);
 SANITIZER_WEAK_ATTRIBUTE
 void __bsan_eject(Node *node);
 
+// Inline root Node* for the allocation containing `node` (RootNode::from_node
+// → RootNode::node_ptr). Used to canonicalize ZCT / live / pending map keys.
+SANITIZER_WEAK_ATTRIBUTE
+Node *__bsan_alloc_root(Node *node);
+
 } // extern "C"
 
 #endif

--- a/bsan-rt/llvm-wrapper/bsan_set.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_set.cpp
@@ -1,7 +1,17 @@
 #include "bsan_set.h"
 #include "bsan.h"
+#include "bsan_interface_internal.h"
 
 namespace __bsan {
+
+// Map keys are the allocation's inline root Node*. Shadow / RC still pass
+// child Node*; canonicalize before every DenseMap op.
+static Node *AllocRoot(Node *node) {
+  if (!ProvIsConcrete(node) || !__bsan_alloc_root)
+    return node;
+  Node *root = __bsan_alloc_root(node);
+  return root ? root : node;
+}
 
 uptr BorTagSet::lowerBound(BorTag Tag) const {
   // Binary search over the elements of the array
@@ -69,7 +79,7 @@ void ConcreteProvenanceSet::insertTag(Node *node, BorTag tag) {
   if (!ProvIsConcrete(node)) {
     return;
   }
-  set_[node].insert(tag);
+  set_[AllocRoot(node)].insert(tag);
 }
 
 void ConcreteProvenanceSet::remove(Provenance prov) {
@@ -112,7 +122,7 @@ BorTagSet *ConcreteProvenanceSet::find(Node *node) {
   if (!ProvIsConcrete(node)) {
     return nullptr;
   }
-  auto *KV = set_.find(node);
+  auto *KV = set_.find(AllocRoot(node));
   return KV ? &KV->second : nullptr;
 }
 
@@ -120,7 +130,7 @@ const BorTagSet *ConcreteProvenanceSet::find(Node *node) const {
   if (!ProvIsConcrete(node)) {
     return nullptr;
   }
-  const auto *KV = set_.find(node);
+  const auto *KV = set_.find(AllocRoot(node));
   return KV ? &KV->second : nullptr;
 }
 

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -73,12 +73,14 @@ public:
 
   void insert(Provenance Prov);
   void remove(Provenance Prov);
-  // Insert (node, tag) without reading node->tag (GC re-queue).
+  // Insert (node, tag) without reading node->tag (GC re-queue). Keyed by alloc
+  // root.
   void insertTag(Node *node, BorTag tag);
 
   void clear();
+  // Per-tag lookup under the alloc root.
   bool contains(Provenance prov);
-  // Explicit tag (MergeZeroCounts keeps node and tag separate).
+  // Explicit tag when the key is already an alloc root (MergeZeroCounts).
   bool contains(Node *node, BorTag tag);
 
   void swap(ConcreteProvenanceSet &other) { set_.swap(other.set_); }
@@ -107,10 +109,12 @@ public:
     });
   }
 
+  // Lookup by any Node* in the allocation (canonicalized to inline root).
   BorTagSet *find(Node *node);
   const BorTagSet *find(Node *node) const;
 
 private:
+  // Keyed by alloc-root Node*; values are live/pending/ZCT tags for that alloc.
   DenseMap<Node *, BorTagSet> set_;
 };
 

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -630,6 +630,18 @@ unsafe extern "C" fn __bsan_prune(node: NonNull<Node>, bor_tags: *mut BorTag, le
     NodePtr::from(node).prune_dead_tags(dead_tags)
 }
 
+/// Inline root [`Node`] for the allocation containing `node`.
+/// Canonicalizes ZCT / live / pending map keys to one entry per allocation.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn __bsan_alloc_root(node: *mut Node) -> *mut Node {
+    if node.is_null() {
+        return core::ptr::null_mut();
+    }
+    unsafe {
+        let root = RootNode::from_node(NonNull::new_unchecked(node));
+        RootNode::node_ptr(root).as_ptr()
+    }
+}
 
 /// Frees a [`RootNode`] recovered from any node in the allocation.
 /// Must be unreachable from shadow. Stack roots are ignored (frame owns the slot


### PR DESCRIPTION
Shadow/RC still pass child `Node*`; ZCT/live/pending keys canonicalize via `__bsan_alloc_root`

hashbrown@0.17.0 (aarch64-unknown-linux-gnu), 103 tests, mean relative execution time:

| Mode | vs native | vs miri-tb |
|------|----------:|-----------:|
| full | 654× | 0.246× |
| no-op | 7.50× | 0.0029× |