### PR TITLE
Fix performance regression.

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -118,10 +118,13 @@ static void MaybeRequestGC() {
   uptr interval = flags()->visits_per_gc;
   if (interval == 0)
     return;
-  if (atomic_load(&__bsan_visits_since_gc, memory_order_relaxed) >= interval) {
-    atomic_store(&__bsan_visits_since_gc, 0, memory_order_relaxed);
-    global_ctx()->RequestGC();
-  }
+  uptr visits = atomic_load(&__bsan_visits_since_gc, memory_order_acquire);
+  if (visits < interval)
+    return;
+  // Multiple threads can reach this store, but that's okay, because
+  // our GC allows for multiple simultaneous requests
+  atomic_store(&__bsan_visits_since_gc, 0, memory_order_release);
+  global_ctx()->RequestGC();
 }
 
 // Returns the desired length for the current stack trace.

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -159,7 +159,9 @@ INTERCEPTOR(void *, realloc, void *ptr, SIZE_T size) {
 static Provenance BsanAllocateMeta(void *ptr, SIZE_T size, uptr span) {
   BorTag tag = NewBorTag();
   AllocInfo *info = __bsan_alloc(ptr, size, tag, span);
-  return {tag, info};
+  Provenance prov = {tag, info};
+  CurrentThread()->AcquireProvenance(prov);
+  return prov;
 }
 
 static void *BsanAllocateMetaIntoStack(void *ptr, SIZE_T size, bool is_inst,
@@ -167,8 +169,7 @@ static void *BsanAllocateMetaIntoStack(void *ptr, SIZE_T size, bool is_inst,
   if (is_inst) {
     Provenance *slot = GetRetValSlot(slot_idx);
     Provenance prov = BsanAllocateMeta(ptr, size, span);
-    *slot = BsanAllocateMeta(ptr, size, span);
-    CurrentThread()->AcquireProvenance(prov);
+    *slot = prov;
   } else {
     ClearRetValSlot(slot_idx);
   }
@@ -178,7 +179,8 @@ static void *BsanAllocateMetaIntoStack(void *ptr, SIZE_T size, bool is_inst,
 static void *BsanAllocateMetaIntoHeap(void *ptr, SIZE_T size, bool is_inst,
                                       uptr span, void *dest) {
   if (is_inst) {
-    WriteShadow(dest, BsanAllocateMeta(ptr, size, span));
+    Provenance prov = BsanAllocateMeta(ptr, size, span);
+    WriteShadow(dest, prov);
   } else {
     ClearShadow(dest, sizeof(void *));
   }

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -5,6 +5,7 @@
 #include "sanitizer_common/sanitizer_array_ref.h"
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_dense_map.h"
+#include "sanitizer_common/sanitizer_vector.h"
 
 using __sanitizer::ArrayRef;
 using __sanitizer::DenseMap;
@@ -85,22 +86,25 @@ public:
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       visit(KV.first, KV.second);
       KV.second.destroy();
-      set_.erase(KV.first);
       return true;
     });
+    set_.clear();
   }
 
   // Retain only the provenance values that satisfy the given predicate.
   template <typename Fn> void retainIf(Fn retain) {
+    Vector<AllocInfo *> ToErase;
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       AllocInfo *info = KV.first;
       KV.second.retainIf([&](BorTag tag) { return retain(info, tag); });
       if (KV.second.size() == 0) {
         KV.second.destroy();
-        set_.erase(info);
+        ToErase.PushBack(info);
       }
       return true;
     });
+    for (unsigned Idx = 0; Idx < ToErase.Size(); ++Idx)
+      set_.erase(ToErase[Idx]);
   }
 
   BorTagSet *find(AllocInfo *Info) {

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -233,22 +233,25 @@ void CopyAligned(void *dest, const void *src, uptr size) {
 ALWAYS_INLINE static void UpdateShadowSlot(uptr d_shadow, uptr d_origin,
                                            uptr s_shadow, uptr s_origin,
                                            uptr offset) {
-  AllocInfo **dest_info = reinterpret_cast<AllocInfo **>(d_origin + offset);
-  AllocInfo **source_info = reinterpret_cast<AllocInfo **>(s_origin + offset);
+  AllocInfo **dest_info_ptr = reinterpret_cast<AllocInfo **>(d_origin + offset);
+  AllocInfo **source_info_ptr =
+      reinterpret_cast<AllocInfo **>(s_origin + offset);
 
-  BorTag *dest_tag = reinterpret_cast<BorTag *>(d_shadow + offset);
-  BorTag *source_tag = reinterpret_cast<BorTag *>(s_shadow + offset);
+  BorTag *dest_tag_ptr = reinterpret_cast<BorTag *>(d_shadow + offset);
+  BorTag *source_tag_ptr = reinterpret_cast<BorTag *>(s_shadow + offset);
 
-  BorTag src_tag = *source_tag;
-  AllocInfo *src_info = *source_info;
+  BorTag dest_tag = *dest_tag_ptr;
+  BorTag source_tag = *source_tag_ptr;
 
-  if (src_tag != 0)
-    __bsan_rc_inc(src_tag, src_info);
+  if (source_tag != 0)
+    __bsan_rc_inc(source_tag, *source_info_ptr);
   if (dest_tag != 0)
-    __bsan_rc_dec(*dest_tag, *dest_info);
+    __bsan_rc_dec(dest_tag, *dest_info_ptr);
 
-  *dest_tag = src_tag;
-  *dest_info = src_info;
+  *dest_tag_ptr = source_tag;
+
+  if (source_tag != 0)
+    *dest_info_ptr = *source_info_ptr;
 }
 
 void CopyShadow(void *dest, const void *src, uptr size) {

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -242,9 +242,9 @@ ALWAYS_INLINE static void UpdateShadowSlot(uptr d_shadow, uptr d_origin,
   BorTag src_tag = *source_tag;
   AllocInfo *src_info = *source_info;
 
-  if (src_info != nullptr)
+  if (src_tag != 0)
     __bsan_rc_inc(src_tag, src_info);
-  if (*dest_info != nullptr)
+  if (dest_tag != 0)
     __bsan_rc_dec(*dest_tag, *dest_info);
 
   *dest_tag = src_tag;


### PR DESCRIPTION
Our update to nightly caused a performance regression. This is because our use of `DenseMap` within the garbage collector was unsound. For a couple of helper functions, we were iterating while removing entries. Claude pointed me toward [this change](https://github.com/llvm/llvm-project/pull/200595) to the `DenseMap` algorithm, which was ported to `compiler-rt`. Live entries are shifted over to fill deleted gaps, preventing possible candidates from being removed. 

> In exchange, erase now relocates the following live entries to close the
hole, so it invalidates iterators and references other than the erased
one. 

This PR also fixes a couple of other soundness issues. We had been leaking provenance in the `BsanAllocateMeta` helpers. It also switches to using acquire / release ordering for checking the value of the `__bsan_visits_since_gc` counter.