### PR TITLE
Parallelize benchmarking across crates and architectures

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,7 +2,7 @@ name: Benchmarks
 on:
   push:
     branches: [ "main" ]
-  workflow_dispatch: 
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 permissions:
@@ -13,7 +13,18 @@ concurrency:
   group: benchmarks-${{ github.ref }}
   cancel-in-progress: false
 jobs:
-  build:
+  setup:
+    name: Compute crate matrix
+    runs-on: ubuntu-latest
+    outputs:
+      crates: ${{ steps.crates.outputs.crates }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Read crate list from crates.json
+      id: crates
+      run: echo "crates=$(jq -c '[.[].name]' tests/benches/crates.json)" >> "$GITHUB_OUTPUT"
+  bench:
+    needs: setup
     strategy:
       fail-fast: false
       matrix:
@@ -22,13 +33,14 @@ jobs:
             os: ubuntu-24.04-arm
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04
+        crate: ${{ fromJson(needs.setup.outputs.crates) }}
     runs-on: ${{ matrix.config.os }}
     container:
       image: ghcr.io/borrowsanitizer/bsan:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.github_token }}
-    name: ${{ matrix.config.target }}
+    name: ${{ matrix.crate }} (${{ matrix.config.target }})
     steps:
     - uses: actions/checkout@v4
     - name: Setup dependencies
@@ -39,14 +51,22 @@ jobs:
       run: ./xb install
     - name: Set output filename
       id: filename
-      run: echo "results=results_$(date +%Y-%m-%d_%H-%M-%S)_${{ matrix.config.target }}" >> $GITHUB_OUTPUT
+      env:
+        TARGET: ${{ matrix.config.target }}
+        CRATE: ${{ matrix.crate }}
+      run: echo "results=results_$(date +%Y-%m-%d_%H-%M-%S)_${TARGET}_${CRATE}" >> "$GITHUB_OUTPUT"
     - name: Benchmarks
-      run: | 
+      env:
+        TARGET: ${{ matrix.config.target }}
+        CRATE: ${{ matrix.crate }}
+        RESULTS: ${{ steps.filename.outputs.results }}
+      run: |
         python3 ./bsan-script/etc/bench.py \
+        --crate "$CRATE" \
         ./tests/benches/crates.json \
-        ${{ matrix.config.target }} \
-        ${{ steps.filename.outputs.results }}.json \
-        ${{ steps.filename.outputs.results }}.csv 
+        "$TARGET" \
+        "$RESULTS.json" \
+        "$RESULTS.csv"
     - name: Upload results
       uses: actions/upload-artifact@v4
       with:
@@ -57,7 +77,7 @@ jobs:
         retention-days: 30
   merge:
     name: Merge & Upload
-    needs: build
+    needs: bench
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -69,7 +89,7 @@ jobs:
         path: results/
     - name: Set merged filename
       id: merged_filename
-      run: echo "name=results_$(date +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_OUTPUT
+      run: echo "name=results_$(date +%Y-%m-%d_%H-%M-%S)" >> "$GITHUB_OUTPUT"
     - name: Merge JSON files
       run: jq -s 'add' results/*.json > ${{ steps.merged_filename.outputs.name }}.json
     - name: Upload merged results

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -431,13 +431,21 @@ def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         description="Benchmark relative execution time",
         usage=(
-            "%(prog)s <crates> <target> <output_json> <output_csv>"
+            "%(prog)s [--crate NAME ...] <crates> <target> <output_json> <output_csv>"
         ),
     )
     parser.add_argument("crates_json", type=Path)
     parser.add_argument("target", type=str)
     parser.add_argument("output_json", type=Path)
     parser.add_argument("output_csv", type=Path)
+    parser.add_argument(
+        "--crate",
+        action="append",
+        dest="only",
+        metavar="NAME",
+        help="Only benchmark the named crate from <crates> (repeatable). "
+             "Used to shard the benchmark suite one crate per CI job.",
+    )
 
     args = parser.parse_args(argv)
     for tool in ["cargo", "hyperfine"]:
@@ -447,10 +455,18 @@ def main(argv: list[str]) -> int:
     if not crates_json.is_file():
         sys.exit(f"Error: invalid config file: {crates_json}")
 
+    configs = json.loads(crates_json.read_text())
+    if args.only:
+        wanted = set(args.only)
+        configs = [cfg for cfg in configs if cfg.get("name") in wanted]
+        missing = wanted - {cfg.get("name") for cfg in configs}
+        if missing:
+            sys.exit(f"Error: crate(s) not found in {crates_json}: {', '.join(sorted(missing))}")
+
     all_results = {}
     with tempfile.TemporaryDirectory() as scratch_str:
         scratch = Path(scratch_str)
-        for cfg in json.loads(crates_json.read_text()):
+        for cfg in configs:
             cfg_results = process_config(cfg, args.target, scratch)
             all_results.setdefault("relative", [])
             all_results["relative"] += cfg_results["relative"]


### PR DESCRIPTION
## Overview

Parallelizing benchmark CI job across 8 shards (2 architectures x 4 crates). This also opens up the possibility of running more crates without bloating the benchmark job. GitHub limits us to 256 parallel shards, giving us room for 128 crates!