### PR TITLE
Add script for building nightly clang

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,172 @@
+# Updates the current nightly version of Rust, creating a
+# pull request for manual validation. This will also build 
+# and distribute a compatible version of clang, as needed.
+name: nightly 
+on:
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: "clang-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  init:
+    runs-on: ubuntu-latest
+    outputs:
+      toolchain: ${{ steps.nightly.outputs.toolchain }}
+      rust_sha: ${{ steps.nightly.outputs.rust_sha }}
+      llvm_sha: ${{ steps.nightly.outputs.llvm_sha }}
+      nightly_date: ${{ steps.nightly.outputs.nightly_date }}
+      # the name of the release tag
+      tag: ${{ steps.nightly.outputs.tag }}
+      should_build: ${{ steps.nightly.outputs.should_build }}
+    steps:
+      - name: Fetch nightly release info
+        id: nightly
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          base=https://static.rust-lang.org/dist
+          nightly_date=$(curl -sSfL "$base/channel-rust-nightly-date.txt")
+          rust_sha=$(curl -sSfL "$base/$nightly_date/channel-rust-nightly-git-commit-hash.txt")
+          llvm_sha=$(gh api "repos/rust-lang/rust/contents/src/llvm-project?ref=$rust_sha" --jq .sha)
+          tag="clang/${llvm_sha:0:7}"
+          should_build=false
+          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            should_build=true
+          fi
+          {
+            echo "toolchain=nightly-$nightly_date"
+            echo "rust_sha=$rust_sha"
+            echo "llvm_sha=$llvm_sha"
+            echo "nightly_date=$nightly_date"
+            echo "tag=clang-${llvm_sha:0:7}"
+            echo "should_build=$should_build"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: ${{ matrix.config.target }}
+    needs: init
+    if: needs.init.outputs.should_build == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.config.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build lld
+          
+      - uses: actions/checkout@v4
+        with:
+            sparse-checkout: bsan-script/etc/build-clang.sh
+            sparse-checkout-cone-mode: false
+            
+      - name: Build
+        run: |
+          # We need a version of `clang` that matches nightly Rust toolchain
+          # to ensure compatibility between Rust, Clang, and our LLVM pass plugin.
+          # This workflow uses Rust's nightly CI artifacts to build and distribute
+          # clang and its headers, without having to rebuild LLVM.
+          ./bsan-script/etc/build-clang.sh \
+            ${{ needs.init.outputs.llvm_sha }} \
+            ${{ needs.init.outputs.rust_sha }} \
+            ${{ matrix.config.target }} \
+            ${{ needs.init.outputs.tag }}
+
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.init.outputs.tag }}-${{ matrix.config.target }}
+          path: ${{ needs.init.outputs.tag }}-${{ matrix.config.target }}.tar.xz
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    name: Publish rolling release
+    needs: [init, build]
+    if: needs.init.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.init.outputs.tag }}-*
+          merge-multiple: true
+
+      - name: Publish
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(*.tar.xz)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No build artifacts found!"
+            exit 1
+          fi
+          llvm_sha="${{ needs.init.outputs.llvm_sha }}"
+          llvm_link="[\`${llvm_sha:0:7}\`]($GITHUB_SERVER_URL/rust-lang/llvm-project/commit/$llvm_sha)"
+          gh release create "${{ needs.init.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --target "${{ github.sha }}" \
+            --title "Clang (${llvm_sha:0:7})" \
+            --notes "A build of Clang that shares its LLVM version with nightly Rust ($llvm_link)." \
+            --prerelease \
+            "${files[@]}"
+
+
+  update:
+    name: Open PR
+    needs: [init, build, release]
+    # Run this step if we did not need to build clang,
+    # or if we did, and both the build and release
+    # steps succeeded
+    if: >-
+      ${{ !cancelled()
+        && ((needs.init.outputs.should_build == 'false')
+             || (needs.build.result == 'success' && needs.release.result == 'success'))}}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Update config.toml
+        run: |
+          set -euo pipefail
+          {
+            echo "rust_sha = \"${{ needs.init.outputs.rust_sha }}\""
+            echo "llvm_sha = \"${{ needs.init.outputs.llvm_sha }}\""
+          } > config.toml
+      - name: Open PR
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            exit 0
+          fi
+          branch="toolchain/${{ needs.init.outputs.toolchain }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git commit -am "${{ needs.init.outputs.toolchain }}"
+          git push --force origin "$branch"
+          tag="${{ needs.init.outputs.tag }}"
+          llvm_sha="${{ needs.init.outputs.llvm_sha }}"
+          llvm_link="[\`${llvm_sha:0:7}\`]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/releases/tag/$tag)"
+          gh pr create --head "$branch" \
+            --title "Update to \`${{ needs.init.outputs.toolchain }}\`" \
+            --body "Updates the Rust toolchain to \`${{ needs.init.outputs.toolchain }}\`, along with a compatible version of Clang ($llvm_link)."\
+            || echo "PR already exists."

