### PR TITLE
Use real memintrinsics, and avoid deadlock on internal allocator

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan_global.h
+++ b/bsan-rt/llvm-wrapper/bsan_global.h
@@ -115,9 +115,11 @@ struct ScopedStopTheWorldLock {
     // once we resume.
     global_ctx()->Threads().LockThreads();
     LockAllocator();
+    InternalAllocatorLock();
   }
 
   ~ScopedStopTheWorldLock() {
+    InternalAllocatorUnlock();
     UnlockAllocator();
     global_ctx()->Threads().UnlockThreads();
   }

--- a/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_interceptors.cpp
@@ -31,6 +31,9 @@ int OnExit() { return 0; }
 
 DECLARE_REAL(void *, malloc, SIZE_T)
 DECLARE_REAL(void, free, void *)
+DECLARE_REAL(void *, memcpy, void *dest, const void *src, SIZE_T n)
+DECLARE_REAL(void *, memset, void *dest, int c, SIZE_T n)
+DECLARE_REAL(void *, memmove, void *dest, const void *src, SIZE_T n)
 
 extern "C" int pthread_attr_init(void *attr);
 extern "C" int pthread_attr_destroy(void *attr);
@@ -269,7 +272,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memset(void *dest, int c, uptr n) {
     internal_memset(dest, c, n);
   } else {
     ENSURE_BSAN_INITED();
-    internal_memset(dest, c, n);
+    REAL(memset)(dest, c, n);
     ClearShadow(dest, n);
   }
 }
@@ -280,7 +283,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memmove(void *dest, const void *src,
     internal_memmove(dest, src, n);
   } else {
     ENSURE_BSAN_INITED();
-    internal_memmove(dest, src, n);
+    REAL(memmove)(dest, src, n);
     MoveShadow(dest, src, n);
   }
 }
@@ -291,7 +294,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void __bsan_memcpy(void *dest, const void *src,
     internal_memcpy(dest, src, n);
   } else {
     ENSURE_BSAN_INITED();
-    internal_memcpy(dest, src, n);
+    REAL(memcpy)(dest, src, n);
     CopyShadow(dest, src, n);
   }
 }

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -1,6 +1,12 @@
 #ifndef BSAN_GC_H
 #define BSAN_GC_H
 
+// We use a variety of custom data structures
+// for BorrowSanitizer's garbage collector. Each
+// relies directly on `InternalMmapVector`, or
+// uses a proxy (e.g. `DenseMap`, which is an
+// `InternalMmapVector` underneath).
+
 #include "bsan.h"
 #include "sanitizer_common/sanitizer_array_ref.h"
 #include "sanitizer_common/sanitizer_common.h"
@@ -101,17 +107,17 @@ public:
 
   // Retain only the provenance values that satisfy the given predicate.
   template <typename Fn> void retainIf(Fn retain) {
-    Vector<AllocInfo *> ToErase;
+    InternalMmapVector<AllocInfo *> ToErase;
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       AllocInfo *info = KV.first;
       KV.second.retainIf([&](BorTag tag) { return retain(info, tag); });
       if (KV.second.size() == 0) {
         KV.second.destroy();
-        ToErase.PushBack(info);
+        ToErase.push_back(info);
       }
       return true;
     });
-    for (unsigned Idx = 0; Idx < ToErase.Size(); ++Idx)
+    for (unsigned Idx = 0; Idx < ToErase.size(); ++Idx)
       set_.erase(ToErase[Idx]);
   }
 


### PR DESCRIPTION
This PR adds two minor changes to the LLVM wrapper.

* When we stop the world, we first acquire a lock for the sanitizers' internal allocator. This prevents a deadlock, if any thread has already acquired this lock prior to us stopping the world. It also switches out `Vector` for `InternalMmapVector` in `ConcreteProvenanceSet::retainIf`, which was triggering this error for the crate `colored`.

* Use `memset`, `memcpy`, etc. instead of the `internal_` variants within interceptors.