### PR TITLE
Make the GC acquire stack slots

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -393,9 +393,6 @@ private:
   /// Runtime function for reserving alloca metadata.
   FunctionCallee BsanFuncReserveStackSlot;
 
-  /// Runtime function for deallocating alloca metadata.
-  FunctionCallee BsanFuncDestroyStackSlot;
-
   /// A default personality function used for exception-handling.
   FunctionCallee DefaultPersonalityFn;
 
@@ -679,9 +676,6 @@ void BorrowSanitizer::initializeCallbacks(Module &M,
   BsanFuncReserveStackSlot =
       M.getOrInsertFunction(BSAN("reserve_stack_slot"),
                             FunctionType::get(PtrTy, /*isVarArg=*/false), AL);
-
-  BsanFuncDestroyStackSlot = M.getOrInsertFunction(BSAN("destroy_stack_slot"),
-                                                   AL, IRB.getVoidTy(), PtrTy);
 
   BsanFuncExposeProv = M.getOrInsertFunction(BSAN("expose_prov"), AL,
                                              IRB.getVoidTy(), IntptrTy, PtrTy);

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -548,17 +548,6 @@ AllocInfo *__bsan_reserve_stack_slot() {
 }
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_destroy_stack_slot_impl(AllocInfo *slot);
-
-SANITIZER_INTERFACE_ATTRIBUTE
-void __bsan_destroy_stack_slot(AllocInfo *slot) {
-  if (__bsan_destroy_stack_slot_impl) {
-    InterceptorBarrier barrier;
-    __bsan_destroy_stack_slot_impl(slot);
-  }
-}
-
-SANITIZER_WEAK_ATTRIBUTE
 AllocInfo *__bsan_alloc_impl(void *base_addr, uptr size, BorTag bor_tag,
                              Span pc);
 
@@ -623,8 +612,7 @@ void __bsan_protector_end_impl(BorTag bor_tag, AllocInfo *alloc_info, Span pc);
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_pop_frame(const Provenance *frame_start, uptr prot,
                       uptr alloca_vec_size) {
-  if (__bsan_protector_end_impl && __bsan_destroy_stack_slot_impl &&
-      __bsan_dealloc_stack_impl) {
+  if (__bsan_protector_end_impl && __bsan_dealloc_stack_impl) {
     GET_SPAN;
     InterceptorBarrier barrier;
     for (uptr i = 0; i < prot + alloca_vec_size; i++) {
@@ -633,7 +621,6 @@ void __bsan_pop_frame(const Provenance *frame_start, uptr prot,
         __bsan_protector_end_impl(prov.tag, prov.info, span);
       } else {
         __bsan_dealloc_stack_impl(prov.tag, prov.info, span);
-        __bsan_destroy_stack_slot_impl(prov.info);
       }
     }
   }

--- a/bsan-rt/llvm-wrapper/bsan_set.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_set.cpp
@@ -58,6 +58,11 @@ void BorTagSet::destroy() {
   }
 }
 
+void ConcreteProvenanceSet::insert(AllocInfo *info) {
+  if (info != nullptr) {
+    set_[info] = BorTagSet();
+  }
+}
 void ConcreteProvenanceSet::insert(Provenance prov) {
   if (prov.info != nullptr) {
     set_[prov.info].insert(prov.tag);

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -78,6 +78,8 @@ public:
   ConcreteProvenanceSet(const ConcreteProvenanceSet &) = delete;
   ConcreteProvenanceSet &operator=(const ConcreteProvenanceSet &) = delete;
 
+  void insert(AllocInfo *info);
+  void remove(AllocInfo *info);
   void insert(Provenance Prov);
   void remove(Provenance Prov);
 

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -529,9 +529,6 @@ unsafe extern "C-unwind" fn __bsan_rc_inc_impl(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) -> bool {
-    // A null `alloc_info` denotes an empty/cleared shadow slot (e.g. one whose
-    // info was nulled by `ClearShadow` while a stale tag lingered). There is no
-    // allocation to deref, so there is nothing to count.
     if alloc_info.is_null() {
         return false;
     }
@@ -547,8 +544,6 @@ unsafe extern "C-unwind" fn __bsan_rc_dec_impl(
     bor_tag: BorTag,
     alloc_info: *mut AllocInfo,
 ) -> bool {
-    // See `__bsan_rc_inc_impl`: a null `alloc_info` is an empty shadow slot with
-    // no live reference to release.
     if alloc_info.is_null() {
         return false;
     }
@@ -560,14 +555,6 @@ unsafe extern "C-unwind" fn __bsan_rc_dec_impl(
 #[unsafe(no_mangle)]
 unsafe extern "C" fn __bsan_reserve_stack_slot_impl() -> NonNull<AllocInfo> {
     unsafe { global_ctx().create_alloc_info(AllocInfo::invalid()) }
-}
-
-#[unsafe(no_mangle)]
-unsafe extern "C" fn __bsan_destroy_stack_slot_impl(slot: NonNull<AllocInfo>) {
-    let ctx = unsafe { global_ctx() };
-    unsafe {
-        ctx.destroy_alloc_info(slot);
-    }
 }
 
 /// Initializes stack allocation metadata in-place.


### PR DESCRIPTION
We originally handled stack allocation lifetimes through a different mechanism than garbage collection. When a stack slot was deallocated at the end of a function, we would eagerly return its metadata to the allocator, even if associated provenance still remained in memory. 

We were able to avoid this because our allocator never releases memory back to the system. However, we might want to be able to do this in a future revision. It's also much simpler to manage all allocation metadata through the same GC mechanism than to treat stack slots differently. 

There's a different issue here, which is that we reuse the same metadata object for each lifetime of an `alloca`. This decision is sound, but it relies on provenance values carrying an identifier that uniquely identifies each lifetime. This is true today, because our borrow tags are created by a global `usize` counter, but it might not be true forever if we switch to a smaller provenance representation. 