--- a/bsan-script/etc/build-clang.sh
+++ b/bsan-script/etc/build-clang.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# This script builds clang from source by reusing build artifacts
+# from `rust-dev`.
+set -euo pipefail
+
+if [[ $# -ne 4 ]]; then
+    echo "usage: $0 <llvm-sha> <rust-sha> <target> <output>"
+    exit 1
+fi
+
+check_dependencies() {
+    local missing=()
+    for cmd in "$@"; do
+        command -v "$cmd" &> /dev/null || missing+=("$cmd")
+    done
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "Missing dependencies: ${missing[*]}" >&2
+        return 1
+    fi
+    return 0
+}
+
+check_dependencies git cmake ninja lld curl || exit 1
+
+LLVM_SHA=$1
+RUSTC_SHA=$2
+# The target architecture that we are building for.
+TARGET=$3
+
+# We place an archive with the build output into the current directory.
+OUTPUT_DIR="$PWD"
+# we produce the file $OUTPUT.tar.xz
+OUTPUT="$4-$TARGET"
+
+# Rust's LLVM fork.
+LLVM_ORIGIN="https://github.com/rust-lang/llvm-project.git"
+
+# The endpoint where CI artifacts are hosted for nightly builds.
+RUST_DEV_ENDPOINT="https://ci-artifacts.rust-lang.org/rustc-builds/$RUSTC_SHA"
+
+# Rust distributes a `rust-dev` archive that contains build artifacts which can
+# be reused to speed-up building the compiler from source (download-ci-llvm). The 
+# artifact contains a copy of libLLVM for the current nightly.
+RUST_DEV_ARTIFACT="rust-dev-nightly-$TARGET"
+RUST_DEV_URL="$RUST_DEV_ENDPOINT/$RUST_DEV_ARTIFACT.tar.xz"
+
+# Create a temporary directory where we build everything.
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR"
+
+git init -q
+git remote add origin $LLVM_ORIGIN
+git sparse-checkout init --cone
+git sparse-checkout set cmake llvm clang third-party libc
+git fetch -q --depth=1 --filter=tree:0 origin "$LLVM_SHA"
+git checkout -q FETCH_HEAD
+ 
+echo "Downloading rust-dev artifacts..."
+curl --proto '=https' --tlsv1.2 -sSfL --retry 3 \
+    "$RUST_DEV_URL" -o rust-dev.tar.xz
+tar -xf rust-dev.tar.xz --strip-components=1
+
+# Rust's libLLVM is labelled "libLLVM.so.<MAJOR>.<MINOR>-rust-<VERSION>-nightly"
+LIB_LLVM=$(find "$PWD"/rust-dev/lib/libLLVM.so.*-rust-* | head -1)
+LIB_LLVM_NAME=$(basename "$LIB_LLVM")
+LLVM_VERSION_SUFFIX="-${LIB_LLVM_NAME#*-}"
+
+# We reinitialize rust-dev as a build directory for LLVM,
+# keeping the same suffix that Rust uses.
+cmake -S llvm -B "rust-dev" -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DLLVM_LINK_LLVM_DYLIB=ON \
+    -DLLVM_VERSION_SUFFIX="$LLVM_VERSION_SUFFIX" \
+    -DLLVM_TARGETS_TO_BUILD=host \
+    -DLLVM_ENABLE_ASSERTIONS=OFF \
+    -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF \
+    -DLLVM_ENABLE_RTTI=OFF \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DLLVM_INCLUDE_BENCHMARKS=OFF \
+    -DLLVM_INCLUDE_EXAMPLES=OFF
+
+# Clang needs all of these generated headers, which are not shipped
+# with rust-dev by default. 
+ninja -C rust-dev intrinsics_gen omp_gen acc_gen analysis_gen \
+    target_parser_gen vt_gen
+
+# Build clang
+cmake -S clang -B clang-build -G Ninja \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$PWD/dist/$OUTPUT" \
+    -DLLVM_DIR="$PWD/rust-dev/lib/cmake/llvm" \
+    -DLLVM_TABLEGEN_EXE="$PWD/rust-dev/bin/llvm-tblgen" \
+    -DLLVM_ENABLE_ASSERTIONS=OFF \
+    -DLLVM_ENABLE_RTTI=OFF \
+    -DLLVM_ENABLE_PLUGINS=ON \
+    -DCLANG_PLUGIN_SUPPORT=ON \
+    -DLLVM_INCLUDE_TESTS=OFF \
+    -DCLANG_INCLUDE_TESTS=OFF
+
+cmake --build clang-build --target clang clang-format libclang
+cmake --build clang-build --target install-clang install-clang-cpp \
+    install-clang-format install-clang-resource-headers install-libclang
+
+tar -cJf "$OUTPUT_DIR/$OUTPUT.tar.xz" -C dist "$OUTPUT"


### PR DESCRIPTION
This PR a continuation of #309. It adds a new GitHub action, `nightly`, that will update our version of Rust to the latest nightly. As necessary, it will build and release a version of clang that is compatible with Rust's nightly toolchain.