### PR TITLE
Switch to nightly Rust!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 target
 Makefile
 CMakeCache.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-build
 target
 Makefile
 CMakeCache.txt

--- a/bsan-pass/BorrowSanitizer.cpp
+++ b/bsan-pass/BorrowSanitizer.cpp
@@ -1592,7 +1592,8 @@ private:
     // from the rest of its body. This creates a dedicated insertion point for
     // instructions that require the shadow stack to be initialized and
     // need to create values that dominate the body of the function.
-    FnPrologueEnd = TopIRB.CreateIntrinsic(Intrinsic::donothing, {});
+    FnPrologueEnd = static_cast<Instruction *>(
+        TopIRB.CreateIntrinsic(Intrinsic::donothing, {}));
     IRBuilder<> EntryIRB(FnPrologueEnd);
 
     // We need to compute the total number of provenance values that

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -448,7 +448,7 @@ struct CompilerRt;
 impl CompilerRt {
     fn cmake(env: &mut BsanEnv) -> Result<Config> {
         let output_dir = path!(env.artifact_dir() / "compiler-rt");
-        let src_dir = path!(env.sysroot / "compiler-rt");
+        let src_dir = path!(env.toolchain_config.llvm_dir / "compiler-rt");
         let crt_include = path!(src_dir / "include");
         let sanitizer_common = path!(src_dir / "lib");
 
@@ -456,14 +456,15 @@ impl CompilerRt {
         let cmake_common = path!(env.toolchain_config.llvm_dir / "cmake");
 
         let mut cfg = env.llvm_cmake(&src_dir, &output_dir, &[crt_include, sanitizer_common])?;
-        cfg.define("LLVM_MAIN_SRC_DIR", &env.sysroot);
+
+        cfg.define("LLVM_MAIN_SRC_DIR", &env.toolchain_config.llvm_dir);
         cfg.define("COMPILER_RT_SANITIZERS_TO_BUILD", "bsan");
         cfg.define("COMPILER_RT_HAS_BSAN", "TRUE");
         cfg.define("COMPILER_RT_HAS_LLVMTESTINGSUPPORT", "FALSE");
         cfg.define("LLVM_COMMON_CMAKE_UTILS", cmake_common);
         cfg.define("LLVM_CMAKE_DIR", llvm_cmake);
         cfg.define("BSAN_CLANG_FORMAT", env.sysroot_binary("clang-format"));
-        
+
         cfg.build_target(&CompilerRt.artifact(env));
         Ok(cfg)
     }

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -92,7 +92,7 @@ impl Command {
 
         crate::all_components!().iter().try_for_each(|c| c.install(env, &[]))?;
 
-        let cargo_test_path = path!(env.build_dir / "bsan");
+        let cargo_test_path = path!(env.target_dir / "bsan");
         cmd!(env.sh, "rm -rf {cargo_test_path}").run()?;
         cmd!(env.sh, "python3 tests/test-cargo-bsan/run_test.py").run()?;
         Self::stats(env)?;
@@ -114,7 +114,7 @@ impl Command {
     }
 
     fn clean(env: &mut BsanEnv) -> Result<()> {
-        fs::remove_dir_all(&env.build_dir)?;
+        fs::remove_dir_all(&env.target_dir)?;
         Ok(())
     }
 
@@ -144,7 +144,7 @@ impl Command {
 
             let llvm_runtime = env.build_artifact(CompilerRt, &[])?;
             let cargo_bsan = env.build_artifact(CargoBsan, &[])?;
-            let sysroot_dir = path!(&env.build_dir / "sysroot");
+            let sysroot_dir = path!(&env.target_dir / "sysroot");
 
             let env_guards = vec![
                 env.sh.push_env("BSAN_PLUGIN", &plugin),
@@ -258,13 +258,13 @@ struct TestConfig {
 }
 
 fn run_tests(env: &mut BsanEnv, config: TestConfig) -> Result<(), anyhow::Error> {
-    let sysroot_dir = path!(&env.build_dir / "sysroot");
+    let sysroot_dir = path!(&env.target_dir / "sysroot");
     if !config.keep_sysroot {
         cmd!(env.sh, "rm -rf {sysroot_dir}").quiet().run()?;
         // The cached build of the test suite's dependencies goes stale for the
         // same reasons as the sysroot: Cargo does not know to rebuild it when
         // the instrumentation pass changes.
-        let dep_cache = path!(&env.build_dir / "tmp" / "bsan_ui");
+        let dep_cache = path!(&env.target_dir / "tmp" / "bsan_ui");
         cmd!(env.sh, "rm -rf {dep_cache}").quiet().run()?;
     }
     env.sh.set_var("BSAN_SYSROOT", &sysroot_dir);

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -282,7 +282,7 @@ fn run_tests(env: &mut BsanEnv, config: TestConfig) -> Result<(), anyhow::Error>
         let llvm_runtime = env.build_artifact(CompilerRt, args)?;
 
         let pass = env.build_artifact(BsanPass, args)?;
-        let symbolizer = env.sysroot_binary("llvm-symbolizer");
+        let symbolizer = env.ci_llvm_binary("llvm-symbolizer");
 
         env_guards.push(env.sh.push_env("BSAN_RT_RUST", &rust_runtime));
         env_guards.push(env.sh.push_env("BSAN_RT_LLVM", &llvm_runtime));

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -452,14 +452,18 @@ impl CompilerRt {
         let crt_include = path!(src_dir / "include");
         let sanitizer_common = path!(src_dir / "lib");
 
+        let llvm_cmake = path!(env.toolchain_config.llvm_dir / "llvm" / "cmake");
+        let cmake_common = path!(env.toolchain_config.llvm_dir / "cmake");
+
         let mut cfg = env.llvm_cmake(&src_dir, &output_dir, &[crt_include, sanitizer_common])?;
         cfg.define("LLVM_MAIN_SRC_DIR", &env.sysroot);
         cfg.define("COMPILER_RT_SANITIZERS_TO_BUILD", "bsan");
         cfg.define("COMPILER_RT_HAS_BSAN", "TRUE");
         cfg.define("COMPILER_RT_HAS_LLVMTESTINGSUPPORT", "FALSE");
-        cfg.define("LLVM_COMMON_CMAKE_UTILS", &env.toolchain_config.llvm_cmake.common);
-        cfg.define("LLVM_CMAKE_DIR", &env.toolchain_config.llvm_cmake.llvm);
+        cfg.define("LLVM_COMMON_CMAKE_UTILS", cmake_common);
+        cfg.define("LLVM_CMAKE_DIR", llvm_cmake);
         cfg.define("BSAN_CLANG_FORMAT", env.sysroot_binary("clang-format"));
+        
         cfg.build_target(&CompilerRt.artifact(env));
         Ok(cfg)
     }

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -282,7 +282,7 @@ fn run_tests(env: &mut BsanEnv, config: TestConfig) -> Result<(), anyhow::Error>
         let llvm_runtime = env.build_artifact(CompilerRt, args)?;
 
         let pass = env.build_artifact(BsanPass, args)?;
-        let symbolizer = env.ci_llvm_binary("llvm-symbolizer");
+        let symbolizer = env.sysroot_binary("llvm-symbolizer");
 
         env_guards.push(env.sh.push_env("BSAN_RT_RUST", &rust_runtime));
         env_guards.push(env.sh.push_env("BSAN_RT_LLVM", &llvm_runtime));

--- a/bsan-script/src/env.rs
+++ b/bsan-script/src/env.rs
@@ -20,8 +20,6 @@ pub struct BsanEnv {
     pub target_bindir: PathBuf,
     /// The sysroot of the nightly toolchain.
     pub sysroot: PathBuf,
-    /// The build directory containing dependencies and build artifacts.
-    pub build_dir: PathBuf,
     /// The target directory where build artifacts are placed by Cargo.
     pub target_dir: PathBuf,
     /// The root of the repository checkout we are working in.
@@ -123,14 +121,12 @@ impl BsanEnv {
         let config_path = path!(root_dir / "config.toml");
         let mut config = BsanConfig::from_file(&config_path)?;
 
-        let build_dir = path!(root_dir / "build");
-        let target_dir = path!(build_dir / "target");
+        let target_dir = path!(root_dir / "target");
 
         let toolchain_config = setup::setup_toolchain(
             &sh,
             &host,
             &mut config,
-            &build_dir,
             &deps_dir,
             &root_dir,
             skip,
@@ -186,7 +182,6 @@ impl BsanEnv {
             toolchain_config,
             sysroot,
             target_bindir,
-            build_dir,
             target_dir,
             root_dir,
             config,
@@ -282,18 +277,6 @@ impl BsanEnv {
 
     pub fn sysroot_binary(&self, binary_name: &str) -> PathBuf {
         let bin_dir = path!(self.sysroot / "bin");
-        let binary = path!(bin_dir / binary_name);
-        if !binary.exists() {
-            show_error!(
-                "Unable to locate binary `{binary_name}` within the sysroot bindir ({bin_dir:?})."
-            );
-        } else {
-            binary
-        }
-    }
-
-    pub fn ci_llvm_binary(&self, binary_name: &str) -> PathBuf {
-        let bin_dir = path!(self.build_dir / "ci-llvm" / "bin");
         let binary = path!(bin_dir / binary_name);
         if !binary.exists() {
             show_error!(
@@ -407,7 +390,7 @@ impl BsanEnv {
         out_dir: &Path,
         include_dirs: &[PathBuf],
     ) -> Result<cmake::Config> {
-        let llvm_config = self.ci_llvm_binary("llvm-config");
+        let llvm_config = self.sysroot_binary("llvm-config");
         let cxxflags = cmd!(self.sh, "{llvm_config}").arg("--cxxflags").output()?.stdout;
         let cxxflags: String = String::from_utf8(cxxflags)?;
 

--- a/bsan-script/src/env.rs
+++ b/bsan-script/src/env.rs
@@ -85,12 +85,10 @@ impl Mode {
 #[derive(Serialize, Deserialize)]
 pub struct BsanConfig {
     pub artifact_url: String,
-    pub tag: String,
-    pub sha: String,
-    pub version: String,
     pub dependencies: Vec<String>,
     pub targets: Vec<String>,
-    pub llvm_branch: String,
+    pub rust_sha: String,
+    pub llvm_sha: String,
     pub llvm_url: String,
 }
 
@@ -99,12 +97,6 @@ impl BsanConfig {
         let contents: String = std::fs::read_to_string(path)?;
         let contents: BsanConfig = toml::from_str(&contents)?;
         Ok(contents)
-    }
-
-    fn save(&self, path: &Path) -> Result<()> {
-        let contents: String = toml::to_string(self)?;
-        std::fs::write(path, contents)?;
-        Ok(())
     }
 }
 
@@ -141,7 +133,7 @@ impl BsanEnv {
             skip,
             install_from,
         )?;
-        config.save(&config_path)?;
+
 
         let build_dir = path!(root_dir / "target");
         // Hard-code the target dir, since we rely on all binaries ending up in the same spot.

--- a/bsan-script/src/env.rs
+++ b/bsan-script/src/env.rs
@@ -86,12 +86,8 @@ impl Mode {
 
 #[derive(Serialize, Deserialize)]
 pub struct BsanConfig {
-    pub artifact_url: String,
-    pub dependencies: Vec<String>,
-    pub targets: Vec<String>,
     pub rust_sha: String,
     pub llvm_sha: String,
-    pub llvm_url: String,
 }
 
 impl BsanConfig {
@@ -127,10 +123,9 @@ impl BsanEnv {
         let config_path = path!(root_dir / "config.toml");
         let mut config = BsanConfig::from_file(&config_path)?;
 
-
         let build_dir = path!(root_dir / "build");
         let target_dir = path!(build_dir / "target");
-        
+
         let toolchain_config = setup::setup_toolchain(
             &sh,
             &host,
@@ -142,9 +137,6 @@ impl BsanEnv {
             install_from,
         )?;
 
-
-
-        let build_dir = path!(root_dir / "target");
         // Hard-code the target dir, since we rely on all binaries ending up in the same spot.
         sh.set_var("CARGO_TARGET_DIR", &target_dir);
 
@@ -268,7 +260,7 @@ impl BsanEnv {
     }
 
     pub fn host_binary(&self, binary_name: &str) -> PathBuf {
-        if !self.config.dependencies.contains(&binary_name.to_string()) {
+        if !crate::DEPENDENCIES.contains(&binary_name) {
             show_error!(
                 "`{binary_name}` is not available as a host dependency. Try adding it to `config.toml`. "
             );
@@ -290,6 +282,18 @@ impl BsanEnv {
 
     pub fn sysroot_binary(&self, binary_name: &str) -> PathBuf {
         let bin_dir = path!(self.sysroot / "bin");
+        let binary = path!(bin_dir / binary_name);
+        if !binary.exists() {
+            show_error!(
+                "Unable to locate binary `{binary_name}` within the sysroot bindir ({bin_dir:?})."
+            );
+        } else {
+            binary
+        }
+    }
+
+    pub fn ci_llvm_binary(&self, binary_name: &str) -> PathBuf {
+        let bin_dir = path!(self.build_dir / "ci-llvm" / "bin");
         let binary = path!(bin_dir / binary_name);
         if !binary.exists() {
             show_error!(
@@ -403,7 +407,7 @@ impl BsanEnv {
         out_dir: &Path,
         include_dirs: &[PathBuf],
     ) -> Result<cmake::Config> {
-        let llvm_config = self.sysroot_binary("llvm-config");
+        let llvm_config = self.ci_llvm_binary("llvm-config");
         let cxxflags = cmd!(self.sh, "{llvm_config}").arg("--cxxflags").output()?.stdout;
         let cxxflags: String = String::from_utf8(cxxflags)?;
 

--- a/bsan-script/src/env.rs
+++ b/bsan-script/src/env.rs
@@ -20,8 +20,10 @@ pub struct BsanEnv {
     pub target_bindir: PathBuf,
     /// The sysroot of the nightly toolchain.
     pub sysroot: PathBuf,
-    /// The build directory
+    /// The build directory containing dependencies and build artifacts.
     pub build_dir: PathBuf,
+    /// The target directory where build artifacts are placed by Cargo.
+    pub target_dir: PathBuf,
     /// The root of the repository checkout we are working in.
     pub root_dir: PathBuf,
     /// The shell we use.
@@ -124,10 +126,16 @@ impl BsanEnv {
 
         let config_path = path!(root_dir / "config.toml");
         let mut config = BsanConfig::from_file(&config_path)?;
+
+
+        let build_dir = path!(root_dir / "build");
+        let target_dir = path!(build_dir / "target");
+        
         let toolchain_config = setup::setup_toolchain(
             &sh,
             &host,
             &mut config,
+            &build_dir,
             &deps_dir,
             &root_dir,
             skip,
@@ -135,9 +143,10 @@ impl BsanEnv {
         )?;
 
 
+
         let build_dir = path!(root_dir / "target");
         // Hard-code the target dir, since we rely on all binaries ending up in the same spot.
-        sh.set_var("CARGO_TARGET_DIR", &build_dir);
+        sh.set_var("CARGO_TARGET_DIR", &target_dir);
 
         let sysroot = active_sysroot()?;
         let target_libdir = active_libdir()?;
@@ -186,6 +195,7 @@ impl BsanEnv {
             sysroot,
             target_bindir,
             build_dir,
+            target_dir,
             root_dir,
             config,
             cargo_extra_flags,
@@ -292,7 +302,7 @@ impl BsanEnv {
 
     pub fn assert_artifact(&self, artifact_name: &str) -> PathBuf {
         let artifact_subdir = self.mode.cargo_output_dir();
-        let build_dir = path!(self.build_dir / artifact_subdir);
+        let build_dir = path!(self.target_dir / artifact_subdir);
         let artifact_path = path!(build_dir / artifact_name);
         if !artifact_path.exists() {
             show_error!(
@@ -337,7 +347,7 @@ impl BsanEnv {
 
     pub fn artifact_dir(&self) -> PathBuf {
         let artifact_subdir = self.mode.cargo_output_dir();
-        path!(self.build_dir / artifact_subdir)
+        path!(self.target_dir / artifact_subdir)
     }
 
     pub fn test(&self, crate_dir: impl AsRef<OsStr>, args: &[String]) -> Result<()> {

--- a/bsan-script/src/main.rs
+++ b/bsan-script/src/main.rs
@@ -13,6 +13,8 @@ mod stats;
 mod utils;
 
 static TOOLCHAIN_NAME: &str = "bsan";
+static DEPENDENCIES: &[&str] = &["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"];
+static TARGETS: &[&str] = &["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"];
 
 #[derive(Clone, Debug, Parser)]
 pub enum Command {

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -23,13 +23,14 @@ pub fn setup_toolchain(
     sh: &Shell,
     host: &VersionMeta,
     config: &mut BsanConfig,
+    build_dir: &Path,
     toolchain_dir: &Path,
     root_dir: &Path,
     skip_prompt: bool,
     local_dir: Option<PathBuf>,
 ) -> Result<ToolchainConfig> {
     let meta = ensure_toolchain(sh, host, config, toolchain_dir, skip_prompt, local_dir)?;
-    let llvm_cmake = ensure_llvm_cmake(sh, config, toolchain_dir, root_dir)?;
+    let llvm_cmake = ensure_llvm_cmake(sh, config, host, build_dir, root_dir)?;
     Ok(ToolchainConfig { llvm_cmake, meta })
 }
 fn ensure_toolchain(
@@ -143,10 +144,38 @@ pub struct LLVMCmake {
 pub fn ensure_llvm_cmake(
     sh: &Shell,
     config: &BsanConfig,
-    toolchain_dir: &Path,
+    host: &VersionMeta,
+    build_dir: &Path,
     root_dir: &Path,
 ) -> Result<LLVMCmake> {
-    let compiler_rt_src = path!(toolchain_dir / "compiler-rt");
+    let target = &host.host;
+
+    let tmp_dir = sh.create_temp_dir()?;
+    let help_on_error = "Failed to download the custom rust-dev artifacts.";
+    let artifact_url = path!(&config.artifact_url / config.rust_sha);
+
+    let download_unpack_install = |prefix: &str, needs_target: bool| -> Result<()> {
+        // Download the .tar.xz file
+        let mut tar_file_name = format!("{prefix}-nightly");
+        if needs_target {
+            tar_file_name = format!("{tar_file_name}-{target}");
+        }
+        let tar_file = format!("{tar_file_name}.tar.xz");
+
+
+        let tar_path = path!(tmp_dir.path() / tar_file);
+        utils::download_file(sh, &path!(artifact_url / tar_file), &tar_path, help_on_error)?;
+
+
+        // Unpack it into a .tmp subdirectory
+        let out_dir = path!(build_dir / prefix);
+        utils::unpack(&tar_path, &out_dir, "")?;
+        fs::remove_file(&tar_path)?;
+        Ok(())
+    };
+    download_unpack_install("rust-dev",true);
+
+    let compiler_rt_src = path!(build_dir / "compiler-rt");
     if !compiler_rt_src.exists() {
         show_error!(
             "Unable to locate the source for `compiler-rt` within the sysroot for the `bsan` toolchain."
@@ -164,7 +193,7 @@ pub fn ensure_llvm_cmake(
 
     let url = &config.llvm_url;
     let sha = &config.llvm_sha;
-    let lockfile = path!(toolchain_dir / ".llvm.lock");
+    let lockfile = path!(build_dir / ".llvm.lock");
 
     if !(lockfile.exists() && fs::read_to_string(&lockfile)?.eq(sha)) {
         let _tmp = sh.push_dir(&tmp_dir);
@@ -179,18 +208,18 @@ pub fn ensure_llvm_cmake(
         cmd!(sh, "git checkout -q FETCH_HEAD").run()?;
 
         for subdir in ["llvm", "cmake"] {
-            cmd!(sh, "cp -fr {subdir} {toolchain_dir}").run()?;
+            cmd!(sh, "cp -fr {subdir} {build_dir}").run()?;
         }
         fs::write(lockfile, sha)?;
     }
 
     let link_source = path!(root_dir / "bsan-rt" / "llvm-wrapper");
-    let link_target = path!(toolchain_dir / "compiler-rt" / "lib" / "bsan");
+    let link_target = path!(build_dir / "compiler-rt" / "lib" / "bsan");
     if !link_target.exists() {
         cmd!(sh, "ln -fs {link_source} {link_target}").quiet().run()?;
     }
     Ok(LLVMCmake {
-        llvm: path!(toolchain_dir / "llvm" / "cmake"),
-        common: path!(toolchain_dir / "cmake"),
+        llvm: path!(build_dir / "llvm" / "cmake"),
+        common: path!(build_dir / "cmake"),
     })
 }

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -34,14 +34,13 @@ pub fn setup_toolchain(
     sh: &Shell,
     host: &VersionMeta,
     config: &mut BsanConfig,
-    build_dir: &Path,
     toolchain_dir: &Path,
     root_dir: &Path,
     skip_prompt: bool,
     local_dir: Option<PathBuf>,
 ) -> Result<ToolchainConfig> {
     let meta = ensure_toolchain(sh, host, config, toolchain_dir, skip_prompt, local_dir)?;
-    let llvm_dir = ensure_llvm_cmake(sh, config, host, build_dir, root_dir)?;
+    let llvm_dir = ensure_llvm_cmake(sh, config, toolchain_dir, root_dir)?;
     Ok(ToolchainConfig { llvm_dir, meta })
 }
 fn ensure_toolchain(
@@ -139,6 +138,7 @@ fn install_toolchain(
     };
 
     download_unpack_install("rust", true)?;
+    download_unpack_install("rust-dev", true)?;
     download_unpack_install("rust-src", false)?;
     install_clang(sh, config, version, &toolchain_dir)?;
 
@@ -175,34 +175,14 @@ pub fn install_clang(
 pub fn ensure_llvm_cmake(
     sh: &Shell,
     config: &BsanConfig,
-    host: &VersionMeta,
-    build_dir: &Path,
+    toolchain_dir: &Path,
     root_dir: &Path,
 ) -> Result<PathBuf> {
-    let dest_path = path!(build_dir / "ci-llvm");
-
-    let sha = &config.llvm_sha;
-    let lockfile = path!(build_dir / ".llvm.lock");
-
-    if lockfile.exists() && fs::read_to_string(&lockfile)?.eq(sha) {
-        return Ok(dest_path);
-    }
-
-    let target = &host.host;
-
-    let tmp_dir = sh.create_temp_dir()?;
-    let help_on_error = "Failed to download the custom rust-dev artifacts.";
-    let artifact_url = path!(&RUST_ARTIFACT_URL / config.rust_sha);
-
-    let tar_file = format!("rust-dev-nightly-{target}.tar.xz");
-    let tar_path = path!(tmp_dir.path() / tar_file);
-    utils::download_file(sh, &path!(artifact_url / tar_file), &tar_path, help_on_error)?;
-    utils::unpack(&tar_path, &dest_path, Some("rust-dev"))?;
-    fs::remove_file(&tar_path)?;
-
-    let compiler_rt_src = path!(dest_path / "compiler-rt");
+    let compiler_rt_src = path!(toolchain_dir / "compiler-rt");
     if !compiler_rt_src.exists() {
-        show_error!("Unable to locate the source for `compiler-rt`.");
+        show_error!(
+            "Unable to locate the source for `compiler-rt` within the sysroot for the `bsan` toolchain."
+        );
     }
 
     let llvm_sparse = path!(root_dir / "bsan-script" / "etc" / "llvm-sparse");
@@ -211,31 +191,37 @@ pub fn ensure_llvm_cmake(
             "Unable to locate sparse checkout config file `llvm-sparse` in `bsan-script/etc/`."
         );
     }
-    let tmp_dir = sh.create_temp_dir()?;
-    let tmp_dir = tmp_dir.path();
 
-    let _tmp = sh.push_dir(&tmp_dir);
-    cmd!(sh, "git init -q .").run()?;
-    cmd!(sh, "git remote add origin {LLVM_URL}").run()?;
+    let sha = &config.llvm_sha;
+    let lockfile = path!(toolchain_dir / ".llvm.lock");
 
-    cmd!(sh, "git sparse-checkout set --no-cone --stdin")
-        .stdin(sh.read_file(&llvm_sparse)?)
-        .run()?;
+    if !(lockfile.exists() && fs::read_to_string(&lockfile)?.eq(sha)) {
+        let tmp_dir = sh.create_temp_dir()?;
+        let tmp_dir = tmp_dir.path();
 
-    cmd!(sh, "git fetch -q --depth=1 --filter=tree:0 origin {sha}").run()?;
-    cmd!(sh, "git checkout -q FETCH_HEAD").run()?;
+        let _tmp = sh.push_dir(tmp_dir);
+        cmd!(sh, "git init -q .").run()?;
+        cmd!(sh, "git remote add origin {LLVM_URL}").run()?;
 
-    for subdir in ["llvm", "cmake"] {
-        cmd!(sh, "cp -fr {subdir} {dest_path}").run()?;
+        cmd!(sh, "git sparse-checkout set --no-cone --stdin")
+            .stdin(sh.read_file(&llvm_sparse)?)
+            .run()?;
+
+        cmd!(sh, "git fetch -q --depth=1 --filter=tree:0 origin {sha}").run()?;
+        cmd!(sh, "git checkout -q FETCH_HEAD").run()?;
+
+        for subdir in ["llvm", "cmake"] {
+            cmd!(sh, "cp -fr {subdir} {toolchain_dir}").run()?;
+        }
+
+        fs::write(lockfile, sha)?;
     }
 
-    fs::write(lockfile, sha)?;
-
     let link_source = path!(root_dir / "bsan-rt" / "llvm-wrapper");
-    let link_target = path!(dest_path / "compiler-rt" / "lib" / "bsan");
+    let link_target = path!(compiler_rt_src / "lib" / "bsan");
     if !link_target.exists() {
         cmd!(sh, "ln -fs {link_source} {link_target}").quiet().run()?;
     }
 
-    Ok(dest_path)
+    Ok(toolchain_dir.to_path_buf())
 }

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -14,6 +14,13 @@ use crate::TOOLCHAIN_NAME;
 
 static INSTALL_PROMPT: &str = "You need to install the latest version of our custom Rust toolchain (`bsan`) to build BorrowSanitizer. Continue?";
 
+// The endpoint where Rust CI artifacts are distributed. This is the same URL used
+// by default with `rustup-toolchain-install-master`.
+static ARTIFACT_URL: &str = "https://ci-artifacts.rust-lang.org/rustc-builds";
+
+// Rust's fork of LLVM
+static LLVM_URL: &str = "https://github.com/rust-lang/llvm-project.git";
+
 pub struct ToolchainConfig {
     pub llvm_cmake: LLVMCmake,
     pub meta: VersionMeta,
@@ -59,7 +66,7 @@ fn ensure_toolchain(
     };
 
     // Let's make sure that we have all of the right dependencies
-    for dep in config.dependencies.iter() {
+    for dep in crate::DEPENDENCIES.iter() {
         if which::which(dep).is_err() {
             show_error!("Unable to find `{dep}`, is it installed?");
         }
@@ -70,7 +77,7 @@ fn ensure_toolchain(
     } else {
         // First, check if the current platform is supported.
         let current_target = &host.host;
-        if !config.targets.contains(&host.host) {
+        if !crate::TARGETS.contains(&current_target.as_str()) {
             show_error!("The current target `{current_target}` is not supported.");
         }
         // If we've passed these checks, then let's do the expensive step of
@@ -95,7 +102,7 @@ fn install_toolchain(
     cmd!(sh, "rustup toolchain uninstall {TOOLCHAIN_NAME}").quiet().run()?;
 
     let target = &host.host;
-    let artifact_url = path!(&config.artifact_url / config.rust_sha);
+    let artifact_url = path!(&ARTIFACT_URL / config.rust_sha);
     let help_on_error = "Failed to download the custom Rust toolchain.";
 
     let tmp_dir = sh.create_temp_dir()?;
@@ -118,7 +125,7 @@ fn install_toolchain(
 
         // Unpack it into a .tmp subdirectory
         let out_dir = path!(tmp_dir.path() / prefix);
-        utils::unpack(&tar_path, &out_dir, "")?;
+        utils::unpack(&tar_path, &out_dir, None)?;
         fs::remove_file(&tar_path)?;
 
         // Install it into the toolchain directory
@@ -128,7 +135,6 @@ fn install_toolchain(
     };
 
     download_unpack_install("rust", true)?;
-    download_unpack_install("rust-dev", true)?;
     download_unpack_install("rust-src", false)?;
 
     let meta = version_meta(sh, TOOLCHAIN_NAME)?;
@@ -148,38 +154,33 @@ pub fn ensure_llvm_cmake(
     build_dir: &Path,
     root_dir: &Path,
 ) -> Result<LLVMCmake> {
+    let dest_path = path!(build_dir / "ci-llvm");
+
+    let sha = &config.llvm_sha;
+    let lockfile = path!(build_dir / ".llvm.lock");
+
+    let llvm_cmake =
+        LLVMCmake { llvm: path!(dest_path / "llvm" / "cmake"), common: path!(dest_path / "cmake") };
+
+    if lockfile.exists() && fs::read_to_string(&lockfile)?.eq(sha) {
+        return Ok(llvm_cmake);
+    }
+
     let target = &host.host;
 
     let tmp_dir = sh.create_temp_dir()?;
     let help_on_error = "Failed to download the custom rust-dev artifacts.";
-    let artifact_url = path!(&config.artifact_url / config.rust_sha);
+    let artifact_url = path!(&ARTIFACT_URL / config.rust_sha);
 
-    let download_unpack_install = |prefix: &str, needs_target: bool| -> Result<()> {
-        // Download the .tar.xz file
-        let mut tar_file_name = format!("{prefix}-nightly");
-        if needs_target {
-            tar_file_name = format!("{tar_file_name}-{target}");
-        }
-        let tar_file = format!("{tar_file_name}.tar.xz");
+    let tar_file = format!("rust-dev-nightly-{target}.tar.xz");
+    let tar_path = path!(tmp_dir.path() / tar_file);
+    utils::download_file(sh, &path!(artifact_url / tar_file), &tar_path, help_on_error)?;
+    utils::unpack(&tar_path, &dest_path, Some("rust-dev"))?;
+    fs::remove_file(&tar_path)?;
 
-
-        let tar_path = path!(tmp_dir.path() / tar_file);
-        utils::download_file(sh, &path!(artifact_url / tar_file), &tar_path, help_on_error)?;
-
-
-        // Unpack it into a .tmp subdirectory
-        let out_dir = path!(build_dir / prefix);
-        utils::unpack(&tar_path, &out_dir, "")?;
-        fs::remove_file(&tar_path)?;
-        Ok(())
-    };
-    download_unpack_install("rust-dev",true);
-
-    let compiler_rt_src = path!(build_dir / "compiler-rt");
+    let compiler_rt_src = path!(dest_path / "compiler-rt");
     if !compiler_rt_src.exists() {
-        show_error!(
-            "Unable to locate the source for `compiler-rt` within the sysroot for the `bsan` toolchain."
-        );
+        show_error!("Unable to locate the source for `compiler-rt`.");
     }
 
     let llvm_sparse = path!(root_dir / "bsan-script" / "etc" / "llvm-sparse");
@@ -191,35 +192,28 @@ pub fn ensure_llvm_cmake(
     let tmp_dir = sh.create_temp_dir()?;
     let tmp_dir = tmp_dir.path();
 
-    let url = &config.llvm_url;
-    let sha = &config.llvm_sha;
-    let lockfile = path!(build_dir / ".llvm.lock");
+    let _tmp = sh.push_dir(&tmp_dir);
+    cmd!(sh, "git init -q .").run()?;
+    cmd!(sh, "git remote add origin {LLVM_URL}").run()?;
 
-    if !(lockfile.exists() && fs::read_to_string(&lockfile)?.eq(sha)) {
-        let _tmp = sh.push_dir(&tmp_dir);
-        cmd!(sh, "git init -q .").run()?;
-        cmd!(sh, "git remote add origin {url}").run()?;
+    cmd!(sh, "git sparse-checkout set --no-cone --stdin")
+        .stdin(sh.read_file(&llvm_sparse)?)
+        .run()?;
 
-        cmd!(sh, "git sparse-checkout set --no-cone --stdin")
-            .stdin(sh.read_file(&llvm_sparse)?)
-            .run()?;
+    cmd!(sh, "git fetch -q --depth=1 --filter=tree:0 origin {sha}").run()?;
+    cmd!(sh, "git checkout -q FETCH_HEAD").run()?;
 
-        cmd!(sh, "git fetch -q --depth=1 --filter=tree:0 origin {sha}").run()?;
-        cmd!(sh, "git checkout -q FETCH_HEAD").run()?;
-
-        for subdir in ["llvm", "cmake"] {
-            cmd!(sh, "cp -fr {subdir} {build_dir}").run()?;
-        }
-        fs::write(lockfile, sha)?;
+    for subdir in ["llvm", "cmake"] {
+        cmd!(sh, "cp -fr {subdir} {dest_path}").run()?;
     }
 
+    fs::write(lockfile, sha)?;
+
     let link_source = path!(root_dir / "bsan-rt" / "llvm-wrapper");
-    let link_target = path!(build_dir / "compiler-rt" / "lib" / "bsan");
+    let link_target = path!(dest_path / "compiler-rt" / "lib" / "bsan");
     if !link_target.exists() {
         cmd!(sh, "ln -fs {link_source} {link_target}").quiet().run()?;
     }
-    Ok(LLVMCmake {
-        llvm: path!(build_dir / "llvm" / "cmake"),
-        common: path!(build_dir / "cmake"),
-    })
+
+    Ok(llvm_cmake)
 }

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -46,7 +46,7 @@ fn ensure_toolchain(
     // bail out.
     let metadata = if let Ok(meta) = version_meta(sh, TOOLCHAIN_NAME)
         && let Some(ref commit_hash) = meta.commit_hash
-        && commit_hash == &config.sha
+        && commit_hash == &config.rust_sha
         && local_dir.is_none()
     {
         if active_toolchain()? != TOOLCHAIN_NAME {
@@ -94,16 +94,14 @@ fn install_toolchain(
     cmd!(sh, "rustup toolchain uninstall {TOOLCHAIN_NAME}").quiet().run()?;
 
     let target = &host.host;
-    let version = &config.version;
-    let archive_postfix: String = version.to_string();
-    let artifact_url = path!(&config.artifact_url / &config.tag);
+    let artifact_url = path!(&config.artifact_url / config.rust_sha);
     let help_on_error = "Failed to download the custom Rust toolchain.";
 
     let tmp_dir = sh.create_temp_dir()?;
 
     let download_unpack_install = |prefix: &str, needs_target: bool| -> Result<()> {
         // Download the .tar.xz file
-        let mut tar_file_name = format!("{prefix}-{archive_postfix}");
+        let mut tar_file_name = format!("{prefix}-nightly");
         if needs_target {
             tar_file_name = format!("{tar_file_name}-{target}");
         }
@@ -133,10 +131,6 @@ fn install_toolchain(
     download_unpack_install("rust-src", false)?;
 
     let meta = version_meta(sh, TOOLCHAIN_NAME)?;
-    config.sha =
-        meta.commit_hash.clone().expect("Unable to resolve commit hash for latest toolchain.");
-    config.version = meta.semver.to_string();
-
     cmd!(sh, "rustup override set {TOOLCHAIN_NAME}").quiet().run()?;
     Ok(meta)
 }
@@ -169,25 +163,25 @@ pub fn ensure_llvm_cmake(
     let tmp_dir = tmp_dir.path();
 
     let url = &config.llvm_url;
-    let branch = &config.llvm_branch;
+    let sha = &config.llvm_sha;
     let lockfile = path!(toolchain_dir / ".llvm.lock");
 
-    if !(lockfile.exists() && fs::read_to_string(&lockfile)?.eq(branch)) {
-        cmd!(sh, "git clone -n --depth=1 --filter=tree:0 --branch={branch} {url} {tmp_dir}")
+    if !(lockfile.exists() && fs::read_to_string(&lockfile)?.eq(sha)) {
+        let _tmp = sh.push_dir(&tmp_dir);
+        cmd!(sh, "git init -q .").run()?;
+        cmd!(sh, "git remote add origin {url}").run()?;
+
+        cmd!(sh, "git sparse-checkout set --no-cone --stdin")
+            .stdin(sh.read_file(&llvm_sparse)?)
             .run()?;
 
-        let mut sparse_checkout = path!(&tmp_dir / ".git/info");
-        fs::create_dir_all(&sparse_checkout)?;
-        sparse_checkout.push("sparse-checkout");
+        cmd!(sh, "git fetch -q --depth=1 --filter=tree:0 origin {sha}").run()?;
+        cmd!(sh, "git checkout -q FETCH_HEAD").run()?;
 
-        cmd!(sh, "ln -s {llvm_sparse} {sparse_checkout}").run()?;
-
-        cmd!(sh, "git -C {tmp_dir} sparse-checkout init").run()?;
-        cmd!(sh, "git -C {tmp_dir} checkout").run()?;
-        cmd!(sh, "cp -fr {tmp_dir}/llvm {toolchain_dir}").run()?;
-        cmd!(sh, "cp -fr {tmp_dir}/cmake {toolchain_dir}").run()?;
-
-        fs::write(lockfile, branch)?;
+        for subdir in ["llvm", "cmake"] {
+            cmd!(sh, "cp -fr {subdir} {toolchain_dir}").run()?;
+        }
+        fs::write(lockfile, sha)?;
     }
 
     let link_source = path!(root_dir / "bsan-rt" / "llvm-wrapper");

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -18,8 +18,9 @@ static INSTALL_PROMPT: &str = "You need to install the latest version of our cus
 // by default with `rustup-toolchain-install-master`.
 static RUST_ARTIFACT_URL: &str = "https://ci-artifacts.rust-lang.org/rustc-builds";
 
-// The endpoint where BorrowSanitizer's release artifacts are stored. 
-static GH_ARTIFACT_URL: &str = "https://github.com/BorrowSanitizer/nightly-clang/releases/download/";
+// The endpoint where BorrowSanitizer's release artifacts are stored.
+static GH_ARTIFACT_URL: &str =
+    "https://github.com/BorrowSanitizer/nightly-clang/releases/download/";
 
 // Rust's fork of LLVM
 static LLVM_URL: &str = "https://github.com/rust-lang/llvm-project.git";
@@ -97,14 +98,14 @@ fn ensure_toolchain(
 
 fn install_toolchain(
     sh: &Shell,
-    host: &VersionMeta,
+    version: &VersionMeta,
     config: &mut BsanConfig,
     toolchain_dir: &Path,
     local_dir: Option<&Path>,
 ) -> Result<VersionMeta> {
     cmd!(sh, "rustup toolchain uninstall {TOOLCHAIN_NAME}").quiet().run()?;
 
-    let target = &host.host;
+    let target = &version.host;
     let artifact_url = path!(&RUST_ARTIFACT_URL / config.rust_sha);
     let help_on_error = "Failed to download the custom Rust toolchain.";
 
@@ -139,15 +140,36 @@ fn install_toolchain(
 
     download_unpack_install("rust", true)?;
     download_unpack_install("rust-src", false)?;
+    install_clang(sh, config, version, &toolchain_dir)?;
 
     let meta = version_meta(sh, TOOLCHAIN_NAME)?;
     cmd!(sh, "rustup override set {TOOLCHAIN_NAME}").quiet().run()?;
     Ok(meta)
 }
 
+pub fn install_clang(
+    sh: &Shell,
+    config: &BsanConfig,
+    version: &VersionMeta,
+    toolchain_dir: &Path,
+) -> Result<()> {
+    let llvm_sha_tag = &config.llvm_sha.as_str()[0..7];
+    let release_tag = format!("clang-{}", llvm_sha_tag);
+    let endpoint = path!(GH_ARTIFACT_URL / release_tag);
 
-pub fn install_clang(sh: &Shell, config: &BsanConfig) {
+    let target = version.host.as_str();
+    let archive = format!("{release_tag}-{target}.tar.xz");
 
+    let artifact = path!(endpoint / archive);
+    let tmp_dir = sh.create_temp_dir()?;
+    let tar_path = path!(tmp_dir.path() / archive);
+
+    let help_text = "Unable to download BorrowSanitizer's nightly build of Clang.";
+
+    utils::download_file(sh, &artifact, &tar_path, help_text)?;
+    utils::unpack(&tar_path, &toolchain_dir, None)?;
+    fs::remove_file(&tar_path)?;
+    Ok(())
 }
 
 pub fn ensure_llvm_cmake(

--- a/bsan-script/src/setup.rs
+++ b/bsan-script/src/setup.rs
@@ -16,13 +16,16 @@ static INSTALL_PROMPT: &str = "You need to install the latest version of our cus
 
 // The endpoint where Rust CI artifacts are distributed. This is the same URL used
 // by default with `rustup-toolchain-install-master`.
-static ARTIFACT_URL: &str = "https://ci-artifacts.rust-lang.org/rustc-builds";
+static RUST_ARTIFACT_URL: &str = "https://ci-artifacts.rust-lang.org/rustc-builds";
+
+// The endpoint where BorrowSanitizer's release artifacts are stored. 
+static GH_ARTIFACT_URL: &str = "https://github.com/BorrowSanitizer/nightly-clang/releases/download/";
 
 // Rust's fork of LLVM
 static LLVM_URL: &str = "https://github.com/rust-lang/llvm-project.git";
 
 pub struct ToolchainConfig {
-    pub llvm_cmake: LLVMCmake,
+    pub llvm_dir: PathBuf,
     pub meta: VersionMeta,
 }
 
@@ -37,8 +40,8 @@ pub fn setup_toolchain(
     local_dir: Option<PathBuf>,
 ) -> Result<ToolchainConfig> {
     let meta = ensure_toolchain(sh, host, config, toolchain_dir, skip_prompt, local_dir)?;
-    let llvm_cmake = ensure_llvm_cmake(sh, config, host, build_dir, root_dir)?;
-    Ok(ToolchainConfig { llvm_cmake, meta })
+    let llvm_dir = ensure_llvm_cmake(sh, config, host, build_dir, root_dir)?;
+    Ok(ToolchainConfig { llvm_dir, meta })
 }
 fn ensure_toolchain(
     sh: &Shell,
@@ -102,7 +105,7 @@ fn install_toolchain(
     cmd!(sh, "rustup toolchain uninstall {TOOLCHAIN_NAME}").quiet().run()?;
 
     let target = &host.host;
-    let artifact_url = path!(&ARTIFACT_URL / config.rust_sha);
+    let artifact_url = path!(&RUST_ARTIFACT_URL / config.rust_sha);
     let help_on_error = "Failed to download the custom Rust toolchain.";
 
     let tmp_dir = sh.create_temp_dir()?;
@@ -142,9 +145,9 @@ fn install_toolchain(
     Ok(meta)
 }
 
-pub struct LLVMCmake {
-    pub common: PathBuf,
-    pub llvm: PathBuf,
+
+pub fn install_clang(sh: &Shell, config: &BsanConfig) {
+
 }
 
 pub fn ensure_llvm_cmake(
@@ -153,24 +156,21 @@ pub fn ensure_llvm_cmake(
     host: &VersionMeta,
     build_dir: &Path,
     root_dir: &Path,
-) -> Result<LLVMCmake> {
+) -> Result<PathBuf> {
     let dest_path = path!(build_dir / "ci-llvm");
 
     let sha = &config.llvm_sha;
     let lockfile = path!(build_dir / ".llvm.lock");
 
-    let llvm_cmake =
-        LLVMCmake { llvm: path!(dest_path / "llvm" / "cmake"), common: path!(dest_path / "cmake") };
-
     if lockfile.exists() && fs::read_to_string(&lockfile)?.eq(sha) {
-        return Ok(llvm_cmake);
+        return Ok(dest_path);
     }
 
     let target = &host.host;
 
     let tmp_dir = sh.create_temp_dir()?;
     let help_on_error = "Failed to download the custom rust-dev artifacts.";
-    let artifact_url = path!(&ARTIFACT_URL / config.rust_sha);
+    let artifact_url = path!(&RUST_ARTIFACT_URL / config.rust_sha);
 
     let tar_file = format!("rust-dev-nightly-{target}.tar.xz");
     let tar_path = path!(tmp_dir.path() / tar_file);
@@ -215,5 +215,5 @@ pub fn ensure_llvm_cmake(
         cmd!(sh, "ln -fs {link_source} {link_target}").quiet().run()?;
     }
 
-    Ok(llvm_cmake)
+    Ok(dest_path)
 }

--- a/bsan-script/src/utils.rs
+++ b/bsan-script/src/utils.rs
@@ -262,7 +262,7 @@ pub fn download_file(
     Ok(())
 }
 
-pub fn unpack(tarball: &Path, dst: &Path, pattern: &str) -> Result<()> {
+pub fn unpack(tarball: &Path, dst: &Path, pattern: Option<&str>) -> Result<()> {
     if !dst.exists() {
         std::fs::create_dir_all(dst)?;
     }
@@ -285,7 +285,11 @@ pub fn unpack(tarball: &Path, dst: &Path, pattern: &str) -> Result<()> {
             continue;
         }
         let mut short_path = original_path.strip_prefix(directory_prefix)?;
-        short_path = short_path.strip_prefix(pattern).unwrap_or(short_path);
+
+        if let Some(pattern) = pattern {
+            short_path = short_path.strip_prefix(pattern).unwrap_or(short_path);
+        }
+
         let dst_path = dst.join(short_path);
 
         if !member.unpack_in(dst)? {

--- a/cargo-bsan/src/llvm.rs
+++ b/cargo-bsan/src/llvm.rs
@@ -21,9 +21,9 @@ fn rustc_lld(sysroot_target_bindir: &Path) -> PathBuf {
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct LlvmTools {
     pub clang: PathBuf,
+    pub libclang_dir: PathBuf,
     pub llvm_symbolizer: PathBuf,
     pub lld: PathBuf,
-    pub llvm_config: PathBuf,
 }
 
 impl LlvmTools {
@@ -32,13 +32,11 @@ impl LlvmTools {
             show_error!("Unable to resolve the LLVM version for the current `rustc`.")
         });
 
-        let llvm_config = assert_host_bin(host_sysroot, "llvm-config");
-        assert_rustc_llvm_version(&llvm_config, &rustc_llvm_version);
-
         let clang = assert_host_bin(host_sysroot, &format!("clang-{}", rustc_llvm_version.major));
         assert_rustc_llvm_version(&clang, &rustc_llvm_version);
 
-        let sysroot_target_dir = host_sysroot.target_dir(rustc_version);
+        let sysroot_libdir: PathBuf = host_sysroot.lib();
+        let sysroot_target_dir: PathBuf = host_sysroot.target_dir(rustc_version);
         let sysroot_target_bindir = sysroot_target_dir.join("bin");
 
         let lld = rustc_lld(&sysroot_target_bindir);
@@ -47,43 +45,24 @@ impl LlvmTools {
         // llvm-symbolizer is versioned independent to LLVM
         let llvm_symbolizer = assert_host_bin(host_sysroot, "llvm-symbolizer");
 
-        LlvmTools { clang, llvm_symbolizer, lld, llvm_config }
+        LlvmTools { clang, libclang_dir: sysroot_libdir, llvm_symbolizer, lld }
     }
 
     pub fn populate_env(&self, cmd: &mut Command) {
         cmd.env("LLVM_SYMBOLIZER", &self.clang);
         cmd.env("LLD", &self.lld);
-        cmd.env("LLVM_CONFIG", &self.lld);
         // bindgen's clang-sys dependency requires these variables
         // to be set so that it uses our clang to parse headers.
-        cmd.env("LIBCLANG_PATH", self.llvm_libdir());
+        cmd.env("LIBCLANG_PATH", &self.libclang_dir);
         cmd.env("CLANG_PATH", &self.clang);
     }
 
     pub fn from_env() -> Self {
+        let libclang_dir = expect_env_path("LIBCLANG_PATH");
         let clang = expect_env_path("CLANG_PATH");
         let llvm_symbolizer = expect_env_path("LLVM_SYMBOLIZER");
         let lld = expect_env_path("LLD");
-        let llvm_config = expect_env_path("LLVM_CONFIG");
-        Self { clang, llvm_symbolizer, lld, llvm_config }
-    }
-
-    pub fn llvm_libdir(&self) -> PathBuf {
-        let mut cmd = Command::new(&self.llvm_config);
-        cmd.arg("--libdir");
-
-        let Some(path) = command_output(&mut cmd) else {
-            show_error_cmd!(cmd, "Unable to resolve the LLVM `lib` directory using `llvm-config`.");
-        };
-        let path = PathBuf::from(path);
-        if !path.try_exists().unwrap() {
-            show_error_cmd!(
-                cmd,
-                "The `lib` directory returned by `llvm-config` does not exist: {}",
-                path.display()
-            );
-        }
-        path
+        Self { clang, libclang_dir, llvm_symbolizer, lld }
     }
 }
 

--- a/cargo-bsan/src/util.rs
+++ b/cargo-bsan/src/util.rs
@@ -262,6 +262,10 @@ impl Sysroot {
         self.root.join("bin")
     }
 
+    pub fn lib(&self) -> PathBuf {
+        self.root.join("lib")
+    }
+
     pub fn binary(&self, binary: &str) -> Option<PathBuf> {
         let path = self.bin().join(binary);
         path.exists().then_some(path)

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,2 @@
-dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
-targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
-artifact_url = "https://ci-artifacts.rust-lang.org/rustc-builds"
 rust_sha = "7608eb7b07eaf93f16d7cf5bcb2098eca87503df"
 llvm_sha = "21cf28432798952d942bacc6bcee3a328faa3638"
-llvm_url = "https://github.com/rust-lang/llvm-project.git"

--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,6 @@
-artifact_url = "https://github.com/BorrowSanitizer/rust/releases/download/"
-tag = "rolling-1.99.0-dev-19aae76"
-sha = "19aae76e1251f647cf0fc8520ca8290f4c772660"
-version = "1.99.0-dev"
 dependencies = ["cmake", "ninja", "curl", "clang", "clang-tidy", "python3"]
 targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
-llvm_branch = "rustc/22.1-2026-05-19"
+artifact_url = "https://ci-artifacts.rust-lang.org/rustc-builds"
+rust_sha = "7608eb7b07eaf93f16d7cf5bcb2098eca87503df"
+llvm_sha = "21cf28432798952d942bacc6bcee3a328faa3638"
 llvm_url = "https://github.com/rust-lang/llvm-project.git"

--- a/tests/fail-dep/mirilli/bzip2.run.stderr
+++ b/tests/fail-dep/mirilli/bzip2.run.stderr
@@ -26,7 +26,7 @@ stack backtrace:
  at CARGO_REGISTRY/.../bzlib.rs:LL:CC
 1: <bzip2::mem::Compress>::compress
  at CARGO_REGISTRY/.../mem.rs:LL:CC
-2: <bzip2::bufread::BzEncoder<std::io::buffered::bufreader::BufReader<&[u8]>> as std::io::Read>::read
+2: <bzip2::bufread::BzEncoder<alloc::io::buffered::bufreader::BufReader<&[u8]>> as alloc::io::read::Read>::read
  at CARGO_REGISTRY/.../bufread.rs:LL:CC
 
 note: stack trace was truncated after 3 frames; set stacktrace_max_len (e.g. BSAN_OPTIONS=stacktrace_max_len=32) to capture more.

--- a/tests/fail/aliasing/c_variadics.rs
+++ b/tests/fail/aliasing/c_variadics.rs
@@ -1,0 +1,19 @@
+//@run: 1
+fn main() {
+    #[inline(never)]
+    unsafe extern "C" fn write_with_first_arg(val: i32, mut ap: ...) {
+        unsafe {
+            *(ap.next_arg::<*mut i32>()) = val;
+        }
+    }
+
+    let mut x = 1;
+    let rx = &mut x;
+    let ptr_x = rx as *mut i32;
+    let vx = &mut x;
+    *vx = 2;
+    
+    unsafe {
+        write_with_first_arg(128, ptr_x);
+    }
+}

--- a/tests/fail/aliasing/c_variadics.run.stderr
+++ b/tests/fail/aliasing/c_variadics.run.stderr
@@ -1,0 +1,27 @@
+error: Undefined Behavior: write access through <TAG>(unprotected) at ALLOC[0x0] is forbidden
+  --> bsan/tests/fail/aliasing/c_variadics.rs:LL:CC
+   |
+LL | *(ap.next_arg::<*mut i32>()) = val;
+   | ^
+   = help: the accessed tag <TAG>(unprotected) has state Disabled which forbids this child write access
+help: the accessed tag <TAG>(unprotected) was created here, in the initial state Reserved
+  --> bsan/tests/fail/aliasing/c_variadics.rs:LL:CC
+   |
+LL | let rx = &mut x;
+   |          ^
+help: the accessed tag <TAG>(unprotected) later transitioned to Disabled due to a foreign write access at offsets [0x0..0x4]
+  --> bsan/tests/fail/aliasing/c_variadics.rs:LL:CC
+   |
+LL | *vx = 2;
+   | ^
+   = help: this transition corresponds to a loss of read and write permissions
+
+stack backtrace:
+0: c_variadics::main::write_with_first_arg
+ at bsan/tests/fail/aliasing/c_variadics.rs:LL:CC
+1: c_variadics::main
+ at bsan/tests/fail/aliasing/c_variadics.rs:LL:CC
+2: <fn() as core::ops::function::FnOnce<()>>::call_once
+ at RUSTLIB/core/src/ops/function.rs:LL:CC
+
+note: stack trace was truncated after 3 frames; set stacktrace_max_len (e.g. BSAN_OPTIONS=stacktrace_max_len=32) to capture more.

--- a/tests/miri-tests/pass/both_borrows/c_variadics.rs
+++ b/tests/miri-tests/pass/both_borrows/c_variadics.rs
@@ -1,5 +1,4 @@
 //@run:0
-#![feature(c_variadic)]
 fn main() {
     unsafe extern "C" fn write_with_first_arg(ptr_to_val: *mut i32, _hidden_mut_ref_to_val: ...) {
         // Retagging needs to be disabled for arguments

--- a/tests/miri-tests/pass/c-variadic.rs
+++ b/tests/miri-tests/pass/c-variadic.rs
@@ -1,5 +1,4 @@
 //@run:0
-#![feature(c_variadic)]
 use std::ffi::{CStr, VaList, c_char, c_double, c_int, c_long};
 
 fn ignores_arguments() {

--- a/tests/miri-tests/pass/intrinsics/portable-simd-ptrs.rs
+++ b/tests/miri-tests/pass/intrinsics/portable-simd-ptrs.rs
@@ -9,5 +9,5 @@ fn main() {
     // Pointer casts
     let _val: Simd<*const u8, 4> = Simd::<*const i32, 4>::splat(ptr::null()).cast();
     let addrs = Simd::<*const i32, 4>::splat(ptr::null()).expose_provenance();
-    let _ptrs = Simd::<*const i32, 4>::with_exposed_provenance(addrs);
+    let _ptrs: Simd<*const i32, 4> = std::simd::ptr::with_exposed_provenance(addrs);
 }

--- a/tests/miri-tests/pass/issues/issue-3200-packed-field-offset.rs
+++ b/tests/miri-tests/pass/issues/issue-3200-packed-field-offset.rs
@@ -1,5 +1,4 @@
 //@run:0
-#![feature(layout_for_ptr)]
 use std::mem;
 
 #[repr(packed, C)]

--- a/tests/miri-tests/pass/issues/issue-3200-packed2-field-offset.rs
+++ b/tests/miri-tests/pass/issues/issue-3200-packed2-field-offset.rs
@@ -1,5 +1,4 @@
 //@run:0
-#![feature(layout_for_ptr)]
 use std::mem;
 
 #[repr(packed(4))]

--- a/tests/miri-tests/pass/issues/issue-miri-2123.rs
+++ b/tests/miri-tests/pass/issues/issue-miri-2123.rs
@@ -1,5 +1,5 @@
 //@run:0
-#![feature(ptr_metadata, layout_for_ptr)]
+#![feature(ptr_metadata)]
 
 use std::{mem, ptr};
 

--- a/tests/miri-tests/pass/slices.rs
+++ b/tests/miri-tests/pass/slices.rs
@@ -3,7 +3,6 @@
 //miri: @[tree]compile-flags: -Zmiri-tree-borrows
 //miri: @compile-flags: -Zmiri-strict-provenance
 #![feature(slice_partition_dedup)]
-#![feature(layout_for_ptr)]
 
 use std::{ptr, slice};
 

--- a/tests/miri-tests/should-pass/c-variadic-ignored-argument.rs
+++ b/tests/miri-tests/should-pass/c-variadic-ignored-argument.rs
@@ -1,0 +1,21 @@
+//@run:0
+//miri: @ ignore-target: windows # does not ignore ZST arguments
+//miri: @ ignore-target: powerpc # does not ignore ZST arguments
+//miri: @ ignore-target: s390x # does not ignore ZST arguments
+//miri: @ ignore-target: sparc # does not ignore ZST arguments
+
+// Some platforms ignore ZSTs, meaning that the argument is not passed, even though it is part
+// of the callee's ABI. Test that this doesn't trip any asserts.
+//
+// NOTE: this  test only succeeds when the `()` argument uses `Passmode::Ignore`. For some targets,
+// notably msvc, such arguments are not ignored, which would cause UB when attempting to read the
+// second `i32` argument while the next item in the variable argument list is `()`.
+
+fn main() {
+    unsafe extern "C" fn variadic(mut ap: ...) {
+        ap.arg::<i32>();
+        ap.arg::<i32>();
+    }
+
+    unsafe { variadic(0i32, (), 1i32) }
+}

--- a/tests/miri-tests/should-pass/c-variadic.rs
+++ b/tests/miri-tests/should-pass/c-variadic.rs
@@ -1,0 +1,115 @@
+//@run:0
+
+use std::ffi::{CStr, VaList, c_char, c_double, c_int, c_long};
+
+fn ignores_arguments() {
+    unsafe extern "C" fn variadic(_: ...) {}
+
+    unsafe { variadic() };
+    unsafe { variadic(1, 2, 3) };
+}
+
+fn echo() {
+    unsafe extern "C" fn variadic(mut ap: ...) -> i32 {
+        ap.arg()
+    }
+
+    assert_eq!(unsafe { variadic(1) }, 1);
+    assert_eq!(unsafe { variadic(3, 2, 1) }, 3);
+}
+
+fn forward_by_val() {
+    unsafe fn helper(mut ap: VaList) -> i32 {
+        ap.arg()
+    }
+
+    unsafe extern "C" fn variadic(ap: ...) -> i32 {
+        helper(ap)
+    }
+
+    assert_eq!(unsafe { variadic(1) }, 1);
+    assert_eq!(unsafe { variadic(3, 2, 1) }, 3);
+}
+
+fn forward_by_ref() {
+    unsafe fn helper(ap: &mut VaList) -> i32 {
+        ap.arg()
+    }
+
+    unsafe extern "C" fn variadic(mut ap: ...) -> i32 {
+        helper(&mut ap)
+    }
+
+    assert_eq!(unsafe { variadic(1) }, 1);
+    assert_eq!(unsafe { variadic(3, 2, 1) }, 3);
+}
+
+#[allow(improper_ctypes_definitions)]
+fn nested() {
+    unsafe fn helper(mut ap1: VaList, mut ap2: VaList) -> (i32, i32) {
+        (ap1.arg(), ap2.arg())
+    }
+
+    unsafe extern "C" fn variadic2(ap1: VaList, ap2: ...) -> (i32, i32) {
+        helper(ap1, ap2)
+    }
+
+    unsafe extern "C" fn variadic1(ap1: ...) -> (i32, i32) {
+        variadic2(ap1, 2, 2)
+    }
+
+    assert_eq!(unsafe { variadic1(1) }, (1, 2));
+
+    let (a, b) = unsafe { variadic1(1, 1) };
+
+    assert_eq!(a, 1);
+    assert_eq!(b, 2);
+}
+
+fn various_types() {
+    unsafe extern "C" fn check_list_2(mut ap: ...) {
+        macro_rules! continue_if {
+            ($cond:expr) => {
+                if !($cond) {
+                    panic!();
+                }
+            };
+        }
+
+        unsafe fn compare_c_str(ptr: *const c_char, val: &str) -> bool {
+            match CStr::from_ptr(ptr).to_str() {
+                Ok(cstr) => cstr == val,
+                Err(_) => panic!(),
+            }
+        }
+
+        continue_if!(ap.arg::<c_double>().floor() == 3.14f64.floor());
+        continue_if!(ap.arg::<c_long>() == 12);
+        continue_if!(ap.arg::<c_int>() == 'a' as c_int);
+        continue_if!(ap.arg::<c_double>().floor() == 6.18f64.floor());
+        continue_if!(compare_c_str(ap.arg::<*const c_char>(), "Hello"));
+        continue_if!(ap.arg::<c_int>() == 42);
+        continue_if!(compare_c_str(ap.arg::<*const c_char>(), "World"));
+    }
+
+    unsafe {
+        check_list_2(
+            3.14 as c_double,
+            12 as c_long,
+            b'a' as c_int,
+            6.28 as c_double,
+            c"Hello".as_ptr(),
+            42 as c_int,
+            c"World".as_ptr(),
+        );
+    }
+}
+
+fn main() {
+    ignores_arguments();
+    echo();
+    forward_by_val();
+    forward_by_ref();
+    nested();
+    various_types();
+}


### PR DESCRIPTION
This PR switches us over to nightly Rust. Instead of downloading artifacts from our fork of Rust, we can pull them from Rust's CI distribution endpoint.

However, there's one caveat: we still need a build of `clang` that uses the same LLVM version as nightly Rust. The build scripts in [`nightly-clang`](https://github.com/borrowSanitizer/nightly-clang) will create this for us, publishing a release with the artifacts. These scripts will be merged in a subsequent PR, with an accompanying GitHub action. We can run this action every so often, and it will automatically create a PR that updates our nightly version.