### PR TITLE
Factor out runtime-check decisions from the core instrumentation pass.

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1,4 +1,5 @@
 #include "BorrowSanitizerPass.h"
+#include "InstrumentationPlan.h"
 #include "Retag.h"
 #include "llvm/Analysis/DomTreeUpdater.h"
 #include "llvm/Analysis/GlobalsModRef.h"
@@ -1100,18 +1101,14 @@ class BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
   // Cached analysis results
   const TargetLibraryInfo *TLI;
   DominatorTree &DT;
+
   CycleInfo Cycles;
-  const StackSafetyGlobalInfo &SSGI;
+
+  InstrumentationPlan Plan;
 
   // The end of the prologue of the function, where we initialize our
   // instrumentation. This is a call to llvm.donothing.
   Instruction *FnPrologueEnd;
-
-  // The static allocations that we will instrument.
-  SmallVector<AllocaInst *, 8> StaticAllocaVec;
-
-  // The static allocations that have a `lifetime.start` intrinsic.
-  SmallDenseSet<AllocaInst *> HasLifetimeStart;
 
   // A map from Arguments to (byte offset, provenance count) pairs, indicating
   // the offset from the top of the header where the argument's provenane is
@@ -1147,26 +1144,17 @@ class BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
   // pointer to the PHINode and the index into its provenance.
   SmallVector<std::pair<ProvenanceMap::Key, Provenance>> ProvPHINodes;
 
-  // A vector containing every retag intrinsic invocation. Since these are
-  // "dummy" function calls, they need to be erased before the pass has
-  // finished.
-  SmallVector<CallBase *> Retags;
-
-  // The number of function-entry retags that occurred.
-  unsigned NumFnEntryRetags = 0;
-
   ShadowStackAllocator ShadowStack;
   Value *FrameVariadicTop = nullptr;
 
   // An allocation used to store the boundary marker for
   // invoke instructions involving uninstrumented functions.
   AllocaInst *MarkerAlloca = nullptr;
-
 public:
   BorrowSanitizerVisitor(Function &F, BorrowSanitizer &BS,
                          const TargetLibraryInfo &TLI, DominatorTree &DT,
                          const StackSafetyGlobalInfo &SSGI)
