### PR TITLE
Added carets to error messages to indicate the column location.

### DIFF
--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -135,8 +135,9 @@ impl ErrorFormatContext {
                     .entry(path.clone())
                     .or_insert_with(|| SanitizerCommon::read_file(&path).unwrap_or_default());
                 if let Some(content_raw) = SanitizerCommon::get_source_line(file, line) {
-                    let content = content_raw.trim();
+                    let content = content_raw.trim_start();
                     let trimmed_ws_diff = content_raw.len() - content.len();
+                    let content = content.trim_end();
 
                     let line = line.to_string();
                     let line_indent_len = max(indentation, line.len()) - line.len();
@@ -146,16 +147,9 @@ impl ErrorFormatContext {
                     buffer.push_str(&format!("{line_indent}{line} | {content}\n"));
 
                     let col = col as usize;
-                    if trimmed_ws_diff > col {
-                        // For some reason, the column offset points into whitespace.
-                        // There's an error in the symbolizer or instrumentation that is
-                        // beyond our control at this point, so we skip printing the caret.
-                        buffer.push_str(&format!("{max_indent} |\n",));
-                    } else {
-                        let offset = col.saturating_sub(trimmed_ws_diff).saturating_sub(1);
-                        let column_repeat = " ".repeat(offset);
-                        buffer.push_str(&format!("{max_indent} | {column_repeat}^\n",));
-                    }
+                    let offset = col.saturating_sub(trimmed_ws_diff).saturating_sub(1);
+                    let column_repeat = " ".repeat(offset);
+                    buffer.push_str(&format!("{max_indent} | {column_repeat}^\n",));
                 }
             }
             Symbol::Unresolved { pc } => {

--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -135,14 +135,12 @@ impl ErrorFormatContext {
                     .entry(path.clone())
                     .or_insert_with(|| SanitizerCommon::read_file(&path).unwrap_or_default());
                 if let Some(content_raw) = SanitizerCommon::get_source_line(file, line) {
-
                     let content = content_raw.trim();
                     let trimmed_ws_diff = content_raw.len() - content.len();
-                    
+
                     let line = line.to_string();
                     let line_indent_len = max(indentation, line.len()) - line.len();
                     let line_indent = " ".repeat(line_indent_len);
-
 
                     buffer.push_str(&format!("{max_indent} |\n",));
                     buffer.push_str(&format!("{line_indent}{line} | {content}\n"));
@@ -153,11 +151,8 @@ impl ErrorFormatContext {
                         // There's an error in the symbolizer or instrumentation that is
                         // beyond our control at this point, so we skip printing the caret.
                         buffer.push_str(&format!("{max_indent} |\n",));
-                    }else{
-                        let mut offset = col - trimmed_ws_diff;
-                        if offset > 0 {
-                            offset -= 1;
-                        }
+                    } else {
+                        let offset = col.saturating_sub(trimmed_ws_diff).saturating_sub(1);
                         let column_repeat = " ".repeat(offset);
                         buffer.push_str(&format!("{max_indent} | {column_repeat}^\n",));
                     }

--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -134,14 +134,33 @@ impl ErrorFormatContext {
                     .file_cache
                     .entry(path.clone())
                     .or_insert_with(|| SanitizerCommon::read_file(&path).unwrap_or_default());
-                if let Some(content) = SanitizerCommon::get_source_line(file, line) {
+                if let Some(content_raw) = SanitizerCommon::get_source_line(file, line) {
+
+                    let content = content_raw.trim();
+                    let trimmed_ws_diff = content_raw.len() - content.len();
+                    
                     let line = line.to_string();
                     let line_indent_len = max(indentation, line.len()) - line.len();
                     let line_indent = " ".repeat(line_indent_len);
 
+
                     buffer.push_str(&format!("{max_indent} |\n",));
                     buffer.push_str(&format!("{line_indent}{line} | {content}\n"));
-                    buffer.push_str(&format!("{max_indent} |\n",));
+
+                    let col = col as usize;
+                    if trimmed_ws_diff > col {
+                        // For some reason, the column offset points into whitespace.
+                        // There's an error in the symbolizer or instrumentation that is
+                        // beyond our control at this point, so we skip printing the caret.
+                        buffer.push_str(&format!("{max_indent} |\n",));
+                    }else{
+                        let mut offset = col - trimmed_ws_diff;
+                        if offset > 0 {
+                            offset -= 1;
+                        }
+                        let column_repeat = " ".repeat(offset);
+                        buffer.push_str(&format!("{max_indent} | {column_repeat}^\n",));
+                    }
                 }
             }
             Symbol::Unresolved { pc } => {

--- a/bsan-rt/src/sanitizer_common.rs
+++ b/bsan-rt/src/sanitizer_common.rs
@@ -132,8 +132,7 @@ impl SanitizerCommon {
         if line_number == 0 {
             return None;
         }
-
-        content.lines().nth((line_number - 1) as usize).map(|s| s.trim().to_string())
+        content.lines().nth((line_number - 1) as usize).map(|s| s.to_string())
     }
 }
 

--- a/tests/fail-dep/mirilli/blitsort-sys.run.stderr
+++ b/tests/fail-dep/mirilli/blitsort-sys.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x4]
    --> bsan/tests/fail-dep/mirilli/blitsort-sys.rs:LL:CC
    |
 LL | blitsort(
-   |
+   | ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../blitsort.rs:LL:CC
    |
 LL | parity_merge_two(swap, array, x, y, ptl, ptr, pts, cmp);
-   |
+   | ^
     = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> RUSTLIB/core/src/slice/mod.rs:LL:CC

--- a/tests/fail-dep/mirilli/blitsort-sys.run.stderr
+++ b/tests/fail-dep/mirilli/blitsort-sys.run.stderr
@@ -13,7 +13,7 @@ help: the accessed tag <TAG>(unprotected) was created here, in the initial state
    --> RUSTLIB/core/src/slice/mod.rs:LL:CC
    |
 LL | pub const fn as_ptr(&self) -> *const T {
-   |
+   | ^
 
 stack backtrace:
 0: parity_swap_four32

--- a/tests/fail-dep/mirilli/bzip2.run.stderr
+++ b/tests/fail-dep/mirilli/bzip2.run.stderr
@@ -7,7 +7,7 @@ LL | c.read_to_end(&mut result).unwrap();
    --> CARGO_REGISTRY/.../bzlib.rs:LL:CC
    |
 LL | if (s->avail_in_expect != s->strm->avail_in)
-   |                                   ^
+   |                                    ^
     = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
    --> CARGO_REGISTRY/.../mem.rs:LL:CC

--- a/tests/fail-dep/mirilli/bzip2.run.stderr
+++ b/tests/fail-dep/mirilli/bzip2.run.stderr
@@ -2,23 +2,23 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x8] 
    --> bsan/tests/fail-dep/mirilli/bzip2.rs:LL:CC
    |
 LL | c.read_to_end(&mut result).unwrap();
-   |
+   |   ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../bzlib.rs:LL:CC
    |
 LL | if (s->avail_in_expect != s->strm->avail_in)
-   |
+   |                                   ^
     = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
    --> CARGO_REGISTRY/.../mem.rs:LL:CC
    |
 LL | ffi::BZ2_bzCompressInit(&mut *raw, lvl.level() as c_int, 0, work_factor as c_int),
-   |
+   |                         ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x8..0xc]
    --> CARGO_REGISTRY/.../mem.rs:LL:CC
    |
 LL | self.inner.raw.avail_in = input.len().min(c_uint::MAX as usize) as c_uint;
-   |
+   | ^
     = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/fail-dep/mirilli/dec.run.stderr
+++ b/tests/fail-dep/mirilli/dec.run.stderr
@@ -2,23 +2,23 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0xc] 
    --> bsan/tests/fail-dep/mirilli/dec.rs:LL:CC
    |
 LL | assert_eq!(lhs.cmp(&rhs), expected);
-   |
+   |                ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../decBasic.rs:LL:CC
    |
 LL | if (DFISCCZERO(df)) return result;  // coefficient continuation is 0
-   |
+   |     ^
     = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> CARGO_REGISTRY/.../decimal128.rs:LL:CC
    |
 LL | decnumber_sys::decQuadReduce(&mut n.inner, &n.inner, &mut self.inner);
-   |
+   |                                            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0xc..0x10]
    --> CARGO_REGISTRY/.../decBasic.rs:LL:CC
    |
 LL | DFWORD(result, 0)&=~ECONNANMASK;    // clear ECON except selector
-   |
+   |                  ^
     = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/fail-dep/mirilli/dec_number_sys.run.stderr
+++ b/tests/fail-dep/mirilli/dec_number_sys.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
     --> bsan/tests/fail-dep/mirilli/dec_number_sys.rs:LL:CC
    |
 LL | assert_eq!(0, dec_quad_get_coefficient(&n!(1), &mut bcd_quad(u128::MAX)));
-   |
+   |               ^
      = note: the above line calls library code, where the error was detected:
     --> CARGO_REGISTRY/.../decCommon.rs:LL:CC
    |
 LL | GETCOEFF(df, bcdar);           // use macro
-   |
+   | ^
      = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
     --> RUSTLIB/core/src/slice/mod.rs:LL:CC

--- a/tests/fail-dep/mirilli/dec_number_sys.run.stderr
+++ b/tests/fail-dep/mirilli/dec_number_sys.run.stderr
@@ -13,7 +13,7 @@ help: the accessed tag <TAG>(unprotected) was created here, in the initial state
     --> RUSTLIB/core/src/slice/mod.rs:LL:CC
    |
 LL | pub const fn as_ptr(&self) -> *const T {
-   |
+   | ^
 
 stack backtrace:
 0: decQuadGetCoefficient

--- a/tests/fail-dep/mirilli/flate2.run.stderr
+++ b/tests/fail-dep/mirilli/flate2.run.stderr
@@ -2,23 +2,23 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x8] 
    --> bsan/tests/fail-dep/mirilli/flate2.rs:LL:CC
    |
 LL | c.read_to_end(&mut result).unwrap();
-   |
+   |   ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../deflate.rs:LL:CC
    |
 LL | if (s->strm->avail_in == 0) break;
-   |
+   |              ^
     = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
    --> CARGO_REGISTRY/.../c.rs:LL:CC
    |
 LL | &mut *state,
-   |
+   | ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x8..0xc]
    --> CARGO_REGISTRY/.../c.rs:LL:CC
    |
 LL | raw.avail_in = cmp::min(input.len(), c_uint::MAX as usize) as c_uint;
-   |
+   | ^
     = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/fail-dep/mirilli/klu-rs.run.stderr
+++ b/tests/fail-dep/mirilli/klu-rs.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x4c
    --> bsan/tests/fail-dep/mirilli/klu-rs.rs:LL:CC
    |
 LL | builder.finish(KluSettings::new())
-   |
+   |         ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../klu_analyze.rs:LL:CC
    |
 LL | Common->status = KLU_OK ;
-   |
+   |                ^
     = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> CARGO_REGISTRY/.../lib.rs:LL:CC
    |
 LL | self.data.as_ref() as *const I::KluCommon as *mut I::KluCommon
-   |
+   |           ^
 
 stack backtrace:
 0: klu_analyze

--- a/tests/fail-dep/mirilli/lcms2.run.stderr
+++ b/tests/fail-dep/mirilli/lcms2.run.stderr
@@ -13,7 +13,7 @@ help: the accessed tag <TAG>(unprotected) was created here, in the initial state
   --> CARGO_REGISTRY/.../lib.rs:LL:CC
    |
 LL | fn as_ptr(&self) -> *mut Self::CType {
-   |
+   | ^
 
 stack backtrace:
 0: GrowMLUpool

--- a/tests/fail-dep/mirilli/lcms2.run.stderr
+++ b/tests/fail-dep/mirilli/lcms2.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x20
   --> bsan/tests/fail-dep/mirilli/lcms2.rs:LL:CC
    |
 LL | assert!(m.set_text("Hello 世界！", Locale::none()));
-   |
+   |           ^
    = note: the above line calls library code, where the error was detected:
   --> CARGO_REGISTRY/.../cmsnamed.rs:LL:CC
    |
 LL | mlu ->MemPool  = NewPtr;
-   |
+   |                ^
    = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> CARGO_REGISTRY/.../lib.rs:LL:CC

--- a/tests/fail-dep/mirilli/librsync.run.stderr
+++ b/tests/fail-dep/mirilli/librsync.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x
    --> bsan/tests/fail-dep/mirilli/librsync.rs:LL:CC
    |
 LL | });
