### PR TITLE
Remove 'matchers' from benchmark list

### DIFF
--- a/tests/benches/crates.json
+++ b/tests/benches/crates.json
@@ -11,10 +11,6 @@
         "version": "0.10.1"
     },
     {
-        "name": "matchers",
-        "version": "0.2.0"
-    },
-    {
         "name": "bit-vec",
         "version": "0.9.1",
         "exclude": [


### PR DESCRIPTION
Removes `matchers` until we have a solution to #316.