-      : F(F), BS(BS), C(BS.C), TLI(&TLI), DT(DT), SSGI(SSGI),
+      : F(F), BS(BS), C(BS.C), TLI(&TLI), DT(DT), Plan(F, BS.DL, DT, SSGI),
         ShadowStack(BS.ProvenanceSize, BS.ProvStackTLS) {}
   bool run() {
     DomTreeUpdater DTU(DT, DomTreeUpdater::UpdateStrategy::Lazy);
@@ -1178,59 +1166,17 @@ public:
 
     BasicBlock *EntryBlock = &F.getEntryBlock();
     IRBuilder<> EntryIRB(EntryBlock, EntryBlock->getFirstNonPHIIt());
-    SmallVector<Instruction *, 64> Instructions;
 
-    for (BasicBlock *BB : depth_first<BasicBlock *>(&F.getEntryBlock())) {
-      for (Instruction &I : *BB) {
-        if (I.getMetadata(LLVMContext::MD_nosanitize))
-          continue;
-        if (I.getOpcode() == Instruction::Alloca) {
-          auto &AI = static_cast<AllocaInst &>(I);
-          // SafeStack marks an alloca as safe when it is never exposed to an
-          // unknown source of memory effects. Such allocas cannot be subject
-          // to the aliasing violations our retags would detect, so we ignore
-          // them entirely instead of tracking and checking their accesses.
-          if (BS.shouldInstrumentAlloca(AI) && AI.isStaticAlloca() &&
-              !SSGI.isSafe(AI))
-            StaticAllocaVec.push_back(&AI);
-          continue;
-        }
-        if (auto *CB = dyn_cast<CallBase>(&I)) {
-          if (IsRetag(CB)) {
-            Retags.push_back(CB);
-            if (IsFnEntryRetag(CB))
-              NumFnEntryRetags += 1;
-          }
-          if (auto *LI = dyn_cast<LifetimeIntrinsic>(CB)) {
-            AllocaInst *AI = findAllocaForValue(LI->getArgOperand(0), true);
-            if (AI && BS.shouldInstrumentAlloca(*AI) && !SSGI.isSafe(*AI)) {
-              if (CB->getIntrinsicID() == Intrinsic::lifetime_start) {
-                HasLifetimeStart.insert(AI);
-              }
-            } else {
-              continue;
-            }
-          }
-        }
-        Instructions.push_back(&I);
-      }
-    }
+    Plan.build();
 
     initStack(EntryIRB);
 
-    for (Instruction *I : Instructions) {
+    for (Instruction *I : Plan.instructions()) {
       InstVisitor<BorrowSanitizerVisitor>::visit(*I);
     }
 
     patchShadowPHINodes();
     ShadowStack.patchStackSlots(DT);
-
-    for (CallBase *CB : Retags) {
-      if (CB->getType()->isPointerTy()) {
-        CB->replaceAllUsesWith(CB->getOperand(0));
-      }
-      CB->eraseFromParent();
-    }
     return true;
   }
 
@@ -1640,10 +1586,10 @@ private:
 
     // We push additional slots into the frame header for
     // static allocas.
-    for (auto [Idx, AI] : llvm::enumerate(StaticAllocaVec)) {
+    for (auto [Idx, AI] : llvm::enumerate(Plan.allocas())) {
       Provenance Prov = createAllocaMetadata(EntryIRB);
       NextNodeIRBuilder IRB(AI);
-      if (!HasLifetimeStart.contains(AI)) {
+      if (Plan.hasLifetimeStart(AI)) {
         Value *AllocaSize = BS.getAllocaSizeBytes(IRB, AI);
         initAllocaMetadata(IRB, AI, AllocaSize, Prov);
       }
@@ -1656,7 +1602,7 @@ private:
     // for function-entry retags. The total number of function
     // entry retags is variable, because function entry retags can
     // happen across different branches.
-    ShadowStack.allocateFnEntryRegion(EntryIRB, NumFnEntryRetags);
+    ShadowStack.allocateFnEntryRegion(EntryIRB, Plan.getNumFnEntryRetags());
 
     // We have initialized the frame header, but we have not updated the frame
     // pointer to reflect it.
@@ -2426,9 +2372,8 @@ private:
     if (ShadowStack.wasUsed()) {
       Value *NumStackAllocs =
           ShadowStack.getNumStackAllocSlots(IRB, BS.IntptrTy);
-      Value *NumProtectors =
-          ShadowStack.getOutgoingOffset(Cycles, IRB, BS.IntptrTy, true);
-      Value *MaxNumProtectors = ConstantInt::get(BS.IntptrTy, NumFnEntryRetags);
+      Value *NumProtectors = ShadowStack.getOutgoingOffset(Cycles, IRB, BS.IntptrTy, true);
+      Value *MaxNumProtectors = ConstantInt::get(BS.IntptrTy, Plan.getNumFnEntryRetags());
 
       Value *FrameHeaderBottom = ShadowStack.getOrInitFrameHeaderBottom(IRB);
       Value *OffsetSlots = IRB.CreateSub(MaxNumProtectors, NumProtectors);

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1150,6 +1150,7 @@ class BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
   // An allocation used to store the boundary marker for
   // invoke instructions involving uninstrumented functions.
   AllocaInst *MarkerAlloca = nullptr;
+
 public:
   BorrowSanitizerVisitor(Function &F, BorrowSanitizer &BS,
                          const TargetLibraryInfo &TLI, DominatorTree &DT,

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1151,6 +1151,11 @@ class BorrowSanitizerVisitor : public InstVisitor<BorrowSanitizerVisitor> {
   // invoke instructions involving uninstrumented functions.
   AllocaInst *MarkerAlloca = nullptr;
 
+  // Memory intrinsics that have been replaced by a call to the runtime. Their
+  // removal is deferred until after checks have been inserted, because each one
+  // is the insertion point for the checks guarding its own access.
+  SmallVector<MemIntrinsic *, 4> ReplacedMemIntrinsics;
+
 public:
   BorrowSanitizerVisitor(Function &F, BorrowSanitizer &BS,
                          const TargetLibraryInfo &TLI, DominatorTree &DT,
@@ -1165,16 +1170,29 @@ public:
     DTU.flush();
     Cycles.compute(F);
 
-    BasicBlock *EntryBlock = &F.getEntryBlock();
-    IRBuilder<> EntryIRB(EntryBlock, EntryBlock->getFirstNonPHIIt());
-
     Plan.build();
 
+    BasicBlock *EntryBlock = &F.getEntryBlock();
+    IRBuilder<> EntryIRB(EntryBlock, EntryBlock->getFirstNonPHIIt());
     initStack(EntryIRB);
 
     for (Instruction *I : Plan.instructions()) {
       InstVisitor<BorrowSanitizerVisitor>::visit(*I);
     }
+
+    for (const CheckInfo &CI : Plan.checks()) {
+      Value *AccessSize = CI.getAccessSize(BS.IntptrTy);
+      IRBuilder<> IRB(CI.InsertPt);
+      if (CI.AccessKind == CheckInfo::Read) {
+        insertReadCheck(IRB, CI.Target, AccessSize);
+      } else {
+        insertWriteCheck(IRB, CI.Target, AccessSize);
+      }
+    }
+
+    for (MemIntrinsic *MI : ReplacedMemIntrinsics)
+      MI->eraseFromParent();
+    ReplacedMemIntrinsics.clear();
 
     patchShadowPHINodes();
     ShadowStack.patchStackSlots(DT);
@@ -1590,7 +1608,7 @@ private:
     for (auto [Idx, AI] : llvm::enumerate(Plan.allocas())) {
       Provenance Prov = createAllocaMetadata(EntryIRB);
       NextNodeIRBuilder IRB(AI);
-      if (Plan.hasLifetimeStart(AI)) {
+      if (!Plan.hasLifetimeStart(AI)) {
         Value *AllocaSize = BS.getAllocaSizeBytes(IRB, AI);
         initAllocaMetadata(IRB, AI, AllocaSize, Prov);
       }
@@ -2047,30 +2065,25 @@ private:
   }
 
   void visitMemSetInst(MemSetInst &I) {
-    IRBuilder<> IRB(&I);
+    NextNodeIRBuilder IRB(&I);
     Value *Val = IRB.CreateIntCast(I.getValue(), IRB.getInt32Ty(), false);
     Value *Size = IRB.CreateIntCast(I.getLength(), BS.IntptrTy, false);
-    insertWriteCheck(IRB, I.getDest(), Size);
     IRB.CreateCall(BS.BsanFuncMemSet, {I.getDest(), Val, Size});
-    I.eraseFromParent();
+    ReplacedMemIntrinsics.push_back(&I);
   }
 
   void visitMemMoveInst(MemMoveInst &I) {
-    IRBuilder<> IRB(&I);
+    NextNodeIRBuilder IRB(&I);
     Value *Size = IRB.CreateIntCast(I.getLength(), BS.IntptrTy, false);
-    insertReadCheck(IRB, I.getSource(), Size);
-    insertWriteCheck(IRB, I.getDest(), Size);
     IRB.CreateCall(BS.BsanFuncMemMove, {I.getDest(), I.getSource(), Size});
-    I.eraseFromParent();
+    ReplacedMemIntrinsics.push_back(&I);
   }
 
   void visitMemCpyInst(MemCpyInst &I) {
-    IRBuilder<> IRB(&I);
+    NextNodeIRBuilder IRB(&I);
     Value *Size = IRB.CreateIntCast(I.getLength(), BS.IntptrTy, false);
-    insertReadCheck(IRB, I.getSource(), Size);
-    insertWriteCheck(IRB, I.getDest(), Size);
     IRB.CreateCall(BS.BsanFuncMemCpy, {I.getDest(), I.getSource(), Size});
-    I.eraseFromParent();
+    ReplacedMemIntrinsics.push_back(&I);
   }
 
   void insertReadCheck(IRBuilder<> &IRB, Value *Ptr, Value *Size) {
@@ -2095,10 +2108,6 @@ private:
       return;
 
     IRBuilder<> IRB(&LI);
-    Value *Ptr = LI.getPointerOperand();
-
-    Value *Size =
-        IRB.CreateTypeSize(BS.IntptrTy, BS.DL->getTypeStoreSize(LI.getType()));
 
     SmallVector<ProvenanceField> Components =
         BS.getProvenanceLayout(IRB, LI.getType());
@@ -2113,25 +2122,14 @@ private:
                                                  Comp.Elems, LI.getOrdering());
       setProvenance({&LI, Idx}, Prov);
     }
-    insertReadCheck(IRB, Ptr, Size);
   }
 
   void visitStoreInst(StoreInst &SI) {
-    IRBuilder<> BeforeIRB(&SI);
     Value *Ptr, *Val;
     Ptr = SI.getPointerOperand();
     Val = SI.getValueOperand();
 
-    // Insert a write check for the store size of the type.
-    // This may be different than the size of the type itself.
-    // An `i48` is a legal integer type in LLVM, but would typically
-    // be stored as an `i64`.
-    TypeSize TypeStoreSize = BS.DL->getTypeStoreSize(Val->getType());
-    Value *ValStoreSize = BeforeIRB.CreateTypeSize(BS.IntptrTy, TypeStoreSize);
-    insertWriteCheck(BeforeIRB, Ptr, ValStoreSize);
-
-    // If the write check succeeds, then we need to propagate provenance
-    // through the store instruction. This includes clearing provenance
+    // In addition to propagating provenance, we also need to clear provenance
     // from memory locations that are clobbered by non-pointer stores.
     // This is necessary for accurate reference counting and to
     // make sure that pointers that are cast from integers via load / store

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -2371,8 +2371,10 @@ private:
     if (ShadowStack.wasUsed()) {
       Value *NumStackAllocs =
           ShadowStack.getNumStackAllocSlots(IRB, BS.IntptrTy);
-      Value *NumProtectors = ShadowStack.getOutgoingOffset(Cycles, IRB, BS.IntptrTy, true);
-      Value *MaxNumProtectors = ConstantInt::get(BS.IntptrTy, Plan.getNumFnEntryRetags());
+      Value *NumProtectors =
+          ShadowStack.getOutgoingOffset(Cycles, IRB, BS.IntptrTy, true);
+      Value *MaxNumProtectors =
+          ConstantInt::get(BS.IntptrTy, Plan.getNumFnEntryRetags());
 
       Value *FrameHeaderBottom = ShadowStack.getOrInitFrameHeaderBottom(IRB);
       Value *OffsetSlots = IRB.CreateSub(MaxNumProtectors, NumProtectors);

--- a/bsan-pass/CMakeLists.txt
+++ b/bsan-pass/CMakeLists.txt
@@ -13,10 +13,12 @@ set(BSAN_SOURCES
   BorrowSanitizer.cpp
   BorrowSanitizerPass.cpp
   Retag.cpp
+  InstrumentationPlan.cpp
 )
 
 set(BSAN_HEADERS
   BorrowSanitizerPass.h
+  InstrumentationPlan.h
   Retag.h
 )
 

--- a/bsan-pass/InstrumentationPlan.cpp
+++ b/bsan-pass/InstrumentationPlan.cpp
@@ -5,22 +5,75 @@ namespace llvm {
 // We only instrument static allocas that have a non-zero size
 // and cannot be proven safe via LLVM's StackSafetyAnalysis.
 bool InstrumentationPlan::shouldInstrumentAlloca(const AllocaInst &AI) {
+  // Although Rust emits retags for ZSTs, tracking these
+  // allocations leads to false positive errors—probably
+  // due to interactions with lowering.
   Type *AllocType = AI.getAllocatedType();
   std::optional<TypeSize> AllocSize = AI.getAllocationSize(*DL);
-  return AllocType->isSized() && AI.isStaticAlloca() && !SSGI.isSafe(AI);
+  return AllocType->isSized() && AllocSize.has_value() &&
+         !AllocSize.value().isZero() &&
+         // We only instrument static allocas
+         AI.isStaticAlloca() &&
+         // Retags are treated as an unknown source
+         // of memory effects, so they block stack safety
+         // from eliding checks for allocations that are
+         // accessed in-bounds, but may still be subject to
+         // aliasing violations.
+         !SSGI.isSafe(AI);
+}
+
+void InstrumentationPlan::collectChecks(Instruction *Inst) {
+  if (isa<MemSetInst>(Inst) || isa<MemTransferInst>(Inst)) {
+
+    auto *MI = cast<MemIntrinsic>(Inst);
+    AccessRange Range(DL, MI->getLength());
+
+    if (auto *MTI = dyn_cast<MemTransferInst>(MI)) {
+      Checks.emplace_back(Inst, CheckInfo::Read, MTI->getSource(), Range);
+    }
+    Checks.emplace_back(Inst, CheckInfo::Write, MI->getDest(), Range);
+    return;
+  }
+
+  Value *Ptr;
+  Type *AccessTy;
+  CheckInfo::Kind AccessKind;
+
+  if (auto *SI = dyn_cast<StoreInst>(Inst)) {
+    Ptr = SI->getPointerOperand();
+    AccessTy = SI->getValueOperand()->getType();
+    AccessKind = CheckInfo::Write;
+  } else if (auto *LI = dyn_cast<LoadInst>(Inst)) {
+    Ptr = LI->getPointerOperand();
+    AccessTy = LI->getType();
+    AccessKind = CheckInfo::Read;
+  } else {
+    return;
+  }
+
+  TypeSize AccessSize = DL->getTypeStoreSize(AccessTy);
+  if (AccessSize.isZero())
+    return;
+
+  Checks.emplace_back(Inst, AccessKind, Ptr, AccessRange(DL, AccessSize));
 }
 
 void InstrumentationPlan::build() {
+  // Collect each of the instructions might propagate provenance metadata.
   for (BasicBlock *BB : depth_first<BasicBlock *>(&F.getEntryBlock())) {
     for (Instruction &I : *BB) {
+      // Skip instructions that are marked to be ignored by the sanitizers.
       if (I.getMetadata(LLVMContext::MD_nosanitize))
         continue;
+
+      // Collect a list of static allocas to instrument.
       if (I.getOpcode() == Instruction::Alloca) {
         auto &AI = static_cast<AllocaInst &>(I);
         if (shouldInstrumentAlloca(AI))
           StaticAllocaVec.push_back(&AI);
         continue;
       }
+
       if (auto *CB = dyn_cast<CallBase>(&I)) {
         if (IsRetag(CB)) {
           Retags.push_back(CB);
@@ -38,8 +91,11 @@ void InstrumentationPlan::build() {
           }
         }
       }
+
+      collectChecks(&I);
       Instructions.push_back(&I);
     }
   }
 }
+
 } // namespace llvm

--- a/bsan-pass/InstrumentationPlan.cpp
+++ b/bsan-pass/InstrumentationPlan.cpp
@@ -1,0 +1,45 @@
+#include "InstrumentationPlan.h"
+
+namespace llvm {
+
+// We only instrument static allocas that have a non-zero size
+// and cannot be proven safe via LLVM's StackSafetyAnalysis.
+bool InstrumentationPlan::shouldInstrumentAlloca(const AllocaInst &AI) {
+  Type *AllocType = AI.getAllocatedType();
+  std::optional<TypeSize> AllocSize = AI.getAllocationSize(*DL);
+  return AllocType->isSized() && AI.isStaticAlloca() && !SSGI.isSafe(AI);
+}
+
+void InstrumentationPlan::build() {
+  for (BasicBlock *BB : depth_first<BasicBlock *>(&F.getEntryBlock())) {
+    for (Instruction &I : *BB) {
+      if (I.getMetadata(LLVMContext::MD_nosanitize))
+        continue;
+      if (I.getOpcode() == Instruction::Alloca) {
+        auto &AI = static_cast<AllocaInst &>(I);
+        if (shouldInstrumentAlloca(AI))
+          StaticAllocaVec.push_back(&AI);
+        continue;
+      }
+      if (auto *CB = dyn_cast<CallBase>(&I)) {
+        if (IsRetag(CB)) {
+          Retags.push_back(CB);
+          if (IsFnEntryRetag(CB))
+            NumFnEntryRetags += 1;
+        }
+        if (auto *LI = dyn_cast<LifetimeIntrinsic>(CB)) {
+          AllocaInst *AI = findAllocaForValue(LI->getArgOperand(0), true);
+          if (AI && shouldInstrumentAlloca(*AI)) {
+            if (CB->getIntrinsicID() == Intrinsic::lifetime_start) {
+              HasLifetimeStart.insert(AI);
+            }
+          } else {
+            continue;
+          }
+        }
+      }
+      Instructions.push_back(&I);
+    }
+  }
+}
+} // namespace llvm

--- a/bsan-pass/InstrumentationPlan.h
+++ b/bsan-pass/InstrumentationPlan.h
@@ -10,9 +10,11 @@
 #include "llvm/Analysis/StackLifetime.h"
 #include "llvm/Analysis/StackSafetyAnalysis.h"
 #include "llvm/Analysis/ValueTracking.h"
+#include "llvm/IR/ConstantRange.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
 #include "llvm/Transforms/Utils/Instrumentation.h"
@@ -21,6 +23,76 @@
 using namespace llvm;
 
 namespace llvm {
+
+// The extent of a memory access, in bytes, relative to the pointer being
+// dereferenced. This has multiple components, which is necessary to handle
+// static and dynamic ranges.
+struct AccessRange {
+  // The known minimum static range of the access. For dynamically-sized types,
+  // like scalable vectors, this does not cover the full range of the access,
+  // but it is sufficient for optimizing checks, because we can still coalesce
+  // accesses of smaller sizes into a dynamically-sized check that is known to
+  // be at least as large. An empty range indicates that we do not know anything
+  // about the bounds of the access.
+  ConstantRange StaticRange;
+  // The size of the type. This only applies for checks associated with
+  // operations like `load` and `store`, where a specific type determines the
+  // size of the access.
+  TypeSize Size = TypeSize::getFixed(0);
+  // The (optional) dynamic size of the access. This is necessary to record
+  // access sizes for memintrinsics.
+  Value *DynValue = nullptr;
+
+  AccessRange(const DataLayout *DL)
+      : StaticRange(ConstantRange::getEmpty(DL->getPointerSizeInBits())) {}
+
+  AccessRange(const DataLayout *DL, TypeSize AccessSize) : AccessRange(DL) {
+    Size = AccessSize;
+    APInt Bytes(StaticRange.getLower().getBitWidth(), Size.getKnownMinValue(),
+                /*isSigned=*/true);
+    if (Bytes.isNonNegative()) {
+      StaticRange = ConstantRange(StaticRange.getLower(), Bytes);
+    }
+  }
+
+  AccessRange(const DataLayout *DL, Value *Val) : AccessRange(DL) {
+    DynValue = Val;
+    if (auto *CL = dyn_cast<ConstantInt>(DynValue)) {
+      unsigned BitWidth = StaticRange.getLower().getBitWidth();
+      APInt APLen = CL->getValue().sextOrTrunc(BitWidth);
+      if (APLen.isStrictlyPositive()) {
+        StaticRange = ConstantRange(StaticRange.getLower(), APLen);
+      }
+    }
+  }
+};
+
+// Everything needed to emit a runtime check validating read or write access for
+// a given pointer, across a particular range.
+struct CheckInfo {
+  // The location where the check needs to be inserted.
+  Instruction *InsertPt;
+  enum Kind { Read, Write };
+  Kind AccessKind;
+  // The pointer being dereferenced.
+  Value *Target;
+  AccessRange Range;
+  CheckInfo(Instruction *InsertPt, Kind AccessKind, Value *Target,
+            AccessRange Range)
+      : InsertPt(InsertPt), AccessKind(AccessKind), Target(Target),
+        Range(Range) {}
+
+  // Materializes the number of bytes that this check needs to validate, as a
+  // value of type `Ty`, immediately before `InsertPt`. A runtime length takes
+  // precedence; otherwise the count follows from the accessed type, which
+  // `CreateTypeSize` expands into a `vscale` multiply when that type is
+  // scalable.
+  Value *getAccessSize(Type *Ty) const {
+    IRBuilder<> IRB(InsertPt);
+    return Range.DynValue ? IRB.CreateIntCast(Range.DynValue, Ty, false)
+                          : IRB.CreateTypeSize(Ty, Range.Size);
+  }
+};
 
 class InstrumentationPlan {
 private:
@@ -56,10 +128,16 @@ private:
   // Instructions to be visited by the subsequent instrumentation pass.
   SmallVector<Instruction *, 64> Instructions;
 
+  // The locations where a runtime access check is required, in the order
+  // that they are encountered while walking the function.
+  SmallVector<CheckInfo, 32> Checks;
+
 public:
   unsigned getNumFnEntryRetags() { return NumFnEntryRetags; }
 
   SmallVector<Instruction *, 64> &instructions() { return Instructions; }
+
+  SmallVector<CheckInfo, 32> &checks() { return Checks; }
 
   SmallVector<AllocaInst *, 8> &allocas() { return StaticAllocaVec; }
 
@@ -78,6 +156,7 @@ public:
 
 private:
   bool shouldInstrumentAlloca(const AllocaInst &AI);
+  void collectChecks(Instruction *Inst);
 };
 
 } // namespace llvm

--- a/bsan-pass/InstrumentationPlan.h
+++ b/bsan-pass/InstrumentationPlan.h
@@ -1,0 +1,84 @@
+#ifndef BSAN_INST_PLAN_H
+#define BSAN_INST_PLAN_H
+
+#include "BorrowSanitizerPass.h"
+#include "Retag.h"
+#include "llvm/Analysis/CFG.h"
+#include "llvm/Analysis/DomTreeUpdater.h"
+#include "llvm/Analysis/GlobalsModRef.h"
+#include "llvm/Analysis/MemoryBuiltins.h"
+#include "llvm/Analysis/StackLifetime.h"
+#include "llvm/Analysis/StackSafetyAnalysis.h"
+#include "llvm/Analysis/ValueTracking.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+#include "llvm/Transforms/Utils/Instrumentation.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
+
+using namespace llvm;
+
+namespace llvm {
+
+class InstrumentationPlan {
+private:
+  Function &F;
+  const DataLayout *DL;
+
+  // Cached analysis results
+  DominatorTree &DT;
+  const StackSafetyGlobalInfo &SSGI;
+
+public:
+  InstrumentationPlan(Function &F, const DataLayout *DL, DominatorTree &DT,
+                      const StackSafetyGlobalInfo &SSGI)
+      : F(F), DL(DL), DT(DT), SSGI(SSGI) {}
+
+  void build();
+
+private:
+  // The static allocations that we will instrument.
+  SmallVector<AllocaInst *, 8> StaticAllocaVec;
+
+  // The static allocations that have a `lifetime.start` intrinsic.
+  SmallDenseSet<const AllocaInst *> HasLifetimeStart;
+
+  // A vector containing every retag intrinsic invocation. Since these are
+  // "dummy" function calls, they need to be erased before the pass has
+  // finished.
+  SmallVector<CallBase *> Retags;
+
+  // The number of function-entry retags that occurred.
+  unsigned NumFnEntryRetags = 0;
+
+  // Instructions to be visited by the subsequent instrumentation pass.
+  SmallVector<Instruction *, 64> Instructions;
+
+public:
+  unsigned getNumFnEntryRetags() { return NumFnEntryRetags; }
+
+  SmallVector<Instruction *, 64> &instructions() { return Instructions; }
+
+  SmallVector<AllocaInst *, 8> &allocas() { return StaticAllocaVec; }
+
+  bool hasLifetimeStart(const AllocaInst *AI) {
+    return HasLifetimeStart.contains(AI);
+  }
+
+  ~InstrumentationPlan() {
+    for (CallBase *CB : Retags) {
+      if (CB->getType()->isPointerTy()) {
+        CB->replaceAllUsesWith(CB->getOperand(0));
+      }
+      CB->eraseFromParent();
+    }
+  }
+
+private:
+  bool shouldInstrumentAlloca(const AllocaInst &AI);
+};
+
+} // namespace llvm
+#endif


### PR DESCRIPTION
We determine when to insert run-time checks while we propagate provenance metadata. However, these are relatively independent operations. This PR introduces an `InstrumentationPlan` class, which does the following:

* Filters out instructions that are irrelevant for BorrowSanitizer.
* Determines which `allocas` need to be instrumented.
* Identifies calls to retag intrinsics.
* Determines which read and write checks need to be inserted, and where.

It will be much easier to prototype static optimizations within this intermediate stage, instead of having to weave optimization throughout the core instrumentation pass.