-   |
+   | ^
     = note: the above line calls library code, where the error was detected:
    --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
     = help: the accessed tag <TAG>(WeakProtector) has state Reserved (conflicted) which forbids this deallocation (acting as a child write access)
 help: the accessed tag <TAG>(WeakProtector) was created here, in the initial state Reserved
    --> bsan/tests/fail-dep/mirilli/librsync.rs:LL:CC
@@ -18,7 +18,7 @@ help: the accessed tag <TAG>(WeakProtector) later transitioned to Reserved (conf
    --> CARGO_REGISTRY/.../lib.rs:LL:CC
    |
 LL | (*h).borrow_mut()
-   |
+   | ^
     = help: this transition corresponds to a temporary loss of write permissions until function exit
 
 stack backtrace:

--- a/tests/fail-dep/mirilli/librsync.run.stderr
+++ b/tests/fail-dep/mirilli/librsync.run.stderr
@@ -13,7 +13,7 @@ help: the accessed tag <TAG>(WeakProtector) was created here, in the initial sta
    --> bsan/tests/fail-dep/mirilli/librsync.rs:LL:CC
    |
 LL | let t = thread::spawn(move || {
-   |
+   | ^
 help: the accessed tag <TAG>(WeakProtector) later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x10]
    --> CARGO_REGISTRY/.../lib.rs:LL:CC
    |

--- a/tests/fail-dep/mirilli/lsmlite_rs.run.stderr
+++ b/tests/fail-dep/mirilli/lsmlite_rs.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
    --> bsan/tests/fail-dep/mirilli/lsmlite_rs.rs:LL:CC
    |
 LL | db.connect().unwrap();
-   |
+   |    ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../lsm_main.rs:LL:CC
     = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
@@ -10,7 +10,7 @@ help: the accessed tag <TAG>(unprotected) was created here, in the initial state
    --> CARGO_REGISTRY/.../lsmdb.rs:LL:CC
    |
 LL | rc = lsm_new(null_mut(), &db_handle);
-   |
+   |                          ^
 
 stack backtrace:
 0: lsm_new

--- a/tests/fail-dep/mirilli/ms5837.run.stderr
+++ b/tests/fail-dep/mirilli/ms5837.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
    --> bsan/tests/fail-dep/mirilli/ms5837.rs:LL:CC
    |
 LL | c_implementation::crc4(c_input_buffer.as_ptr());
-   |
+   | ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../crc4.rs:LL:CC
    |
 LL | n_prom[0] = ((n_prom[0]) & $HEX);  // CRC byte is replaced by 0
-   |
+   |           ^
     = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> RUSTLIB/core/src/slice/mod.rs:LL:CC

--- a/tests/fail-dep/mirilli/ms5837.run.stderr
+++ b/tests/fail-dep/mirilli/ms5837.run.stderr
@@ -13,7 +13,7 @@ help: the accessed tag <TAG>(unprotected) was created here, in the initial state
    --> RUSTLIB/core/src/slice/mod.rs:LL:CC
    |
 LL | pub const fn as_ptr(&self) -> *const T {
-   |
+   | ^
 
 stack backtrace:
 0: crc4

--- a/tests/fail-dep/mirilli/sgp4_rs.run.stderr
+++ b/tests/fail-dep/mirilli/sgp4_rs.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0xf]
    --> bsan/tests/fail-dep/mirilli/sgp4_rs.rs:LL:CC
    |
 LL | let _ = TwoLineElement::new(line1, line2).unwrap();
-   |
+   |         ^
     = note: the above line calls library code, where the error was detected:
    --> CARGO_REGISTRY/.../sgp4io.rs:LL:CC
    |
 LL | longstr1[j] = '_';
-   |
+   |             ^
     = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> RUSTLIB/core/src/slice/mod.rs:LL:CC

--- a/tests/fail-dep/mirilli/sgp4_rs.run.stderr
+++ b/tests/fail-dep/mirilli/sgp4_rs.run.stderr
@@ -13,7 +13,7 @@ help: the accessed tag <TAG>(unprotected) was created here, in the initial state
    --> RUSTLIB/core/src/slice/mod.rs:LL:CC
    |
 LL | pub const fn as_ptr(&self) -> *const T {
-   |
+   | ^
 
 stack backtrace:
 0: twoline2rv

--- a/tests/fail/aliasing/bsan-ptr-craft.run.stderr
+++ b/tests/fail/aliasing/bsan-ptr-craft.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x
     --> bsan/tests/fail/aliasing/bsan-ptr-craft.rs:LL:CC
    |
 LL | drop(b2);
-   |
+   | ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
      = help: the accessed tag <TAG>(WeakProtector) is a child of the conflicting tag <TAG>(unprotected)
      = help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this deallocation (acting as a child write access)
 help: the accessed tag <TAG>(WeakProtector) was created here
     --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | pub const fn drop<T>(_x: T)
-   |
+   | ^
 help: the conflicting tag <TAG>(unprotected) was created here, in the initial state Frozen
     --> bsan/tests/fail/aliasing/bsan-ptr-craft.rs:LL:CC
    |
 LL | let ptr = &i as *const i32 as *mut i32 as *mut i32;
-   |
+   |           ^
 
 stack backtrace:
 0: <std::alloc::System as core::alloc::global::GlobalAlloc>::dealloc

--- a/tests/fail/aliasing/forbidden_child_access.run.stderr
+++ b/tests/fail/aliasing/forbidden_child_access.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is 
  --> bsan/tests/fail/aliasing/forbidden_child_access.rs:LL:CC
    |
 LL | std::hint::black_box(r1);
-   |
+   |                      ^
   = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
  --> bsan/tests/fail/aliasing/forbidden_child_access.rs:LL:CC
    |
 LL | let r1 = unsafe { &mut *ptr };
-   |
+   |                   ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
  --> bsan/tests/fail/aliasing/forbidden_child_access.rs:LL:CC
    |
 LL | *r2 += 1;
-   |
+   | ^
   = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/fail/aliasing/frozen_write.run.stderr
+++ b/tests/fail/aliasing/frozen_write.run.stderr
@@ -2,13 +2,13 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
  --> bsan/tests/fail/aliasing/frozen_write.rs:LL:CC
    |
 LL | unsafe { *(ptr as *mut i32) = 1 };
-   |
+   |          ^
   = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
  --> bsan/tests/fail/aliasing/frozen_write.rs:LL:CC
    |
 LL | let rx = &x;
-   |
+   |          ^
 
 stack backtrace:
 0: frozen_write::foo

--- a/tests/fail/aliasing/protected_write.run.stderr
+++ b/tests/fail/aliasing/protected_write.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/fail/aliasing/protected_write.rs:LL:CC
    |
 LL | unsafe { *p = 1 };
-   |
+   |          ^
    = help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
    = help: this foreign write access would cause the protected tag <TAG>(StrongProtector) (currently Reserved) to become Disabled
    = help: protected tags must never be Disabled
@@ -10,12 +10,12 @@ help: the accessed tag <TAG>(unprotected) was created here
   --> bsan/tests/fail/aliasing/protected_write.rs:LL:CC
    |
 LL | let rx = &mut x;
-   |
+   |          ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
   --> bsan/tests/fail/aliasing/protected_write.rs:LL:CC
    |
 LL | fn foo(_r: &mut i32, p: *mut i32) {
-   |
+   | ^
 
 stack backtrace:
 0: protected_write::foo

--- a/tests/fail/aliasing/unique_ref.run.stderr
+++ b/tests/fail/aliasing/unique_ref.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
  --> bsan/tests/fail/aliasing/unique_ref.rs:LL:CC
    |
 LL | *ptr_x = 1;
-   |
+   | ^
   = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
  --> bsan/tests/fail/aliasing/unique_ref.rs:LL:CC
    |
 LL | let rx = &mut x;
-   |
+   |          ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
  --> bsan/tests/fail/aliasing/unique_ref.rs:LL:CC
    |
 LL | *vx = 2;
-   |
+   | ^
   = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/fail/baseline/access_oob.run.stderr
+++ b/tests/fail/baseline/access_oob.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: an access of size 4b at offset 0x4 is out of bounds f
   --> bsan/tests/fail/baseline/access_oob.rs:LL:CC
    |
 LL | unsafe { p.add(1).write(0) }
-   |
+   |                   ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
 
 stack backtrace:
 0: core::ptr::write

--- a/tests/fail/baseline/free_box.run.stderr
+++ b/tests/fail/baseline/free_box.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
   --> bsan/tests/fail/baseline/free_box.rs:LL:CC
    |
 LL | *ptr = 1;
-   |
+   | ^
 
 stack backtrace:
 0: free_box::main

--- a/tests/miri-tests/fail/aliasing/async-shared-mutable.run.stderr
+++ b/tests/miri-tests/fail/aliasing/async-shared-mutable.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x8]
    --> bsan/tests/miri-tests/fail/aliasing/async-shared-mutable.rs:LL:CC
    |
 LL | *x = 1; //miri: ~ERROR: write access
-   |
+   | ^
     = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
    --> bsan/tests/miri-tests/fail/aliasing/async-shared-mutable.rs:LL:CC
    |
 LL | core::future::poll_fn(move |_| {
-   |
+   | ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x8..0x9]
    --> bsan/tests/miri-tests/fail/aliasing/async-shared-mutable.rs:LL:CC
    |
 LL | *x = 1; //miri: ~ERROR: write access
-   |
+   | ^
     = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the accessed tag <TAG>(unprotected) later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x10]
    --> RUSTLIB/core/src/ops/deref.rs:LL:CC
    |
 LL | self
-   |
+   | ^
     = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/alias_through_mutation.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/alias_through_mutation.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/alias_through_mutation.rs:LL:CC
    |
 LL | let _val = *target_alias;
-   |
+   |            ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/alias_through_mutation.rs:LL:CC
    |
 LL | *x = &mut *(target as *mut _);
-   |
+   | ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/alias_through_mutation.rs:LL:CC
    |
 LL | *target = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut1.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut1.rs:LL:CC
    |
 LL | *x = 1; //miri: ~[tree] ERROR: /write access through .* is forbidden/
-   |
+   | ^
   = help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this child write access
 help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut1.rs:LL:CC
    |
 LL | fn safe(x: &mut i32, y: &mut i32) {
-   |
+   | ^
 help: the accessed tag <TAG>(StrongProtector) later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut1.rs:LL:CC
    |
 LL | fn safe(x: &mut i32, y: &mut i32) {
-   |
+   | ^
   = help: this transition corresponds to a temporary loss of write permissions until function exit
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut2.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut2.rs:LL:CC
    |
 LL | *y = 2; //miri: ~[tree] ERROR: /write access through .* is forbidden/
-   |
+   | ^
   = help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this child write access
 help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut2.rs:LL:CC
    |
 LL | fn safe(x: &i32, y: &mut i32) {
-   |
+   | ^
 help: the accessed tag <TAG>(StrongProtector) later transitioned to Reserved (conflicted) due to a foreign read access at offsets [0x0..0x4]
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut2.rs:LL:CC
    |
 LL | let _v = *x;
-   |
+   |          ^
   = help: this transition corresponds to a temporary loss of write permissions until function exit
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut3.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut3.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut3.rs:LL:CC
    |
 LL | *x = 1; //miri: ~[tree] ERROR: /write access through .* is forbidden/
-   |
+   | ^
   = help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this child write access
 help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut3.rs:LL:CC
    |
 LL | fn safe(x: &mut i32, y: &i32) {
-   |
+   | ^
 help: the accessed tag <TAG>(StrongProtector) later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut3.rs:LL:CC
    |
 LL | fn safe(x: &mut i32, y: &i32) {
-   |
+   | ^
   = help: this transition corresponds to a temporary loss of write permissions until function exit
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut4.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut4.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
    --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut4.rs:LL:CC
    |
 LL | y.set(1);
-   |
+   |   ^
     = note: the above line calls library code, where the error was detected:
    --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | crate::intrinsics::write_via_move(dest, src);
-   |
+   |                                         ^
     = help: the accessed tag <TAG>(StrongProtector) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
     = help: this foreign write access would cause the protected tag <TAG>(StrongProtector) (currently Frozen) to become Disabled
     = help: protected tags must never be Disabled
@@ -15,12 +15,12 @@ help: the accessed tag <TAG>(StrongProtector) was created here
    --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | pub const fn replace<T>(dest: &mut T, src: T) -> T {
-   |
+   | ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Frozen
    --> bsan/tests/miri-tests/fail/aliasing/both_borrows/aliasing_mut4.rs:LL:CC
    |
 LL | fn safe(x: &i32, y: &mut Cell<i32>) {
-   |
+   | ^
 
 stack backtrace:
 0: core::mem::replace

--- a/tests/miri-tests/fail/aliasing/both_borrows/box_exclusive_violation1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/box_exclusive_violation1.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/box_exclusive_violation1.rs:LL:CC
    |
 LL | *LEAK = 7;
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/box_exclusive_violation1.rs:LL:CC
    |
 LL | fn unknown_code_1(x: &i32) {
-   |
+   | ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/box_exclusive_violation1.rs:LL:CC
    |
 LL | *our = 5;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/box_noalias_violation.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/box_noalias_violation.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/box_noalias_violation.rs:LL:CC
    |
 LL | *y
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(WeakProtector) (i.e., it is not a child)
    = help: this foreign read access would cause the protected tag <TAG>(WeakProtector) (currently Unique) to become Disabled
    = help: protected tags must never be Disabled
@@ -10,17 +10,17 @@ help: the accessed tag <TAG>(unprotected) was created here
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/box_noalias_violation.rs:LL:CC
    |
 LL | let ptr = &mut v as *mut i32;
-   |
+   |           ^
 help: the protected tag <TAG>(WeakProtector) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/box_noalias_violation.rs:LL:CC
    |
 LL | unsafe fn test(mut x: Box<i32>, y: *const i32) -> i32 {
-   |
+   | ^
 help: the protected tag <TAG>(WeakProtector) later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/box_noalias_violation.rs:LL:CC
    |
 LL | *x = 5;
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/buggy_as_mut_slice.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/buggy_as_mut_slice.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/buggy_as_mut_slice.rs:LL:CC
    |
 LL | v2[1] = 7;
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/buggy_as_mut_slice.rs:LL:CC
    |
 LL | let v2 = safe::as_mut_slice(&v);
-   |
+   |          ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x4..0x8]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/buggy_as_mut_slice.rs:LL:CC
    |
 LL | v1[1] = 5;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/buggy_split_at_mut.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/buggy_split_at_mut.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/buggy_split_at_mut.rs:LL:CC
    |
 LL | b[1] = 6;
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/buggy_split_at_mut.rs:LL:CC
    |
 LL | let (a, b) = safe::split_at_mut(&mut array, 0);
-   |
+   |         ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x4..0x8]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/buggy_split_at_mut.rs:LL:CC
    |
 LL | a[1] = 5;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed1.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed1.rs:LL:CC
    |
 LL | let _val = *root2; //miri: ~[tree]| ERROR: /read access through .* is forbidden/
-   |
+   |            ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed1.rs:LL:CC
    |
 LL | let root2 = &mut *exposed_ptr;
-   |
+   |             ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed1.rs:LL:CC
    |
 LL | *exposed_ptr = 0;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed2.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed2.rs:LL:CC
    |
 LL | *root2 = 3; //miri: ~[tree]| ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed2.rs:LL:CC
    |
 LL | let root2 = &mut *exposed_ptr;
-   |
+   |             ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed2.rs:LL:CC
    |
 LL | *root2 = 42;
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the accessed tag <TAG>(unprotected) later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_read_despite_exposed2.rs:LL:CC
    |
 LL | let _val = *exposed_ptr;
-   |
+   |            ^
    = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/illegal_write1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/illegal_write1.run.stderr
@@ -2,13 +2,13 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write1.rs:LL:CC
    |
 LL | unsafe { *x = 42 };
-   |
+   |          ^
    = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write1.rs:LL:CC
    |
 LL | let xref = &*target;
-   |
+   |            ^
 
 stack backtrace:
 0: illegal_write1::main

--- a/tests/miri-tests/fail/aliasing/both_borrows/illegal_write5.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/illegal_write5.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write5.rs:LL:CC
    |
 LL | let _val = *xref;
-   |
+   |            ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write5.rs:LL:CC
    |
 LL | let xref = unsafe { &mut *xraw };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write5.rs:LL:CC
    |
 LL | unsafe { *xraw = 15 };
-   |
+   |          ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/illegal_write6.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/illegal_write6.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write6.rs:LL:CC
    |
 LL | unsafe { *y = 2 };
-   |
+   |          ^
    = help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
    = help: this foreign write access would cause the protected tag <TAG>(StrongProtector) (currently Unique) to become Disabled
    = help: protected tags must never be Disabled
@@ -10,17 +10,17 @@ help: the accessed tag <TAG>(unprotected) was created here
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write6.rs:LL:CC
    |
 LL | let x = &mut 0u32;
-   |
+   |         ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write6.rs:LL:CC
    |
 LL | fn foo(a: &mut u32, y: *mut u32) -> u32 {
-   |
+   | ^
 help: the protected tag <TAG>(StrongProtector) later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write6.rs:LL:CC
    |
 LL | *a = 1;
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/illegal_write_despite_exposed1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/illegal_write_despite_exposed1.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write_despite_exposed1.rs:LL:CC
    |
 LL | let _val = *root2; //miri: ~[tree]| ERROR: /read access through .* is forbidden/
-   |
+   |            ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write_despite_exposed1.rs:LL:CC
    |
 LL | let root2 = &*exposed_ptr;
-   |
+   |             ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/illegal_write_despite_exposed1.rs:LL:CC
    |
 LL | *exposed_ptr = 0;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector2.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector2.rs:LL:CC
    |
 LL | unsafe { *x = 0 };
-   |
+   |          ^
    = help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
    = help: this foreign write access would cause the protected tag <TAG>(StrongProtector) (currently Frozen) to become Disabled
    = help: protected tags must never be Disabled
@@ -10,12 +10,12 @@ help: the accessed tag <TAG>(unprotected) was created here
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector2.rs:LL:CC
    |
 LL | let xraw = &mut x as *mut _;
-   |
+   |            ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector2.rs:LL:CC
    |
 LL | fn inner(x: *mut i32, _y: &i32) {
-   |
+   | ^
 
 stack backtrace:
 0: invalidate_against_protector2::inner

--- a/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector3.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector3.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <TAG>(unprotected) (root of the 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector3.rs:LL:CC
    |
 LL | unsafe { *x = 0 };
-   |
+   |          ^
    = help: the accessed tag <TAG>(unprotected) (root of the allocation) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
    = help: this foreign write access would cause the protected tag <TAG>(StrongProtector) (currently Frozen) to become Disabled
    = help: protected tags must never be Disabled
@@ -10,12 +10,12 @@ help: the accessed tag <TAG>(unprotected) was created here
   --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::malloc(layout.size()) as *mut u8 }
-   |
+   |          ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/invalidate_against_protector3.rs:LL:CC
    |
 LL | fn inner(x: *mut i32, _y: &i32) {
-   |
+   | ^
 
 stack backtrace:
 0: invalidate_against_protector3::inner

--- a/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is 
    --> bsan/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.rs:LL:CC
    |
 LL | let _val = *xref_in_mem; //miri: ~[tree]| ERROR: /reborrow through .* is forbidden/
-   |
+   |            ^
     = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL | unsafe { core::intrinsics::write_via_move(ptr, x) };
-   |
+   |                                                ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
    --> bsan/tests/miri-tests/fail/aliasing/both_borrows/load_invalid_shr.rs:LL:CC
    |
 LL | unsafe { *xraw = 42 }; // unfreeze
-   |
+   |          ^
     = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/mixed_cell_deallocate.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/mixed_cell_deallocate.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: deallocation through <TAG>(StrongProtector) at ALLOC[
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mixed_cell_deallocate.rs:LL:CC
    |
 LL | unsafe { alloc::dealloc(x as *const _ as *mut T as *mut u8, layout) }; //miri: ~ERROR: dealloc
-   |
+   |          ^
    = note: the above line calls library code, where the error was detected:
   --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
    = help: the accessed tag <TAG>(StrongProtector) has state Frozen which forbids this deallocation (acting as a child write access)
 help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Cell
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mixed_cell_deallocate.rs:LL:CC
    |
 LL | fn foo(x: &T) {
-   |
+   | ^
 
 stack backtrace:
 0: <std::alloc::System as core::alloc::global::GlobalAlloc>::dealloc

--- a/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation1.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation1.rs:LL:CC
    |
 LL | *LEAK = 7;
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation1.rs:LL:CC
    |
 LL | fn unknown_code_1(x: &i32) {
-   |
+   | ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation1.rs:LL:CC
    |
 LL | *our = 5;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation2.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation2.rs:LL:CC
    |
 LL | *raw1 = 3; //miri: ~[tree] ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation2.rs:LL:CC
    |
 LL | let raw1 = ptr1.as_mut();
-   |
+   |                 ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/mut_exclusive_violation2.rs:LL:CC
    |
 LL | *raw2 = 2;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/newtype_pair_retagging.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/newtype_pair_retagging.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x
     --> bsan/tests/miri-tests/fail/aliasing/both_borrows/newtype_pair_retagging.rs:LL:CC
    |
 LL | || drop(Box::from_raw(ptr)),
-   |
+   |    ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
      = help: the accessed tag <TAG>(WeakProtector) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
      = help: this deallocation (acting as a foreign write access) would cause the protected tag <TAG>(StrongProtector) (currently Reserved (conflicted)) to become Disabled
      = help: protected tags must never be Disabled
@@ -15,17 +15,17 @@ help: the accessed tag <TAG>(WeakProtector) was created here
     --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | pub const fn drop<T>(_x: T)
-   |
+   | ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/both_borrows/newtype_pair_retagging.rs:LL:CC
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
-   |
+   | ^
 help: the protected tag <TAG>(StrongProtector) later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
     --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL | Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |
+   | ^
      = help: this transition corresponds to a temporary loss of write permissions until function exit
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/newtype_retagging.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/newtype_retagging.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x
     --> bsan/tests/miri-tests/fail/aliasing/both_borrows/newtype_retagging.rs:LL:CC
    |
 LL | || drop(Box::from_raw(ptr)),
-   |
+   |    ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
      = help: the accessed tag <TAG>(WeakProtector) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
      = help: this deallocation (acting as a foreign write access) would cause the protected tag <TAG>(StrongProtector) (currently Reserved (conflicted)) to become Disabled
      = help: protected tags must never be Disabled
@@ -15,17 +15,17 @@ help: the accessed tag <TAG>(WeakProtector) was created here
     --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | pub const fn drop<T>(_x: T)
-   |
+   | ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/both_borrows/newtype_retagging.rs:LL:CC
    |
 LL | fn dealloc_while_running(_n: Newtype<'_>, dealloc: impl FnOnce()) {
-   |
+   | ^
 help: the protected tag <TAG>(StrongProtector) later transitioned to Reserved (conflicted) due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
     --> RUSTLIB/alloc/src/boxed.rs:LL:CC
    |
 LL | Box(unsafe { Unique::new_unchecked(raw) }, alloc)
-   |
+   | ^
      = help: this transition corresponds to a temporary loss of write permissions until function exit
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/outdated_local.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/outdated_local.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/outdated_local.rs:LL:CC
    |
 LL | assert_eq!(unsafe { *y }, 1);
-   |
+   |                     ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/outdated_local.rs:LL:CC
    |
 LL | let y: *const i32 = &x;
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/outdated_local.rs:LL:CC
    |
 LL | x = 1; // this invalidates y by reactivating the lowermost uniq borrow for this local
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr.rs:LL:CC
    |
 LL | foo(xref);
-   |
+   |     ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr.rs:LL:CC
    |
 LL | let xref = unsafe { &*xraw };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr.rs:LL:CC
    |
 LL | unsafe { *xraw = 42 }; // unfreeze
-   |
+   |          ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_option.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_option.run.stderr
@@ -7,7 +7,7 @@ help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_option.rs:LL:CC
    |
 LL | unsafe { *xraw = 42 }; // unfreeze
-   |
+   |          ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_tuple.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_tuple.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_tuple.rs:LL:CC
    |
 LL | foo(pair_xref);
-   |
+   |     ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_tuple.rs:LL:CC
    |
 LL | let pair_xref = unsafe { (&*xraw0, &*xraw1) };
-   |
+   |                          ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/pass_invalid_shr_tuple.rs:LL:CC
    |
 LL | unsafe { *xraw0 = 42 }; // unfreeze
-   |
+   |          ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x4] is 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr.rs:LL:CC
    |
 LL | ret
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr.rs:LL:CC
    |
 LL | let ret = unsafe { &(*xraw).1 };
-   |
+   |                    ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x4..0x8]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr.rs:LL:CC
    |
 LL | unsafe { *xraw = (42, 23) }; // unfreeze
-   |
+   |          ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_option.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_option.run.stderr
@@ -7,7 +7,7 @@ help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to 
  --> bsan/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_option.rs:LL:CC
    |
 LL | unsafe { *xraw = (42, 23) }; // unfreeze
-   |
+   |          ^
   = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_tuple.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_tuple.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x4] is 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_tuple.rs:LL:CC
    |
 LL | ret
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_tuple.rs:LL:CC
    |
 LL | let ret = (unsafe { &(*xraw).1 },);
-   |
+   |           ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x4..0x8]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/return_invalid_shr_tuple.rs:LL:CC
    |
 LL | unsafe { *xraw = (42, 23) }; // unfreeze
-   |
+   |          ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation1.run.stderr
@@ -2,13 +2,13 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation1.rs:LL:CC
    |
 LL | *(x as *const i32 as *mut i32) = 7;
-   |
+   | ^
    = help: the accessed tag <TAG>(StrongProtector) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation1.rs:LL:CC
    |
 LL | fn unknown_code(x: &i32) {
-   |
+   | ^
 
 stack backtrace:
 0: shr_frozen_violation1::unknown_code

--- a/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation2.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation2.rs:LL:CC
    |
 LL | let _val = *frozen;
-   |
+   |            ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation2.rs:LL:CC
    |
 LL | let frozen = &*ptr;
-   |
+   |              ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/both_borrows/shr_frozen_violation2.rs:LL:CC
    |
 LL | x = 1;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/box-cell-alias.run.stderr
+++ b/tests/miri-tests/fail/aliasing/box-cell-alias.run.stderr
@@ -15,7 +15,7 @@ help: the accessed tag <TAG>(unprotected) was created here
     --> RUSTLIB/core/src/cell.rs:LL:CC
    |
 LL | pub const fn get(&self) -> *mut T {
-   |
+   | ^
 help: the protected tag <TAG>(WeakProtector) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/box-cell-alias.rs:LL:CC
    |

--- a/tests/miri-tests/fail/aliasing/box-cell-alias.run.stderr
+++ b/tests/miri-tests/fail/aliasing/box-cell-alias.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is 
     --> bsan/tests/miri-tests/fail/aliasing/box-cell-alias.rs:LL:CC
    |
 LL | unsafe { (*ptr).set(20) }; //miri: ~ ERROR: does not exist in the borrow stack
-   |
+   |                 ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/core/src/cell.rs:LL:CC
    |
 LL | mem::replace(unsafe { &mut *self.value.get() }, val)
-   |
+   |                       ^
      = help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(WeakProtector) (i.e., it is not a child)
      = help: this reborrow (acting as a foreign read access) would cause the protected tag <TAG>(WeakProtector) (currently Unique) to become Disabled
      = help: protected tags must never be Disabled
@@ -20,12 +20,12 @@ help: the protected tag <TAG>(WeakProtector) was created here, in the initial st
     --> bsan/tests/miri-tests/fail/aliasing/box-cell-alias.rs:LL:CC
    |
 LL | fn helper(val: Box<Cell<u8>>, ptr: *const Cell<u8>) -> u8 {
-   |
+   | ^
 help: the protected tag <TAG>(WeakProtector) later transitioned to Unique due to a child write access at offsets [0x0..0x1]
     --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | crate::intrinsics::write_via_move(dest, src);
-   |
+   |                                         ^
      = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/observed_local_mut.run.stderr
+++ b/tests/miri-tests/fail/aliasing/observed_local_mut.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/observed_local_mut.rs:LL:CC
    |
 LL | assert_eq!(unsafe { *y }, 1);
-   |
+   |                     ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/observed_local_mut.rs:LL:CC
    |
 LL | let y: *const i32 = &x;
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/observed_local_mut.rs:LL:CC
    |
 LL | x = 1;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/deallocate_against_protector1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/deallocate_against_protector1.run.stderr
@@ -2,19 +2,19 @@ error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x
     --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/deallocate_against_protector1.rs:LL:CC
    |
 LL | drop(unsafe { Box::from_raw(raw) });
-   |
+   | ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
      = help: the allocation of the accessed tag <TAG>(WeakProtector) also contains the strongly protected tag <TAG>(StrongProtector)
      = help: the strongly protected tag <TAG>(StrongProtector) disallows deallocations
 help: the accessed tag <TAG>(WeakProtector) was created here
     --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | pub const fn drop<T>(_x: T)
-   |
+   | ^
 help: the strongly protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/deallocate_against_protector1.rs:LL:CC
    |

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/deallocate_against_protector1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/deallocate_against_protector1.run.stderr
@@ -19,7 +19,7 @@ help: the strongly protected tag <TAG>(StrongProtector) was created here, in the
     --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/deallocate_against_protector1.rs:LL:CC
    |
 LL | inner(Box::leak(Box::new(0)), |x| {
-   |
+   | ^
 
 stack backtrace:
 0: <std::alloc::System as core::alloc::global::GlobalAlloc>::dealloc

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/disable_mut_does_not_merge_srw.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/disable_mut_does_not_merge_srw.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/disable_mut_does_not_merge_srw.rs:LL:CC
    |
 LL | let _val = *raw; //miri: ~ERROR: that tag does not exist in the borrow stack
-   |
+   |            ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/disable_mut_does_not_merge_srw.rs:LL:CC
    |
 LL | let mutref = &mut *base;
-   |
+   |              ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/disable_mut_does_not_merge_srw.rs:LL:CC
    |
 LL | *base = 1;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/exposed_only_ro.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/exposed_only_ro.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <wildcard> at ALLOC[0x0] is forb
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/exposed_only_ro.rs:LL:CC
    |
 LL | unsafe { *ptr = 0 }; //miri: ~ ERROR: /write access using <wildcard> .* no exposed tags have suitable permission in the borrow stack/
-   |
+   |          ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_dealloc1.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_dealloc1.run.stderr
@@ -2,23 +2,23 @@ error: Undefined Behavior: deallocation through <TAG>(unprotected) at ALLOC[0x0]
     --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_deALLOC.rs:LL:CC
    |
 LL | dealloc(ptr2, Layout::from_size_align_unchecked(1, 1));
-   |
+   | ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
      = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this deallocation (acting as a child write access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_deALLOC.rs:LL:CC
    |
 LL | let ptr2 = (&mut *ptr1) as *mut u8;
-   |
+   |            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x1]
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_read8.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_read8.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_read8.rs:LL:CC
    |
 LL | let _fail = *y1; //miri: ~ ERROR: /read access .* tag does not exist in the borrow stack/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_read8.rs:LL:CC
    |
 LL | let y1: &i32 = mem::transmute(&*x); // launder lifetimes
-   |
+   |                ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_read8.rs:LL:CC
    |
 LL | *y2 += 1;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_write3.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_write3.run.stderr
@@ -2,13 +2,13 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
  --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_write3.rs:LL:CC
    |
 LL | unsafe { *ptr = 42 }; //miri: ~ ERROR: /write access .* only grants SharedReadOnly permission/
-   |
+   |          ^
   = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
  --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/illegal_write3.rs:LL:CC
    |
 LL | let r#ref = &target; // freeze
-   |
+   |             ^
 
 stack backtrace:
 0: illegal_write3::main

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/pointer_smuggling.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/pointer_smuggling.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/pointer_smuggling.rs:LL:CC
    |
 LL | let _x = unsafe { *PTR }; //miri: ~ ERROR: /read access .* tag does not exist in the borrow stack/
-   |
+   |                   ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/pointer_smuggling.rs:LL:CC
    |
 LL | fn fun1(x: &mut u8) {
-   |
+   | ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x1]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/pointer_smuggling.rs:LL:CC
    |
 LL | *val = 2; // this invalidates any raw ptrs `fun1` might have created.
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/raw_tracking.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/raw_tracking.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/raw_tracking.rs:LL:CC
    |
 LL | unsafe { *raw2 = 13 };
-   |
+   |          ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/raw_tracking.rs:LL:CC
    |
 LL | let raw2 = &mut l as *mut _; // invalidates raw1
-   |
+   |            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/raw_tracking.rs:LL:CC
    |
 LL | unsafe { *raw1 = 13 }; //miri: ~ ERROR: /write access .* tag does not exist in the borrow stack/
-   |
+   |          ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/shared_rw_borrows_are_weak2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/shared_rw_borrows_are_weak2.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x8] 
    --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/shared_rw_borrows_are_weak2.rs:LL:CC
    |
 LL | let _val = *y; //miri: ~ ERROR: /read access .* tag does not exist in the borrow stack/
-   |
+   |            ^
     = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
    --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/shared_rw_borrows_are_weak2.rs:LL:CC
    |
 LL | let y: &i32 = mem::transmute(&*x.borrow()); // launder lifetime
-   |
+   |               ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x8..0xc]
    --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | crate::intrinsics::write_via_move(dest, src);
-   |
+   |                                         ^
     = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/stacked_borrows/stacked-borrows.run.stderr
+++ b/tests/miri-tests/fail/aliasing/stacked_borrows/stacked-borrows.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/stacked-borrows.rs:LL:CC
    |
 LL | *to = 0;
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/stacked-borrows.rs:LL:CC
    |
 LL | let to = &mut root as *mut i32;
-   |
+   |          ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/stacked-borrows.rs:LL:CC
    |
 LL | *to = 0;
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the accessed tag <TAG>(unprotected) later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/stacked_borrows/stacked-borrows.rs:LL:CC
    |
 LL | let _val = root;
-   |
+   |            ^
    = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/alternate-read-write.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/alternate-read-write.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/alternate-read-write.rs:LL:CC
    |
 LL | *y += 1; // Failure
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/alternate-read-write.rs:LL:CC
    |
 LL | let y = unsafe { &mut *(x as *mut u8) };
-   |
+   |                  ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x0..0x1]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/alternate-read-write.rs:LL:CC
    |
 LL | *y += 1; // Success
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the accessed tag <TAG>(unprotected) later transitioned to Frozen due to a foreign read access at offsets [0x0..0x1]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/alternate-read-write.rs:LL:CC
    |
 LL | let _val = *x;
-   |
+   |            ^
    = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/error-range.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/error-range.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x5] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/error-range.rs:LL:CC
    |
 LL | rmut[5] += 1; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/error-range.rs:LL:CC
    |
 LL | let rmut = &mut *addr_of_mut!(data[0..6]);
-   |
+   |            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x5..0x6]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/error-range.rs:LL:CC
    |
 LL | data[5] = 1;
-   |
+   | ^
    = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/fnentry_invalidation.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/fnentry_invalidation.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/fnentry_invalidation.rs:LL:CC
    |
 LL | *z = 2; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/fnentry_invalidation.rs:LL:CC
    |
 LL | let z = &mut x as *mut i32;
-   |
+   |         ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/fnentry_invalidation.rs:LL:CC
    |
 LL | *z = 1;
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the accessed tag <TAG>(unprotected) later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/fnentry_invalidation.rs:LL:CC
    |
 LL | x.do_bad();
-   |
+   | ^
    = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/frozen-lazy-write-to-surrounding.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/frozen-lazy-write-to-surrounding.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/frozen-lazy-write-to-surrounding.rs:LL:CC
    |
 LL | unsafe { ptr.write(0) }; //miri: ~ERROR: /write access .* forbidden/
-   |
+   |              ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/frozen-lazy-write-to-surrounding.rs:LL:CC
    |
 LL | let x = &pair.0;
-   |
+   |         ^
 
 stack backtrace:
 0: core::ptr::write

--- a/tests/miri-tests/fail/aliasing/tree_borrows/outside-range.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/outside-range.run.stderr
@@ -10,7 +10,7 @@ help: the accessed tag <TAG>(unprotected) was created here
    --> RUSTLIB/core/src/slice/mod.rs:LL:CC
    |
 LL | pub const fn as_mut_ptr(&mut self) -> *mut T {
-   |
+   | ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
    --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/outside-range.rs:LL:CC
    |

--- a/tests/miri-tests/fail/aliasing/tree_borrows/outside-range.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/outside-range.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x3]
    --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/outside-range.rs:LL:CC
    |
 LL | *y.add(3) = 42; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
     = help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
     = help: this foreign write access would cause the protected tag <TAG>(StrongProtector) (currently Reserved) to become Disabled
     = help: protected tags must never be Disabled
@@ -15,7 +15,7 @@ help: the protected tag <TAG>(StrongProtector) was created here, in the initial 
    --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/outside-range.rs:LL:CC
    |
 LL | unsafe fn stuff(x: &mut u8, y: *mut u8) {
-   |
+   | ^
 
 stack backtrace:
 0: outside_range::stuff

--- a/tests/miri-tests/fail/aliasing/tree_borrows/parent_read_freezes_raw_mut.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/parent_read_freezes_raw_mut.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/parent_read_freezes_raw_mut.rs:LL:CC
    |
 LL | *ptr = 0; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/parent_read_freezes_raw_mut.rs:LL:CC
    |
 LL | let mref = &mut root;
-   |
+   |            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x0..0x1]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/parent_read_freezes_raw_mut.rs:LL:CC
    |
 LL | *ptr = 0; // Write
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the accessed tag <TAG>(unprotected) later transitioned to Frozen due to a reborrow (acting as a foreign read access) at offsets [0x0..0x1]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/parent_read_freezes_raw_mut.rs:LL:CC
    |
 LL | assert_eq!(root, 0); // Parent Read
-   |
+   | ^
    = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/pass_invalid_mut.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/pass_invalid_mut.run.stderr
@@ -2,30 +2,30 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/pass_invalid_mut.rs:LL:CC
    |
 LL | *nope = 31; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(StrongProtector) is a child of the conflicting tag <TAG>(unprotected)
    = help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(StrongProtector) was created here
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/pass_invalid_mut.rs:LL:CC
    |
 LL | fn foo(nope: &mut i32) {
-   |
+   | ^
 help: the conflicting tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/pass_invalid_mut.rs:LL:CC
    |
 LL | let xref = unsafe { &mut *xraw };
-   |
+   |                     ^
 help: the conflicting tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/pass_invalid_mut.rs:LL:CC
    |
 LL | *xref = 18; // activate xref
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the conflicting tag <TAG>(unprotected) later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/pass_invalid_mut.rs:LL:CC
    |
 LL | let _val = unsafe { *xraw }; // invalidate xref for writing
-   |
+   |                     ^
    = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/protector-write-lazy.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/protector-write-lazy.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/protector-write-lazy.rs:LL:CC
    |
 LL | unsafe { println!("Value of funky: {}", *funky_ptr_lazy_on_fst_elem) } //miri: ~ ERROR: /reborrow through .* is forbidden/
-   |
+   |          ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/protector-write-lazy.rs:LL:CC
    |
 LL | unsafe { (&mut *(ptr_to_vec.wrapping_add(1))) as *mut i32 }.wrapping_sub(1);
-   |
+   |          ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a protector release (acting as a foreign write access) on every location previously accessed by this tag
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/protector-write-lazy.rs:LL:CC
    |
 LL | }
-   |
+   |  ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/repeated_foreign_read_lazy_conflicted.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/repeated_foreign_read_lazy_conflicted.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/repeated_foreign_read_lazy_conflicted.rs:LL:CC
    |
 LL | *(x as *mut u8).byte_sub(1) = 42; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(StrongProtector) has state Reserved (conflicted) which forbids this child write access
 help: the accessed tag <TAG>(StrongProtector) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/repeated_foreign_read_lazy_conflicted.rs:LL:CC
    |
 LL | unsafe fn access_after_sub_1(x: &mut u8, orig_ptr: *mut u8) {
-   |
+   | ^
 help: the accessed tag <TAG>(StrongProtector) later transitioned to Reserved (conflicted) due to a foreign read access at offsets [0x0..0x1]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/repeated_foreign_read_lazy_conflicted.rs:LL:CC
    |
 LL | do_something(*orig_ptr);
-   |
+   |              ^
    = help: this transition corresponds to a temporary loss of write permissions until function exit
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/return_invalid_mut.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/return_invalid_mut.run.stderr
@@ -2,30 +2,30 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/return_invalid_mut.rs:LL:CC
    |
 LL | *ret = 3; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) is a child of the conflicting tag <TAG>(unprotected)
    = help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(unprotected) was created here
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/return_invalid_mut.rs:LL:CC
    |
 LL | let ret = foo(arg);
-   |
+   |           ^
 help: the conflicting tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/return_invalid_mut.rs:LL:CC
    |
 LL | let ret = unsafe { &mut (*xraw).1 };
-   |
+   |                    ^
 help: the conflicting tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x4..0x8]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/return_invalid_mut.rs:LL:CC
    |
 LL | *ret = *ret; // activate
-   |
+   | ^
    = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the conflicting tag <TAG>(unprotected) later transitioned to Frozen due to a foreign read access at offsets [0x4..0x8]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/return_invalid_mut.rs:LL:CC
    |
 LL | let _val = unsafe { *xraw }; // invalidate xref for writing
-   |
+   |                     ^
    = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/strongly-protected.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/strongly-protected.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/strongly-protected.rs:LL:CC
    |
 LL | drop(unsafe { Box::from_raw(raw) });
-   |
+   | ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
      = help: the allocation of the accessed tag <TAG>(WeakProtector) also contains the strongly protected tag <TAG>(StrongProtector)
      = help: the strongly protected tag <TAG>(StrongProtector) disallows deallocations
 help: the accessed tag <TAG>(WeakProtector) was created here
     --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | pub const fn drop<T>(_x: T)
-   |
+   | ^
 help: the strongly protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/strongly-protected.rs:LL:CC
    |
 LL | fn inner(x: &mut i32, f: fn(*mut i32)) {
-   |
+   | ^
 
 stack backtrace:
 0: <std::alloc::System as core::alloc::global::GlobalAlloc>::dealloc

--- a/tests/miri-tests/fail/aliasing/tree_borrows/subtree_traversal_skipping_diagnostics.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/subtree_traversal_skipping_diagnostics.run.stderr
@@ -2,19 +2,19 @@ error: Undefined Behavior: write access through <TAG>(StrongProtector) at ALLOC[
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
    |
 LL | *m = 42; //miri: ~ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(StrongProtector) is a child of the conflicting tag <TAG>(unprotected)
    = help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the accessed tag <TAG>(StrongProtector) was created here
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
    |
 LL | fn write_to_mut(m: &mut u8, other_ptr: *const u8) {
-   |
+   | ^
 help: the conflicting tag <TAG>(unprotected) was created here, in the initial state Frozen
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/subtree_traversal_skipping_diagnostics.rs:LL:CC
    |
 LL | let intermediary = &root;
-   |
+   |                    ^
 
 stack backtrace:
 0: subtree_traversal_skipping_diagnostics::write_to_mut

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_from_main.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_from_main.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_from_main.rs:LL:CC
    |
 LL | let _fail = *reb3; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_from_main.rs:LL:CC
    |
 LL | let reb3 = unsafe { &mut *wild };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_from_main.rs:LL:CC
    |
 LL | *ref2 = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main.rs:LL:CC
    |
 LL | let _fail = *ref2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main.rs:LL:CC
    |
 LL | let ref2 = unsafe { &mut *ptr_base };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main.rs:LL:CC
    |
 LL | *reb = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main_invalid_exposed.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main_invalid_exposed.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <wildcard> at ALLOC[0x0] is forb
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main_invalid_exposed.rs:LL:CC
    |
 LL | *ref2 = 13; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main_invalid_exposed2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main_invalid_exposed2.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <wildcard> at ALLOC[0x0] is forb
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_main_invalid_exposed2.rs:LL:CC
    |
 LL | *ref2 = 13; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer.rs:LL:CC
    |
 LL | let _fail = *reb2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer.rs:LL:CC
    |
 LL | let reb2 = unsafe { &mut *wild };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer.rs:LL:CC
    |
 LL | *ref3 = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer_exposed.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer_exposed.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer_exposed.rs:LL:CC
    |
 LL | let _fail = *reb2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer_exposed.rs:LL:CC
    |
 LL | let reb2 = unsafe { &mut *wild };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_newer_exposed.rs:LL:CC
    |
 LL | *ref3 = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older.rs:LL:CC
    |
 LL | let _fail = *reb1; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older.rs:LL:CC
    |
 LL | let reb1 = unsafe { &mut *wild };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older.rs:LL:CC
    |
 LL | *ref3 = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed.rs:LL:CC
    |
 LL | let _fail = *ref3; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed.rs:LL:CC
    |
 LL | let ref3 = &mut *reb1;
-   |
+   |            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed.rs:LL:CC
    |
 LL | *ref4 = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed2.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed2.rs:LL:CC
    |
 LL | let _fail = *reb1; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed2.rs:LL:CC
    |
 LL | let reb1 = unsafe { &mut *wild };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/cross_tree_update_older_invalid_exposed2.rs:LL:CC
    |
 LL | *ref4 = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/dealloc.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/dealloc.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: deallocation through <wildcard> at ALLOC[0x0] is forb
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/dealloc.rs:LL:CC
    |
 LL | unsafe { std::alloc::dealloc(wild as *mut u8, Layout::new::<u32>()) }; //miri: ~ ERROR: /deallocation through <wildcard> .* is forbidden/
-   |
+   |          ^
    = note: the above line calls library code, where the error was detected:
   --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child.rs:LL:CC
    |
 LL | let _fail = *ref2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
      = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child.rs:LL:CC
    |
 LL | let ref2 = &mut *ref1;
-   |
+   |            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child_unique_writer.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child_unique_writer.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child_unique_writer.rs:LL:CC
    |
 LL | let _fail = *ref2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
      = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_child_unique_writer.rs:LL:CC
    |
 LL | let ref2 = &mut *ref1;
-   |
+   |            ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_disable.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_disable.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: read access through <wildcard> at ALLOC[0x0] is forbi
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_disable.rs:LL:CC
    |
 LL | let _fail = unsafe { *wild }; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |                      ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_foreign.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_foreign.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_foreign.rs:LL:CC
    |
 LL | let _fail = *ref3; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
      = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_foreign.rs:LL:CC
    |
 LL | let ref3 = unsafe { &mut *ptr_base };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_local.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_local.run.stderr
@@ -2,30 +2,30 @@ error: Undefined Behavior: write access through <wildcard> at ALLOC[0x0] is forb
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_local.rs:LL:CC
    |
 LL | unsafe { wild.write(0) }; //miri: ~ ERROR: /write access through <wildcard> at .* is forbidden/
-   |
+   |               ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: the accessed tag <wildcard> is a child of the conflicting tag <TAG>(unprotected)
      = help: the conflicting tag <TAG>(unprotected) has state Frozen which forbids this child write access
 help: the conflicting tag <TAG>(unprotected) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_local.rs:LL:CC
    |
 LL | let ptr_base = &mut x as *mut u32;
-   |
+   |                ^
 help: the conflicting tag <TAG>(unprotected) later transitioned to Unique due to a child write access at offsets [0x0..0x4]
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: this transition corresponds to the first write to a 2-phase borrowed mutable reference
 help: the conflicting tag <TAG>(unprotected) later transitioned to Frozen due to a foreign read access at offsets [0x0..0x4]
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_local.rs:LL:CC
    |
 LL | let _y = x;
-   |
+   |          ^
      = help: this transition corresponds to a loss of write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_unique_writer.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_unique_writer.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_unique_writer.rs:LL:CC
    |
 LL | let _fail = *ref2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
      = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Frozen
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/multi_exposed_siblings_unique_writer.rs:LL:CC
    |
 LL | let ref2 = unsafe { &*ptr_base };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: this transition corresponds to a loss of read permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.rs:LL:CC
    |
 LL | *ref1 = 13; //miri: ~ ERROR: /write access through .* is forbidden/
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) is foreign to the protected tag <TAG>(StrongProtector) (i.e., it is not a child)
    = help: this foreign write access would cause the protected tag <TAG>(StrongProtector) (currently Reserved) to become Disabled
    = help: protected tags must never be Disabled
@@ -10,7 +10,7 @@ help: the accessed tag <TAG>(unprotected) was created here
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.rs:LL:CC
    |
 LL | let mut protect = |_arg: &mut u32| {
-   |
+   |                   ^
 help: the protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.rs:LL:CC
    |

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.run.stderr
@@ -15,7 +15,7 @@ help: the protected tag <TAG>(StrongProtector) was created here, in the initial 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protected_wildcard.rs:LL:CC
    |
 LL | let mut protect = |_arg: &mut u32| {
-   |
+   | ^
 
 stack backtrace:
 0: protected_wildcard::main::{closure#0}

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_conflicted.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_conflicted.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <wildcard> at ALLOC[0x0] is forb
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_conflicted.rs:LL:CC
    |
 LL | unsafe { *wild = 4 }; //miri: ~ ERROR: /write access through <wildcard> at .* is forbidden/
-   |
+   |          ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release.rs:LL:CC
    |
 LL | let _fail = unsafe { *ptr }; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |                      ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release.rs:LL:CC
    |
 LL | let ref6 = unsafe { &mut *ref3.get() };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a protector release (acting as a foreign write access) on every location previously accessed by this tag
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release.rs:LL:CC
    |
 LL | };
-   |
+   |  ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release2.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release2.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release2.rs:LL:CC
    |
 LL | let _fail = unsafe { *ptr }; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |                      ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release2.rs:LL:CC
    |
 LL | let ref6 = unsafe { &mut *ref4.get() };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a protector release (acting as a foreign write access) on every location previously accessed by this tag
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/protector_release2.rs:LL:CC
    |
 LL | };
-   |
+   |  ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_disable.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_disable.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: read access through <wildcard> at ALLOC[0x0] is forbi
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_disable.rs:LL:CC
    |
 LL | let _fail = unsafe { *wild }; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |                      ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_foreign.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_foreign.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_foreign.rs:LL:CC
    |
 LL | let _fail = *ref2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
      = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_foreign.rs:LL:CC
    |
 LL | let ref2 = unsafe { &mut *ptr_base };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_local.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_local.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: write access through <wildcard> at ALLOC[0x0] is forb
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_local.rs:LL:CC
    |
 LL | unsafe { wild.write(0) }; //miri: ~ ERROR: /write access through <wildcard> at .* is forbidden/
-   |
+   |               ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/core/src/ptr/mod.rs:LL:CC
    |
 LL | intrinsics::write_via_move(dst, src)
-   |
+   |                                 ^
      = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_only_ro.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_only_ro.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: write access through <wildcard> at ALLOC[0x0] is forb
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/single_exposed_only_ro.rs:LL:CC
    |
 LL | unsafe { *ptr = 0 }; //miri: ~ ERROR: /write access through <wildcard> at .* is forbidden/
-   |
+   |          ^
    = help: there are no exposed tags which may perform this access here
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/strongly_protected_wildcard.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/strongly_protected_wildcard.run.stderr
@@ -2,24 +2,24 @@ error: Undefined Behavior: deallocation through <TAG>(WeakProtector) at ALLOC[0x
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/strongly_protected_wildcard.rs:LL:CC
    |
 LL | drop(unsafe { Box::from_raw(raw as *mut i32) });
-   |
+   | ^
      = note: the above line calls library code, where the error was detected:
     --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
      = help: the allocation of the accessed tag <TAG>(WeakProtector) also contains the strongly protected tag <TAG>(StrongProtector)
      = help: the strongly protected tag <TAG>(StrongProtector) disallows deallocations
 help: the accessed tag <TAG>(WeakProtector) was created here
     --> RUSTLIB/core/src/mem/mod.rs:LL:CC
    |
 LL | pub const fn drop<T>(_x: T)
-   |
+   | ^
 help: the strongly protected tag <TAG>(StrongProtector) was created here, in the initial state Reserved
     --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/strongly_protected_wildcard.rs:LL:CC
    |
 LL | fn inner(x: &mut i32, f: fn(usize)) {
-   |
+   | ^
 
 stack backtrace:
 0: <std::alloc::System as core::alloc::global::GlobalAlloc>::dealloc

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness.rs:LL:CC
    |
 LL | let _fail = *ref2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness.rs:LL:CC
    |
 LL | let ref2 = unsafe { &mut *ptr_reb };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness.rs:LL:CC
    |
 LL | *ref1 = 13;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness_wildcard.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness_wildcard.run.stderr
@@ -2,18 +2,18 @@ error: Undefined Behavior: read access through <TAG>(unprotected) at ALLOC[0x0] 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness_wildcard.rs:LL:CC
    |
 LL | let _fail = *ref2; //miri: ~ ERROR: /read access through .* is forbidden/
-   |
+   |             ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child read access
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness_wildcard.rs:LL:CC
    |
 LL | let ref2 = unsafe { &mut *ptr_reb };
-   |
+   |                     ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/wildcard/subtree_internal_relatedness_wildcard.rs:LL:CC
    |
 LL | unsafe { *wild = 13 };
-   |
+   |          ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: reborrow through <TAG>(unprotected) at ALLOC[0x0] is 
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.rs:LL:CC
    |
 LL | fn add(&mut self, n: u64) -> u64 {
-   |
+   | ^
    = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this reborrow (acting as a child read access)
 help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.rs:LL:CC

--- a/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.run.stderr
+++ b/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.run.stderr
@@ -8,12 +8,12 @@ help: the accessed tag <TAG>(unprotected) was created here, in the initial state
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.rs:LL:CC
    |
 LL | let res = f.add(unsafe {
-   |
+   |           ^
 help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x8]
   --> bsan/tests/miri-tests/fail/aliasing/tree_borrows/write-during-2phase.rs:LL:CC
    |
 LL | *alias = 42;
-   |
+   | ^
    = help: this transition corresponds to a loss of read and write permissions
 
 stack backtrace:

--- a/tests/miri-tests/fail/baseline/alloc/deallocate-twice.run.stderr
+++ b/tests/miri-tests/fail/baseline/alloc/deallocate-twice.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
  --> bsan/tests/miri-tests/fail/baseline/alloc/deallocate-twice.rs:LL:CC
    |
 LL | dealloc(x, Layout::from_size_align_unchecked(1, 1)); //miri: ~ERROR: has been freed
-   |
+   | ^
    = note: the above line calls library code, where the error was detected:
   --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::free(ptr as *mut libc::c_void) }
-   |
+   |          ^
 
 stack backtrace:
 0: <std::alloc::System as core::alloc::global::GlobalAlloc>::dealloc

--- a/tests/miri-tests/fail/baseline/alloc/reallocate-change-alloc.run.stderr
+++ b/tests/miri-tests/fail/baseline/alloc/reallocate-change-alloc.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
  --> bsan/tests/miri-tests/fail/baseline/alloc/reallocate-change-alloc.rs:LL:CC
    |
 LL | let _z = *x; //miri: ~ ERROR: has been freed
-   |
+   |          ^
 
 stack backtrace:
 0: reallocate_change_alloc::main

--- a/tests/miri-tests/fail/baseline/alloc/reallocate-dangling.run.stderr
+++ b/tests/miri-tests/fail/baseline/alloc/reallocate-dangling.run.stderr
@@ -2,12 +2,12 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
  --> bsan/tests/miri-tests/fail/baseline/alloc/reallocate-dangling.rs:LL:CC
    |
 LL | let _z = realloc(x, Layout::from_size_align_unchecked(1, 1), 1); //miri: ~ERROR: has been freed
-   |
+   |          ^
    = note: the above line calls library code, where the error was detected:
   --> RUSTLIB/std/src/sys/alloc/unix.rs:LL:CC
    |
 LL | unsafe { libc::realloc(ptr as *mut libc::c_void, new_size) as *mut u8 }
-   |
+   |          ^
 
 stack backtrace:
 0: <std::alloc::System as core::alloc::global::GlobalAlloc>::realloc

--- a/tests/miri-tests/fail/baseline/dangling_pointers/dangling_pointer_deref.run.stderr
+++ b/tests/miri-tests/fail/baseline/dangling_pointers/dangling_pointer_deref.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
   --> bsan/tests/miri-tests/fail/baseline/dangling_pointers/dangling_pointer_deref.rs:LL:CC
    |
 LL | let x = unsafe { *p }; //miri: ~ ERROR: has been freed
-   |
+   |                  ^
 
 stack backtrace:
 0: dangling_pointer_deref::main

--- a/tests/miri-tests/fail/baseline/dangling_pointers/dangling_primitive.run.stderr
+++ b/tests/miri-tests/fail/baseline/dangling_pointers/dangling_primitive.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
   --> bsan/tests/miri-tests/fail/baseline/dangling_pointers/dangling_primitive.rs:LL:CC
    |
 LL | dbg!(*ptr); //miri: ~ ERROR: has been freed
-   |
+   | ^
 
 stack backtrace:
 0: dangling_primitive::main

--- a/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_read.run.stderr
+++ b/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_read.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: an access of size 2b at offset 0x6 is out of bounds f
  --> bsan/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_read.rs:LL:CC
    |
 LL | let x = unsafe { *v.as_ptr().wrapping_byte_add(6) }; //miri: ~ ERROR: attempting to access 2 bytes
-   |
+   |                  ^
 
 stack backtrace:
 0: out_of_bounds_read::main

--- a/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_read_neg_offset.run.stderr
+++ b/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_read_neg_offset.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: an access of size 2b at offset $HEX is out of bounds 
  --> bsan/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_read_neg_offset.rs:LL:CC
    |
 LL | let x = unsafe { *v.as_ptr().wrapping_byte_sub(6) }; //miri: ~ ERROR: before the beginning of the allocation
-   |
+   |                  ^
 
 stack backtrace:
 0: out_of_bounds_read_neg_offset::main

--- a/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_write.run.stderr
+++ b/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_write.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: an access of size 2b at offset 0x6 is out of bounds f
  --> bsan/tests/miri-tests/fail/baseline/dangling_pointers/out_of_bounds_write.rs:LL:CC
    |
 LL | unsafe { *v.as_mut_ptr().wrapping_byte_add(6) = 0 }; //miri: ~ ERROR: attempting to access 2 bytes
-   |
+   |          ^
 
 stack backtrace:
 0: out_of_bounds_write::main

--- a/tests/miri-tests/fail/baseline/dangling_pointers/stack_temporary.run.stderr
+++ b/tests/miri-tests/fail/baseline/dangling_pointers/stack_temporary.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
   --> bsan/tests/miri-tests/fail/baseline/dangling_pointers/stack_temporary.rs:LL:CC
    |
 LL | let val = *x; //miri: ~ ERROR: has been freed
-   |
+   |           ^
 
 stack backtrace:
 0: stack_temporary::main

--- a/tests/miri-tests/fail/baseline/tail_calls/dangling-local-var.run.stderr
+++ b/tests/miri-tests/fail/baseline/tail_calls/dangling-local-var.run.stderr
@@ -2,7 +2,7 @@ error: Undefined Behavior: trying to access an allocation that has been freed.
  --> bsan/tests/miri-tests/fail/baseline/tail_calls/dangling-local-var.rs:LL:CC
    |
 LL | let _val = unsafe { *x }; //miri: ~ERROR: has been freed, so this pointer is dangling
-   |
+   |                     ^
 
 stack backtrace:
 0: dangling_local_var::g


### PR DESCRIPTION
This adds carets to our error messages, like so:
```
 --> bsan/tests/fail/aliasing/frozen_write.rs:LL:CC
   |
LL | unsafe { *(ptr as *mut i32) = 1 };
   |          ^
```