### PR TITLE
Clear provenance on unaligned memory transfers

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -528,7 +528,7 @@ void __bsan_shadow_clear_aligned(void *dest_shadow, void *dest_origin,
                                  uptr size) {
   if (!MEM_IS_SHADOW(dest_shadow))
     return;
-  ClearShadowAligned((uptr)dest_shadow, (uptr)dest_origin, size);
+  ClearShadowAligned(dest_shadow, dest_origin, size);
 }
 
 SANITIZER_WEAK_ATTRIBUTE

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -246,6 +246,17 @@ struct ShadowRange {
       : start(ShadowAddr(range.start)), size(range.size) {}
 };
 
+ALWAYS_INLINE static void ClearShadowSlot(ShadowAddr start, uptr offset) {
+  BorTag *tag_ptr = reinterpret_cast<BorTag *>(start.shadow + offset);
+  AllocInfo **info_ptr = reinterpret_cast<AllocInfo **>(start.origin + offset);
+  // We use the borrow tag as a proxy for the initialization of the
+  // `AllocInfo` component of provenance metadata.
+  if (*tag_ptr != 0) {
+    __bsan_rc_dec(*tag_ptr, *info_ptr);
+    *tag_ptr = 0;
+  }
+}
+
 ALWAYS_INLINE static void UpdateShadowSlot(ShadowAddr dest, ShadowAddr src,
                                            uptr offset) {
   AllocInfo **dest_info = reinterpret_cast<AllocInfo **>(dest.origin + offset);
@@ -270,16 +281,7 @@ void ClearShadowRange(ShadowRange range) {
   const uptr step = kMinProvAlignment;
   ShadowAddr start = range.start;
   for (uptr offset = 0; offset < range.size; offset += step) {
-    BorTag *tag_ptr = reinterpret_cast<BorTag *>(start.shadow + offset);
-    AllocInfo **info_ptr =
-        reinterpret_cast<AllocInfo **>(start.origin + offset);
-
-    // We use the borrow tag as a proxy for the initialization of the
-    // `AllocInfo` component of provenance metadata.
-    if (*tag_ptr != 0) {
-      __bsan_rc_dec(*tag_ptr, *info_ptr);
-      *tag_ptr = 0;
-    }
+    ClearShadowSlot(start, offset);
   }
 }
 
@@ -307,16 +309,29 @@ void TransferShadow(void *dest, const void *src, uptr size, bool disjoint) {
   ShadowRange s_shadow(s_range);
 
   uptr step = kMinProvAlignment;
+  uptr rem = d_aligned.align_rem;
+
+  uptr start_offset = 0;
+  uptr end_offset = s_shadow.size;
+
+  // If we are misaligned, then the first and last shadow
+  // slots need to be cleared.
+  if (rem != 0) {
+    ClearShadowSlot(d_shadow, start_offset);
+    start_offset += step;
+    if (start_offset == end_offset)
+      return;
+    end_offset -= step;
+    ClearShadowSlot(d_shadow, end_offset);
+  }
 
   if (disjoint || d_aligned.addr < s_range.start.addr) {
-    for (uptr offset = 0; offset < s_shadow.size; offset += step)
+    for (uptr offset = start_offset; offset < end_offset; offset += step)
       UpdateShadowSlot(d_shadow, s_shadow.start, offset);
   } else {
-    for (uptr offset = s_shadow.size - step;; offset -= step) {
+    for (uptr offset = end_offset - step; offset > start_offset;
+         offset -= step) {
       UpdateShadowSlot(d_shadow, s_shadow.start, offset);
-      // signed so must break at 0
-      if (offset == 0)
-        break;
     }
   }
 }

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -204,40 +204,55 @@ bool InitShadowWithReExec() {
   return InitShadow(init_origins, false);
 }
 
-static void AlignPtr8(uptr addr, uptr &aligned_addr) {
-  aligned_addr = addr & ~7UL;
-}
-static void AlignRange8(uptr addr, uptr size, uptr &aligned_addr,
-                        uptr &aligned_size) {
-  AlignPtr8(addr, aligned_addr);
-  uptr end = (addr + size + 7) & ~7UL;
-  aligned_size = end - aligned_addr;
+static uptr AlignDown(uptr addr) { return addr & ~(kMinProvAlignment - 1); }
+
+static uptr AlignUp(uptr addr) {
+  return AlignDown(addr + (kMinProvAlignment - 1));
 }
 
-void MoveAligned(void *dest, const void *src, uptr size) {
-  uptr d_aligned;
-  uptr s_aligned, s_size;
-  AlignPtr8((uptr)dest, d_aligned);
-  AlignRange8((uptr)src, size, s_aligned, s_size);
-  internal_memmove((void *)d_aligned, (const void *)s_aligned, s_size);
-}
+struct AlignedAddr {
+  uptr addr;
+  uptr align_rem;
+  AlignedAddr(const void *ptr) {
+    addr = AlignDown((uptr)ptr);
+    align_rem = ((uptr)ptr) - addr;
+  }
+};
 
-void CopyAligned(void *dest, const void *src, uptr size) {
-  uptr d_aligned;
-  uptr s_aligned, s_size;
-  AlignPtr8((uptr)dest, d_aligned);
-  AlignRange8((uptr)src, size, s_aligned, s_size);
-  internal_memcpy((void *)d_aligned, (const void *)s_aligned, s_size);
-}
+struct AlignedRange {
+  AlignedAddr start;
+  uptr size;
+  AlignedRange(const void *ptr, uptr len) : start(AlignedAddr(ptr)) {
+    uptr end = AlignUp((uptr)ptr + len);
+    size = end - start.addr;
+  }
+};
 
-ALWAYS_INLINE static void UpdateShadowSlot(uptr d_shadow, uptr d_origin,
-                                           uptr s_shadow, uptr s_origin,
+struct ShadowAddr {
+  uptr shadow = 0;
+  uptr origin = 0;
+  ShadowAddr(uptr shadow, uptr origin) : shadow(shadow), origin(origin) {}
+  ShadowAddr(AlignedAddr aligned) {
+    shadow = MEM_TO_SHADOW(aligned.addr);
+    origin = MEM_TO_ORIGIN(aligned.addr);
+  }
+};
+
+struct ShadowRange {
+  ShadowAddr start;
+  uptr size;
+  ShadowRange(ShadowAddr start, uptr size) : start(start), size(size) {}
+  ShadowRange(AlignedRange range)
+      : start(ShadowAddr(range.start)), size(range.size) {}
+};
+
+ALWAYS_INLINE static void UpdateShadowSlot(ShadowAddr dest, ShadowAddr src,
                                            uptr offset) {
-  AllocInfo **dest_info = reinterpret_cast<AllocInfo **>(d_origin + offset);
-  AllocInfo **source_info = reinterpret_cast<AllocInfo **>(s_origin + offset);
+  AllocInfo **dest_info = reinterpret_cast<AllocInfo **>(dest.origin + offset);
+  AllocInfo **source_info = reinterpret_cast<AllocInfo **>(src.origin + offset);
 
-  BorTag *dest_tag = reinterpret_cast<BorTag *>(d_shadow + offset);
-  BorTag *source_tag = reinterpret_cast<BorTag *>(s_shadow + offset);
+  BorTag *dest_tag = reinterpret_cast<BorTag *>(dest.shadow + offset);
+  BorTag *source_tag = reinterpret_cast<BorTag *>(src.shadow + offset);
 
   BorTag src_tag = *source_tag;
   AllocInfo *src_info = *source_info;
@@ -251,106 +266,13 @@ ALWAYS_INLINE static void UpdateShadowSlot(uptr d_shadow, uptr d_origin,
   *dest_info = src_info;
 }
 
-void CopyShadow(void *dest, const void *src, uptr size) {
-  if (!MEM_IS_APP(dest))
-    return;
-  if (!MEM_IS_APP(src))
-    return;
-  if (size == 0)
-    return;
-
+void ClearShadowRange(ShadowRange range) {
   const uptr step = kMinProvAlignment;
-
-  uptr d_aligned;
-  uptr s_aligned, s_size;
-  AlignPtr8((uptr)dest, d_aligned);
-  AlignRange8((uptr)src, size, s_aligned, s_size);
-
-  uptr d_shadow = MEM_TO_SHADOW(d_aligned);
-  uptr d_origin = MEM_TO_ORIGIN(d_aligned);
-  uptr s_shadow = MEM_TO_SHADOW(s_aligned);
-  uptr s_origin = MEM_TO_ORIGIN(s_aligned);
-
-  for (uptr offset = 0; offset < s_size; offset += step)
-    UpdateShadowSlot(d_shadow, d_origin, s_shadow, s_origin, offset);
-}
-
-void JoinShadow(void *dest, const void *s_shadow, const void *s_origin,
-                uptr s_size) {
-  // This operation relies on our instrumentation pass
-  // to ensure that the source and size are aligned.
-  uptr d_aligned;
-  AlignPtr8((uptr)dest, d_aligned);
-
-  uptr d_shadow = MEM_TO_SHADOW(d_aligned);
-  uptr d_origin = MEM_TO_ORIGIN(d_aligned);
-
-  uptr s_shadow_addr = (uptr)s_shadow;
-  uptr s_origin_addr = (uptr)s_origin;
-
-  const uptr step = kMinProvAlignment;
-
-  for (uptr offset = 0; offset < s_size; offset += step)
-    UpdateShadowSlot(d_shadow, d_origin, s_shadow_addr, s_origin_addr, offset);
-}
-
-void MoveShadow(void *dest, const void *src, uptr size) {
-  if (!MEM_IS_APP(dest))
-    return;
-  if (!MEM_IS_APP(src))
-    return;
-  if (size == 0)
-    return;
-
-  const uptr step = kMinProvAlignment;
-
-  uptr d_aligned;
-  uptr s_aligned, s_size;
-  AlignPtr8((uptr)dest, d_aligned);
-  AlignRange8((uptr)src, size, s_aligned, s_size);
-
-  if (d_aligned == s_aligned)
-    return;
-
-  uptr d_shadow = MEM_TO_SHADOW(d_aligned);
-  uptr d_origin = MEM_TO_ORIGIN(d_aligned);
-  uptr s_shadow = MEM_TO_SHADOW(s_aligned);
-  uptr s_origin = MEM_TO_ORIGIN(s_aligned);
-
-  if (d_aligned < s_aligned) {
-    for (uptr offset = 0; offset < s_size; offset += step)
-      UpdateShadowSlot(d_shadow, d_origin, s_shadow, s_origin, offset);
-  } else {
-    for (uptr offset = s_size - step;; offset -= step) {
-      UpdateShadowSlot(d_shadow, d_origin, s_shadow, s_origin, offset);
-      // signed so must break at 0
-      if (offset == 0)
-        break;
-    }
-  }
-}
-
-void ClearShadow(void *dest, uptr size) {
-  if (!MEM_IS_APP(dest))
-    return;
-  uptr d_aligned, d_size;
-  AlignRange8((uptr)dest, size, d_aligned, d_size);
-
-  uptr shadow_start = MEM_TO_SHADOW(d_aligned);
-  uptr origin_start = MEM_TO_ORIGIN(d_aligned);
-
-  ClearShadowAligned(shadow_start, origin_start, d_size);
-}
-
-void ClearShadowAligned(uptr shadow_start, uptr origin_start,
-                        uptr size_aligned) {
-
-  const uptr step = kMinProvAlignment;
-
-  for (uptr offset = 0; offset < size_aligned; offset += step) {
-    BorTag *tag_ptr = reinterpret_cast<BorTag *>(shadow_start + offset);
+  ShadowAddr start = range.start;
+  for (uptr offset = 0; offset < range.size; offset += step) {
+    BorTag *tag_ptr = reinterpret_cast<BorTag *>(start.shadow + offset);
     AllocInfo **info_ptr =
-        reinterpret_cast<AllocInfo **>(origin_start + offset);
+        reinterpret_cast<AllocInfo **>(start.origin + offset);
 
     // We use the borrow tag as a proxy for the initialization of the
     // `AllocInfo` component of provenance metadata.
@@ -361,16 +283,92 @@ void ClearShadowAligned(uptr shadow_start, uptr origin_start,
   }
 }
 
+void TransferShadow(void *dest, const void *src, uptr size, bool disjoint) {
+  if (!MEM_IS_APP(dest))
+    return;
+  if (!MEM_IS_APP(src))
+    return;
+  if (size == 0)
+    return;
+
+  AlignedAddr d_aligned(dest);
+  AlignedRange s_range(src, size);
+
+  if (d_aligned.align_rem != s_range.start.align_rem) {
+    AlignedRange d_range(dest, size);
+    ShadowRange d_shadow(d_range);
+    return ClearShadowRange(d_shadow);
+  }
+
+  if (d_aligned.addr == s_range.start.addr)
+    return;
+
+  ShadowAddr d_shadow(d_aligned);
+  ShadowRange s_shadow(s_range);
+
+  uptr step = kMinProvAlignment;
+
+  if (disjoint || d_aligned.addr < s_range.start.addr) {
+    for (uptr offset = 0; offset < s_shadow.size; offset += step)
+      UpdateShadowSlot(d_shadow, s_shadow.start, offset);
+  } else {
+    for (uptr offset = s_shadow.size - step;; offset -= step) {
+      UpdateShadowSlot(d_shadow, s_shadow.start, offset);
+      // signed so must break at 0
+      if (offset == 0)
+        break;
+    }
+  }
+}
+
+void MoveShadow(void *dest, const void *src, uptr size) {
+  return TransferShadow(dest, src, size, false);
+}
+
+void CopyShadow(void *dest, const void *src, uptr size) {
+  return TransferShadow(dest, src, size, true);
+}
+
+void JoinShadow(void *dest, const void *s_shadow, const void *s_origin,
+                uptr size) {
+  // This operation relies on our instrumentation pass
+  // to ensure that the source and size are aligned.
+  AlignedAddr d_aligned(dest);
+  ShadowAddr d_shadow(d_aligned);
+
+  ShadowAddr s_addr((uptr)s_shadow, (uptr)s_origin);
+  ShadowRange s_range(s_addr, size);
+
+  const uptr step = kMinProvAlignment;
+  for (uptr offset = 0; offset < s_range.size; offset += step)
+    UpdateShadowSlot(d_shadow, s_range.start, offset);
+}
+
+void ClearShadow(void *dest, uptr size) {
+  if (!MEM_IS_APP(dest))
+    return;
+  AlignedRange aligned(dest, size);
+  ShadowRange range(aligned);
+  ClearShadowRange(range);
+}
+
+void ClearShadowAligned(void *dest_shadow, void *dest_origin, uptr size) {
+  // This operation relies on our instrumentation pass
+  // to ensure that the destination and size are aligned.
+  ShadowAddr s_addr((uptr)dest_shadow, (uptr)dest_origin);
+  ShadowRange range(s_addr, size);
+  ClearShadowRange(range);
+}
+
 void WriteShadow(void *dest, Provenance prov) {
   if (!MEM_IS_APP(dest))
     return;
-  uptr d_aligned, d_size;
-  AlignRange8((uptr)dest, 8, d_aligned, d_size);
-  uptr shadow_start = MEM_TO_SHADOW(d_aligned);
-  uptr origin_start = MEM_TO_ORIGIN(d_aligned);
 
-  BorTag *tag_ptr = reinterpret_cast<BorTag *>(shadow_start);
-  AllocInfo **info_ptr = reinterpret_cast<AllocInfo **>(origin_start);
+  AlignedRange aligned(dest, 8);
+  ShadowRange range(aligned);
+
+  BorTag *tag_ptr = reinterpret_cast<BorTag *>(range.start.shadow);
+  AllocInfo **info_ptr = reinterpret_cast<AllocInfo **>(range.start.origin);
 
   if (prov.info != nullptr)
     __bsan_rc_inc(prov.tag, prov.info);

--- a/bsan-rt/llvm-wrapper/bsan_shadow.h
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.h
@@ -112,7 +112,7 @@ void JoinShadow(void *dest, const void *src_shadow, const void *src_origin,
 
 void MoveShadow(void *dest, const void *src, uptr size);
 void ClearShadow(void *dest, uptr size);
-void ClearShadowAligned(uptr shadow_start, uptr origin_start,
+void ClearShadowAligned(void *dest_shadow, void *dest_origin,
                         uptr size_aligned);
 void WriteShadow(void *dest, Provenance prov);
 } // namespace __bsan

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -27,7 +27,7 @@ WARMUP = 1
 NATIVE = {
     "name": "native",
     "cmd": ["cargo", "test", "--lib"],
-    "env": {"RUSTFLAGS": "--cfg=bsan --cfg=miri"},
+    "env": {"RUSTFLAGS": "--cfg=bsan --cfg=miri", "TERM": None},
 }
 
 # Flags shared by every Miri configuration. These disable most forms of
@@ -48,22 +48,20 @@ MIRI = {
     },
 }
 
-# Miri with Tree Borrows disabled. This is as close to "just interpret" as
-# we can get. However, the core interpreter will still check for certain forms
-# of UB, like accessese out-of-bounds, use-after-free errors, and uninitialized accesses.
-# MIRI_BASE = {
-#     "name": "miri-base",
-#     "env": {"MIRIFLAGS": f"-Zmiri-disable-stacked-borrows {MIRI_COMMON_FLAGS}"},
-# }
-
 # Every Miri configuration.
 MIRI_CONFIGS = [MIRI]
 
 # BorrowSanitizer configurations.
 BSAN_CONFIGS = [
-    # Full checking
+    # Full checking, skip parsing terminal info.
     {
         "name": "full",
+        "cmd": ["cargo", "bsan", "test", "--lib"],
+        "env": {"RUSTFLAGS": "--cfg=miri", "TERM": None},
+    },
+    # Full checking, parse terminal info.
+    {
+        "name": "full-terminfo",
         "cmd": ["cargo", "bsan", "test", "--lib"],
         "env": {"RUSTFLAGS": "--cfg=miri"},
     },
@@ -73,13 +71,12 @@ BSAN_CONFIGS = [
     {
         "name": "no-op",
         "cmd": ["cargo", "bsan", "test", "--nop", "--lib"],
-        "env": {"RUSTFLAGS": "--cfg=miri"},
+        "env": {"RUSTFLAGS": "--cfg=miri", "TERM": None},
     }
 ]
 
 # Every configuration that requires compiling a native binary.
 ALL_BINARY_CONFIGS = [NATIVE] + BSAN_CONFIGS
-
 
 # Raw timing results are output as a CSV with these headers.
 CSV_HEADERS = [
@@ -110,9 +107,17 @@ class TestHarnessJSON:
         raise StopIteration
 
 def _build_env(kwargs: dict) -> dict:
-    """Creates a copy of the current environment, merged with an `env` mapping from `kwargs`."""
+    """Creates a copy of the current environment, merged with an `env` mapping from `kwargs`.
+
+    If a a value is set to `None` in `kwargs`, then the value will be unset from the environment,
+    instead of being inherited by the parent process.
+    """
     env = os.environ.copy()
-    env.update(kwargs.pop("env", None) or {})
+    for key, value in (kwargs.pop("env", None) or {}).items():
+        if value is None:
+            env.pop(key, None)
+        else:
+            env[key] = value
     return env
 
 def run(

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -93,6 +93,15 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         ),
     };
 
+    // This is sound in a single-threaded environment.
+    // Miri skips parting terminfo via a conditional
+    // compilation directive. We do not have equivalent
+    // upstream status, so instead, we unset this variable,
+    // which has the same effect.
+    unsafe {
+        env::remove_var("TERM");
+    }
+
     let env = EnvConfig::from_args();
 
     // Determine the involved architectures.

--- a/tests/pass/shadow_alignment.rs
+++ b/tests/pass/shadow_alignment.rs
@@ -1,0 +1,42 @@
+fn main() {
+    let p_alloc = Box::new(0);
+let q_alloc = Box::new(0);
+
+let p = Box::<u8>::as_ptr(&p_alloc);
+let q = Box::<u8>::as_ptr(&q_alloc);
+
+// Create source and destination arrays that are four words long.
+let mut src = [0u32; 8];
+let mut dst = [0u32; 8];
+
+let src_bytes = src.as_mut_ptr().cast::<u8>();
+let dst_bytes = dst.as_mut_ptr().cast::<u8>();
+
+unsafe {
+
+    src_bytes.add(8).cast::<*const u8>().write(q);
+
+    //   SRC:
+    //        main: |   |   | q | q |   |
+    //      shadow: |   |   | q | q |   |
+
+    src_bytes.add(4).cast::<*const u8>().write_unaligned(p);
+
+    //   SRC:
+    //        main: |   | p | p | q |   |
+    //      shadow: | p | p | q | q |   |
+
+    std::ptr::copy_nonoverlapping(src_bytes, dst_bytes.add(4), 20);
+
+
+    //   DEST:
+    //        main: |   |   | p | p | q |
+    //      shadow: | p | p | q | q |   |
+    //                        ^   ^
+
+    let p2 = dst_bytes.add(8).cast::<*const u8>().read();
+    assert_eq!(p2, p);
+
+    println!("{}", *p2);  // False positive UB! We're accessing p using q's provenance.
+}
+}

--- a/tests/pass/shadow_alignment.rs
+++ b/tests/pass/shadow_alignment.rs
@@ -1,42 +1,56 @@
+//@run: 0
+#![allow(unused)]
+use std::ptr;
+
 fn main() {
-    let p_alloc = Box::new(0);
-let q_alloc = Box::new(0);
-
-let p = Box::<u8>::as_ptr(&p_alloc);
-let q = Box::<u8>::as_ptr(&q_alloc);
-
-// Create source and destination arrays that are four words long.
-let mut src = [0u32; 8];
-let mut dst = [0u32; 8];
-
-let src_bytes = src.as_mut_ptr().cast::<u8>();
-let dst_bytes = dst.as_mut_ptr().cast::<u8>();
-
-unsafe {
-
-    src_bytes.add(8).cast::<*const u8>().write(q);
-
-    //   SRC:
-    //        main: |   |   | q | q |   |
-    //      shadow: |   |   | q | q |   |
-
-    src_bytes.add(4).cast::<*const u8>().write_unaligned(p);
-
-    //   SRC:
-    //        main: |   | p | p | q |   |
-    //      shadow: | p | p | q | q |   |
-
-    std::ptr::copy_nonoverlapping(src_bytes, dst_bytes.add(4), 20);
-
-
-    //   DEST:
-    //        main: |   |   | p | p | q |
-    //      shadow: | p | p | q | q |   |
-    //                        ^   ^
-
-    let p2 = dst_bytes.add(8).cast::<*const u8>().read();
-    assert_eq!(p2, p);
-
-    println!("{}", *p2);  // False positive UB! We're accessing p using q's provenance.
+    packed_struct();
 }
+
+#[repr(C, packed)]
+#[derive(Copy, Clone)]
+struct Skewed {
+    head: u32,        // offset 0
+    p: *const u8,     // offset 4  -- straddles granules 0 and 1
+    tail: u32,        // offset 12
+}
+
+#[repr(C, align(8))]
+struct Buf(Skewed);
+
+
+fn packed_struct() {
+    let p_alloc = Box::new(1u8);
+    let q_alloc = Box::new(2u8);
+    let p: *const u8 = &*p_alloc;
+    let q: *const u8 = &*q_alloc;
+
+    let mut src_box = Box::new([0u64; 3]);
+    let mut dst_box = Box::new(Buf(Skewed { head: 0, p: ptr::null(), tail: 0 }));
+
+    let src = (&raw mut *src_box).cast::<u8>();
+    let dst = &raw mut *dst_box;
+    let dst_bytes = dst.cast::<u8>();
+
+    unsafe {
+        src.cast::<*const u8>().write(q);
+        //   SRC:
+        //        main: | q | q |   |   |
+        //      shadow: |   q   |   |   |
+
+        (*dst).0.p = p;
+        //   DST:
+        //        main: |   | p | p |   |
+        //      shadow: |   p   |   |   |
+
+        ptr::copy_nonoverlapping(src, dst_bytes, 4);
+
+        //   DST:
+        //        main: | q | p | p |   |
+        //      shadow: |   q   |   |   |
+        //                    ^   ^
+
+        let p2 = (*dst).0.p;
+        assert_eq!(p2, p);
+        assert_eq!(*p2, 1);
+    }
 }


### PR DESCRIPTION
When a the source and destination of a memory transfer (e.g. `memmove`, `memcpy`) have different alignment, then it risks desynchronizing a pointer's address from its provenance in shadow memory (see #315). This PR refactors our helper methods for adjusting shadow alongside these operations, so that when we detect this case, we clear the shadow of the destination instead of transferring the unaligned source. This is not a complete fix yet, but it does allow us to support the minimal example in that issue.