### PR TITLE
Ensure that exiting threads queue unpruned nodes for GC

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -263,7 +263,7 @@ void __sanitizer::BufferedStackTrace::UnwindImpl(uptr pc, uptr bp,
   BsanThread *t = CurrentThread();
   if (!t || !StackTrace::WillUseFastUnwind(request_fast)) {
     // Block reports from our interceptors during _Unwind_Backtrace.
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     return Unwind(max_depth, pc, bp, context, t ? t->stack_top() : 0,
                   t ? t->stack_bottom() : 0, false);
   }
@@ -455,7 +455,7 @@ void __bsan_retag(void *object_addr, uptr access_size, u8 flags,
                   void *dest, bool checked) {
   if (__bsan_retag_impl) {
     GET_SPAN;
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     Provenance prov;
     __bsan_retag_impl(object_addr, access_size, flags, im_data, im_len,
                       pin_data, pin_len, bor_tag, alloc_info, &prov, span,
@@ -478,7 +478,7 @@ void __bsan_read(void *ptr, uptr access_size, BorTag bor_tag,
                  AllocInfo *alloc_info, bool checked) {
   if (__bsan_read_impl) {
     GET_SPAN;
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     __bsan_read_impl(ptr, access_size, bor_tag, alloc_info, span, checked);
     HANDLE_ERROR;
   }
@@ -493,7 +493,7 @@ void __bsan_write(void *ptr, uptr access_size, BorTag bor_tag,
                   AllocInfo *alloc_info, bool checked) {
   if (__bsan_write_impl) {
     GET_SPAN;
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     __bsan_write_impl(ptr, access_size, bor_tag, alloc_info, span, checked);
     HANDLE_ERROR;
   }
@@ -505,7 +505,7 @@ bool __bsan_rc_inc_impl(BorTag Tag, AllocInfo *Info);
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_rc_inc(BorTag Tag, AllocInfo *Info) {
   if (__bsan_rc_inc_impl) {
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     __bsan_rc_inc_impl(Tag, Info);
   }
 }
@@ -516,7 +516,7 @@ bool __bsan_rc_dec_impl(BorTag Tag, AllocInfo *Info);
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_rc_dec(BorTag Tag, AllocInfo *Info) {
   if (__bsan_rc_dec_impl) {
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     if (__bsan_rc_dec_impl(Tag, Info)) {
       CurrentThread()->zct.acquireProvenance({Tag, Info});
     }
@@ -540,7 +540,7 @@ AllocInfo *__bsan_reserve_stack_slot_impl();
 SANITIZER_INTERFACE_ATTRIBUTE
 AllocInfo *__bsan_reserve_stack_slot() {
   if (__bsan_reserve_stack_slot_impl) {
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     return __bsan_reserve_stack_slot_impl();
   }
   return nullptr;
@@ -552,7 +552,7 @@ void __bsan_destroy_stack_slot_impl(AllocInfo *slot);
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_destroy_stack_slot(AllocInfo *slot) {
   if (__bsan_destroy_stack_slot_impl) {
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     __bsan_destroy_stack_slot_impl(slot);
   }
 }
@@ -564,7 +564,7 @@ AllocInfo *__bsan_alloc_impl(void *base_addr, uptr size, BorTag bor_tag,
 SANITIZER_INTERFACE_ATTRIBUTE
 AllocInfo *__bsan_alloc(void *base_addr, uptr size, BorTag bor_tag, Span pc) {
   if (__bsan_alloc_impl) {
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     AllocInfo *info = __bsan_alloc_impl(base_addr, size, bor_tag, pc);
     CurrentThread()->zct.acquireProvenance({bor_tag, info});
     return info;
@@ -586,7 +586,7 @@ void __bsan_alloc_stack(void *base_addr, uptr size, BorTag bor_tag,
                         AllocInfo *alloc_info) {
   if (__bsan_alloc_stack_impl) {
     GET_SPAN;
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     __bsan_alloc_stack_impl(base_addr, size, bor_tag, alloc_info, span);
     HANDLE_ERROR;
   }
@@ -599,7 +599,7 @@ SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_dealloc_stack(void *ptr, BorTag bor_tag, AllocInfo *alloc_info) {
   if (__bsan_dealloc_stack_impl) {
     GET_SPAN;
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     __bsan_dealloc_stack_impl(bor_tag, alloc_info, span);
     HANDLE_ERROR;
   }
@@ -611,7 +611,7 @@ void __bsan_expose_prov_impl(BorTag bor_tag, AllocInfo *alloc_info);
 SANITIZER_INTERFACE_ATTRIBUTE
 void __bsan_expose_prov(BorTag bor_tag, AllocInfo *alloc_info) {
   if (__bsan_expose_prov_impl) {
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     __bsan_expose_prov_impl(bor_tag, alloc_info);
   }
 }
@@ -625,7 +625,7 @@ void __bsan_pop_frame(const Provenance *frame_start, uptr prot,
   if (__bsan_protector_end_impl && __bsan_destroy_stack_slot_impl &&
       __bsan_dealloc_stack_impl) {
     GET_SPAN;
-    InterceptorBarrier Barrier;
+    InterceptorBarrier barrier;
     for (uptr i = 0; i < prot + alloca_vec_size; i++) {
       const Provenance prov = frame_start[i];
       if (i < prot) {

--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -464,7 +464,7 @@ void __bsan_retag(void *object_addr, uptr access_size, u8 flags,
     *(Provenance *)(dest) = prov;
     // A retag mints a fresh provenance value with no references yet; record it
     // in this thread's zero-count set as a collection candidate.
-    CurrentThread()->AcquireProvenance(prov);
+    CurrentThread()->zct.acquireProvenance(prov);
     MaybeRequestGC();
   }
 }
@@ -518,7 +518,7 @@ void __bsan_rc_dec(BorTag Tag, AllocInfo *Info) {
   if (__bsan_rc_dec_impl) {
     InterceptorBarrier Barrier;
     if (__bsan_rc_dec_impl(Tag, Info)) {
-      CurrentThread()->AcquireProvenance({Tag, Info});
+      CurrentThread()->zct.acquireProvenance({Tag, Info});
     }
   }
 }
@@ -566,7 +566,7 @@ AllocInfo *__bsan_alloc(void *base_addr, uptr size, BorTag bor_tag, Span pc) {
   if (__bsan_alloc_impl) {
     InterceptorBarrier Barrier;
     AllocInfo *info = __bsan_alloc_impl(base_addr, size, bor_tag, pc);
-    CurrentThread()->AcquireProvenance({bor_tag, info});
+    CurrentThread()->zct.acquireProvenance({bor_tag, info});
     return info;
   } else {
     return nullptr;

--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -11,8 +11,8 @@ using namespace __bsan;
 
 namespace __bsan {
 
-void GlobalContext::CollectProvenance(const uptr, BsanThread *const &thread,
-                                      void *arg) {
+void GlobalContext::CollectProvenance(const ThreadId id,
+                                      BsanThread *const &thread, void *arg) {
   // Iterate over the shadow stacks for each thread,
   // collecting all provenance values into the snapshot.
   auto *state = static_cast<Snapshot *>(arg);
@@ -23,18 +23,25 @@ void GlobalContext::CollectProvenance(const uptr, BsanThread *const &thread,
   }
 }
 
-void GlobalContext::MergeZeroCounts(const uptr, BsanThread *const &thread,
-                                    void *arg) {
+void GlobalContext::MergeZeroCountsCallback(const ThreadId id,
+                                            BsanThread *const &thread,
+                                            void *arg) {
   auto *snap = static_cast<Snapshot *>(arg);
   if (!thread) {
     return;
   }
+  MergeZeroCounts(snap, thread->zct);
+}
+
+void GlobalContext::MergeZeroCounts(Snapshot *snap, ZeroCountTable &zct) {
   // If the thread is not in the middle of updating its zero
   // count table, then we can drain its contents for garbage collection.
-  if (!thread->ZctBusy()) {
+  if (!zct.isBusy()) {
     // Move every unreachable value into the pending set, keeping the reachable
-    // ones in this thread's zero count table for a future collection.
-    thread->zero_count_set_.retainIf([&](AllocInfo *info, BorTag tag) -> bool {
+    // ones in this thread's zero count table for a future collection. Record
+    // the current generation as the last one when this thread's zero count
+    // table was drained.
+    zct.retainIf(snap->gen, [&](AllocInfo *info, BorTag tag) -> bool {
       Provenance prov = {tag, info};
       if (snap->live->contains(prov)) {
         return true;
@@ -42,17 +49,15 @@ void GlobalContext::MergeZeroCounts(const uptr, BsanThread *const &thread,
       global_ctx()->pending_.insert(prov);
       return false;
     });
-    // Record the current generation as the last one
-    // when this thread's zero count table was drained.
-    thread->drained_gen_ = snap->gen;
   }
 
   // The default value of `min_drained` is the current
   // generation. Its final value will be equal to the
   // minimum generation for any thread, after updating
   // the ZCT (if we were able to access it this time).
-  if (thread->drained_gen_ < snap->min_drained) {
-    snap->min_drained = thread->drained_gen_;
+  ZeroCountTable::Generation last_drained = zct.lastDrained();
+  if (last_drained < snap->min_drained) {
+    snap->min_drained = last_drained;
   }
 }
 
@@ -65,7 +70,10 @@ void GlobalContext::SnapshotCallback(const SuspendedThreadsList &, void *arg) {
   // in the set of live provenance values in the `SnapShot`, then remove
   // it from the ZCT and add it to the global "pending" set of provenance
   // values that need pruning.
-  threads.ForEachThread(MergeZeroCounts, arg);
+  threads.ForEachThread(MergeZeroCountsCallback, arg);
+  // We also need to visit the global ZCT, which contains garbage from threads
+  // that have exited since the last collection run.
+  MergeZeroCounts(static_cast<Snapshot *>(arg), threads.global_zct);
 }
 
 void GlobalContext::CollectGarbage(Snapshot &snap) {

--- a/bsan-rt/llvm-wrapper/bsan_global.h
+++ b/bsan-rt/llvm-wrapper/bsan_global.h
@@ -76,14 +76,16 @@ private:
   // Iterates over every thread's shadow stack, creating a set of all reachable
   // provenance values. The last argument is a pointer to the
   // `ConcreteProvenanceSet` being populated.
-  static void CollectProvenance(const uptr, BsanThread *const &thread,
+  static void CollectProvenance(const ThreadId id, BsanThread *const &thread,
                                 void *arg);
 
   // Iterates over every thread's zero-count-table, merging its contents into
   // the set of pending provenance values. We only add values to the pending set
   // if they are not present on any shadow stack. Values that we add to the
   // pending set are also removed from their thread's zero-count-table.
-  static void MergeZeroCounts(const uptr, BsanThread *const &thread, void *arg);
+  static void MergeZeroCountsCallback(const ThreadId id,
+                                      BsanThread *const &thread, void *arg);
+  static void MergeZeroCounts(Snapshot *snap, ZeroCountTable &zct);
 
   // Drains the contents of the pending provenance set, pruning the associated
   // state from the tree for each allocation. Ejects any retired allocation

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -160,7 +160,7 @@ static Provenance BsanAllocateMeta(void *ptr, SIZE_T size, uptr span) {
   BorTag tag = NewBorTag();
   AllocInfo *info = __bsan_alloc(ptr, size, tag, span);
   Provenance prov = {tag, info};
-  CurrentThread()->AcquireProvenance(prov);
+  CurrentThread()->zct.acquireProvenance(prov);
   return prov;
 }
 

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -82,6 +82,14 @@ public:
 
   // Removes all entries from the set, after executing the
   // given callback for each allocation.
+  void takeFrom(ConcreteProvenanceSet &other) {
+    other.drain([&](AllocInfo *info, BorTagSet &tags) {
+      tags.forEach([&](BorTag tag) { set_[info].insert(tag); });
+    });
+  }
+
+  // Removes all entries from the set, after executing the
+  // given callback for each allocation.
   template <typename Fn> void drain(Fn visit) {
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       visit(KV.first, KV.second);

--- a/bsan-rt/llvm-wrapper/bsan_shadow.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_shadow.cpp
@@ -91,7 +91,7 @@ static bool InitShadow(bool init_origins, bool dry_run) {
 
   if (!MEM_IS_APP(&__bsan_init)) {
     if (!dry_run)
-      Printf("FATAL: BorrowSanitizer: code %p is out of application range. "
+      Printf("FATAL: BorrowSanitizer: code %p is out of application range."
              "Non-PIE build?\n",
              (void *)&__bsan_init);
     return false;

--- a/bsan-rt/llvm-wrapper/bsan_thread.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_thread.cpp
@@ -32,8 +32,8 @@ void BsanThread::Init() {
 
 void BsanThread::Destroy(void *tsd) {
   BsanThread *t = (BsanThread *)tsd;
-  global_ctx()->Threads().DeregisterThread(t->id);
-  t->zero_count_set_.~ConcreteProvenanceSet();
+  global_ctx()->Threads().DeregisterThread(t);
+  t->zct.~ZeroCountTable();
   UnmapOrDie(t->shadow_stack_bottom_, t->shadow_stack_size_);
   uptr size = RoundUpTo(sizeof(BsanThread), GetPageSizeCached());
   UnmapOrDie(t, size);
@@ -61,7 +61,8 @@ void ThreadManager::RegisterThread(BsanThread *thread) {
   thread->id = tid;
 }
 
-void ThreadManager::DeregisterThread(ThreadId tid) {
+void ThreadManager::DeregisterThread(BsanThread *thread) {
   Lock l(&mtx_);
-  threads.erase(tid);
+  global_zct.drainFrom(thread->zct);
+  threads.erase(thread->id);
 }

--- a/bsan-rt/llvm-wrapper/bsan_thread.h
+++ b/bsan-rt/llvm-wrapper/bsan_thread.h
@@ -12,6 +12,59 @@ using namespace __sanitizer;
 
 namespace __bsan {
 
+struct ZeroCountTable {
+  typedef uptr Generation;
+  ~ZeroCountTable() {}
+
+private:
+  // A flag indicating that we are currently adding a value to the zero count
+  // table for this thread. If this flag is set when we stop the world, then we
+  // will skip merging its zero count table into the set of pending provenance
+  // values to garbage collect. We will still examine this thread's
+  // shadow stack to exclude reachable provenance values.
+  atomic_uint8_t busy_{};
+
+  Generation drained_gen_ = 0;
+
+  // Whenever we modify this zero-count table, we need to
+  // ensure that we are only doing so from the context of another table.
+  struct GCBarrier {
+    ZeroCountTable &zct;
+    GCBarrier(ZeroCountTable &zct) : zct(zct) {
+      atomic_store(&zct.busy_, 1, memory_order_release);
+    }
+    ~GCBarrier() { atomic_store(&zct.busy_, 0, memory_order_release); }
+  };
+
+  ConcreteProvenanceSet zct_;
+
+  // Adds a provenance value with a zero reference count
+  // to this table.
+public:
+  void acquireProvenance(Provenance Prov) {
+    // We use a release order here so that each of these
+    // stores is ordered before the "acquire" load used
+    // to check the value in `IsBusy`.
+    GCBarrier barrier(*this);
+    zct_.insert(Prov);
+  }
+
+  void drainFrom(ZeroCountTable &other) {
+    GCBarrier other_barrier(other);
+    GCBarrier this_barrier(*this);
+    zct_.takeFrom(other.zct_);
+  }
+
+  template <typename Fn> void retainIf(Generation gen, Fn retain) {
+    drained_gen_ = gen;
+    zct_.retainIf(retain);
+  }
+
+  Generation lastDrained() { return drained_gen_; }
+
+  bool isBusy() { return atomic_load(&busy_, memory_order_acquire) == 1; }
+};
+
 class BsanThread {
 public:
   // Allocates, but does not initialize an instance of the thread state
@@ -76,20 +129,7 @@ public:
 
   BsanThreadLocalMallocStorage &malloc_storage() { return malloc_storage_; }
 
-  // Adds a provenance value with a zero reference count
-  // to this thread's zero count table. Increments the
-  // "busy" flag to stop the garbage collector from
-  // including the contents of the zero count table, in
-  // case the world is stopped mid-acquire.
-  void AcquireProvenance(Provenance Prov) {
-    atomic_store(&zct_busy_, 1, memory_order_release);
-    zero_count_set_.insert(Prov);
-    atomic_store(&zct_busy_, 0, memory_order_release);
-  }
-
-  bool ZctBusy() const {
-    return atomic_load(&zct_busy_, memory_order_acquire) != 0;
-  }
+  ZeroCountTable zct;
 
 private:
   friend struct GlobalContext;
@@ -107,21 +147,6 @@ private:
   uptr shadow_stack_size_;
 
   BsanThreadLocalMallocStorage malloc_storage_;
-
-  // The set of concrete provenance values that reached
-  // a zero reference count while this thread was executing. This includes
-  // values that were decremented to zero, as well as newly allocated values,
-  // which begin at zero.
-  ConcreteProvenanceSet zero_count_set_;
-
-  // A flag indicating that we are currently adding a value to the zero count
-  // table for this thread. If this flag is set when we stop the world, then we
-  // will skip merging its zero count table into the set of pending provenance
-  // values to garbage collect. We will still examine this thread's
-  // shadow stack to exclude reachable provenance values.
-  atomic_uint8_t zct_busy_{};
-
-  uptr drained_gen_;
 
   // The address of this thread's thread-local allocation
   // containing the current value of its shadow stack
@@ -142,7 +167,7 @@ public:
   // from being visited by the garbage collector, so it needs to
   // happen before we deinitialize any of the other states associated
   // with this thread.
-  void DeregisterThread(ThreadId tid);
+  void DeregisterThread(BsanThread *thread);
 
   void LockThreads() SANITIZER_ACQUIRE() { mtx_.Lock(); }
   void UnlockThreads() SANITIZER_RELEASE() { mtx_.Unlock(); }
@@ -164,6 +189,10 @@ private:
   // A hashmap from each thread's `ThreadId`
   // to its state object.
   ThreadStateMap threads;
+  // When a thread exits, its zero count table needs to be
+  // retained, so that we can clean up any of the provenance
+  // values that it acquired in a future garbage collection pass.
+  ZeroCountTable global_zct;
   // We use an atomic counter to generate new `ThreadIds`.
   // We create a new ID every time a thread is registered.
   atomic_uintptr_t thread_id_ctr{0};


### PR DESCRIPTION
Every thread maintains a "zero-count-table"; a set of nodes with a zero reference count that have yet to be pruned by the garbage collector. When a thread exits, its ZCT is destroyed, which causes us to leak provenance. This PR adds a global ZCT that is used to store the contents of exiting threads' ZCTs.