### PR TITLE
Remove protection from inlined retags.

### DIFF
--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1284,7 +1284,7 @@ public:
     DTU.flush();
     Cycles.compute(F);
 
-    Plan.build();
+    Plan.build(Cycles);
 
     BasicBlock *EntryBlock = &F.getEntryBlock();
     IRBuilder<> EntryIRB(EntryBlock, EntryBlock->getFirstNonPHIIt());

--- a/bsan-pass/InstrumentationPlan.cpp
+++ b/bsan-pass/InstrumentationPlan.cpp
@@ -58,7 +58,7 @@ void InstrumentationPlan::collectChecks(Instruction *Inst) {
   Checks.emplace_back(Inst, AccessKind, Ptr, AccessRange(DL, AccessSize));
 }
 
-void InstrumentationPlan::build() {
+void InstrumentationPlan::build(CycleInfo &CI) {
   // Collect each of the instructions might propagate provenance metadata.
   for (BasicBlock *BB : depth_first<BasicBlock *>(&F.getEntryBlock())) {
     for (Instruction &I : *BB) {
@@ -77,8 +77,19 @@ void InstrumentationPlan::build() {
       if (auto *CB = dyn_cast<CallBase>(&I)) {
         if (IsRetag(CB)) {
           Retags.push_back(CB);
-          if (IsFnEntryRetag(CB))
-            NumFnEntryRetags += 1;
+
+          RetagInfo RI(CB);
+          if (RI.isProtected()) {
+            // If we see a function-entry retag within a cyclic subgraph
+            // of the CFG, then we know that a function was inlined.
+            // Protectors do not play well with inlining, so we treat this as
+            // a regular retag.
+            if (CI.getCycle(CB->getParent())) {
+              RI.stripProtector();
+            } else {
+              NumFnEntryRetags += 1;
+            }
+          }
         }
         if (auto *LI = dyn_cast<LifetimeIntrinsic>(CB)) {
           AllocaInst *AI = findAllocaForValue(LI->getArgOperand(0), true);

--- a/bsan-pass/InstrumentationPlan.h
+++ b/bsan-pass/InstrumentationPlan.h
@@ -108,7 +108,7 @@ public:
                       const StackSafetyGlobalInfo &SSGI)
       : F(F), DL(DL), DT(DT), SSGI(SSGI) {}
 
-  void build();
+  void build(CycleInfo &CI);
 
 private:
   // The static allocations that we will instrument.

--- a/bsan-pass/Retag.cpp
+++ b/bsan-pass/Retag.cpp
@@ -1,6 +1,5 @@
 
 #include "Retag.h"
-
 namespace llvm {
 // Indicates that this is a call to one of
 // BorrowSanitizer's retag intrinsic functions.
@@ -10,14 +9,4 @@ bool IsRetag(const CallBase *CB) {
          Callee->getName().starts_with(RUST_FN("retag"));
 }
 
-// Indicates that this is a call to one of
-// BorrowSanitizer's retag intrinsic functions,
-// and that this represents a function-entry retag,
-// which creates a protected permission.
-bool IsFnEntryRetag(const CallBase *CB) {
-  if (IsRetag(CB)) {
-    return RetagInfo(CB).isProtected();
-  }
-  return false;
-}
 } // namespace llvm

--- a/bsan-pass/Retag.h
+++ b/bsan-pass/Retag.h
@@ -10,13 +10,14 @@ namespace llvm {
 
 class RetagInfo {
 public:
+  CallBase *CB;
   Value *Ptr;
   Value *ImArray;
   Value *PinArray;
   ConstantInt *Size;
   ConstantInt *Perms;
 
-  RetagInfo(const CallBase *CB) {
+  RetagInfo(CallBase *CB) : CB(CB) {
     assert(CB->arg_size() == 5);
     Ptr = CB->getOperand(0);
     Size = cast<ConstantInt>(CB->getOperand(1));
@@ -24,14 +25,23 @@ public:
     ImArray = CB->getOperand(3);
     PinArray = CB->getOperand(4);
   }
+
   bool isProtected() {
     // The least significant bit of the permission
     // indicates whether this is a function-entry retag.
     return (Perms->getZExtValue() & 0x1) != 0;
   }
+
+  void stripProtector() {
+    if (!isProtected())
+      return;
+    uint64_t OldVal = Perms->getZExtValue();
+    uint64_t NewVal = OldVal & ~0x1;
+    Perms = cast<ConstantInt>(ConstantInt::get(Perms->getType(), NewVal));
+    CB->setOperand(2, Perms);
+  }
 };
 
-bool IsFnEntryRetag(const CallBase *CB);
 bool IsRetag(const CallBase *CB);
 
 } // end namespace llvm

--- a/tests/pass/issue_306.rs
+++ b/tests/pass/issue_306.rs
@@ -1,0 +1,38 @@
+//@compile-flags: -Copt-level=3
+//@run:0
+fn recurse(b: &mut bool) {
+    if *b {
+    } else {
+        *b = true;
+        recurse(b)
+    }
+}
+
+fn recurse_count(b: &mut bool, ct: usize) {
+    if *b {
+    } else {
+        if ct > 0 {
+            *b = true;
+        }
+        recurse_count(b, ct + 1)
+    }
+}
+
+fn run_recurse() {
+    let mut b = false;
+    recurse(&mut b);
+    b = false;
+    std::hint::black_box(&b);
+}
+
+fn run_recurse_count() {
+    let mut b = false;
+    recurse_count(&mut b, 0);
+    b = false;
+    std::hint::black_box(&b);
+}
+
+fn main() {
+    run_recurse();
+    run_recurse_count();
+}


### PR DESCRIPTION
A tentative fix for #306.

When optimizations are enabled, functions with function-entry retags might be inlined. If a function-entry retag is inlined into the body of a loop, then slots containing protected tags might be overwritten, or the number of function entry retags could be miscounted. This PR avoids the problem by turning function-entry retags into "regular" retags when they occur within a cycle of the CFG. With inlining disabled, function-entry retags will always occur within an acyclic subgraph.