### PR TITLE
Added options to disable wildcard provenance and node-level info.

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan.cpp
+++ b/bsan-rt/llvm-wrapper/bsan.cpp
@@ -278,7 +278,7 @@ using namespace __bsan;
 extern "C" {
 
 SANITIZER_WEAK_ATTRIBUTE
-void __bsan_internal_init() {}
+void __bsan_internal_init(SharedSanitizerFlags *_flags) {}
 
 void __bsan_init() {
   CHECK(!bsan_init_running);
@@ -287,10 +287,11 @@ void __bsan_init() {
   bsan_init_running = true;
 
   AvoidCVE_2016_2143();
-  InitializeFlags();
+  SharedSanitizerFlags flags;
+  InitializeFlags(flags);
   new (global_ctx()) GlobalContext();
 
-  __bsan_internal_init();
+  __bsan_internal_init(&flags);
   InitializePlatformEarly();
 
   if (!InitShadowWithReExec()) {

--- a/bsan-rt/llvm-wrapper/bsan_flags.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_flags.cpp
@@ -90,7 +90,7 @@ static void ProcessFlags() {
   // Flag validation goes here.
 }
 
-void InitializeFlags() {
+void InitializeFlags(SharedSanitizerFlags &shared) {
   InitializeDefaultFlags();
   ProcessFlags();
 
@@ -115,21 +115,15 @@ void InitializeFlags() {
         ApplyFlags();
       });
 #endif
+
+#define COPY_FLAG(name) (shared.name = __bsan::flags()->name)
+  COPY_FLAG(node_debug_info);
+  COPY_FLAG(tree_gc_min_nodes);
+  COPY_FLAG(max_compacted_children);
+  COPY_FLAG(wildcard);
 }
 
 } // namespace __bsan
-
-extern "C" {
-SANITIZER_INTERFACE_ATTRIBUTE bool __bsan_disable_node_debug_info() {
-  return __bsan::flags()->disable_node_debug_info;
-}
-SANITIZER_INTERFACE_ATTRIBUTE uptr __bsan_tree_gc_min_nodes() {
-  return __bsan::flags()->tree_gc_min_nodes;
-}
-SANITIZER_INTERFACE_ATTRIBUTE uptr __bsan_max_compacted_children() {
-  return __bsan::flags()->max_compacted_children;
-}
-}
 
 SANITIZER_INTERFACE_WEAK_DEF(const char *, __bsan_default_options, void) {
   return "";

--- a/bsan-rt/llvm-wrapper/bsan_flags.h
+++ b/bsan-rt/llvm-wrapper/bsan_flags.h
@@ -20,14 +20,20 @@ struct Flags {
 #define BSAN_FLAG(Type, Name, DefaultValue, Description) Type Name;
 #include "bsan_flags.inc"
 #undef BSAN_FLAG
-
   void SetDefaults();
+};
+
+extern "C" struct SharedSanitizerFlags {
+  bool wildcard;
+  bool node_debug_info;
+  uptr tree_gc_min_nodes;
+  uptr max_compacted_children;
 };
 
 extern Flags bsan_flags_dont_use_directly;
 inline Flags *flags() { return &bsan_flags_dont_use_directly; }
 
-void InitializeFlags();
+void InitializeFlags(SharedSanitizerFlags &shared);
 
 } // namespace __bsan
 

--- a/bsan-rt/llvm-wrapper/bsan_flags.inc
+++ b/bsan-rt/llvm-wrapper/bsan_flags.inc
@@ -5,13 +5,15 @@
 // BSAN_FLAG(Type, Name, DefaultValue, Description)
 // See COMMON_FLAG in sanitizer_flags.inc for more details.
 
-BSAN_FLAG(bool, disable_node_debug_info, false,
-          "Disable NodeDebugInfo diagnostics from the tree.")
+BSAN_FLAG(bool, node_debug_info, true,
+          "Enable node-level diagnostics from the tree.")
 BSAN_FLAG(uptr, stacktrace_max_len, 3,
           "Maximum number of frames captured for BorrowSanitizer stack traces.")
 BSAN_FLAG(uptr, visits_per_gc, 150000,
           "Trigger a garbage collection request after this many retags."
           "0 disables the garbage collector.")
+BSAN_FLAG(bool, wildcard, true,
+          "Use wildcard provenance semantics.")
 BSAN_FLAG(uptr, tree_gc_min_nodes, 64,
           "Only prune borrow trees with more than this many nodes."
           "0 makes every initialized tree prunable.")

--- a/bsan-rt/src/borrow_tracker.rs
+++ b/bsan-rt/src/borrow_tracker.rs
@@ -274,7 +274,12 @@ impl<'b> BorrowTracker<'b> {
         }
     }
 
-    pub fn retag(&mut self, retag_info: RetagInfo<'_>, span: Span) -> UBResult<Provenance> {
+    pub fn retag(
+        &mut self,
+        global_ctx: &GlobalCtx,
+        retag_info: RetagInfo<'_>,
+        span: Span,
+    ) -> UBResult<Provenance> {
         let alloc_id = self.alloc_info.alloc_id.get();
         let parent_tag = self.bor_tag;
         let new_tag = BorTag::default();
@@ -342,6 +347,7 @@ impl<'b> BorrowTracker<'b> {
 
                 // Perform the access (update the Tree Borrows FSM)
                 self.tree.perform_access(
+                    global_ctx,
                     parent_tag,
                     range_in_alloc,
                     access_kind,
@@ -366,8 +372,13 @@ impl<'b> BorrowTracker<'b> {
         Ok(Provenance { alloc_info: self.alloc_info.0.as_ptr(), bor_tag: new_tag })
     }
 
-    pub fn protector_end(&mut self, span: Span) -> UBResult<()> {
-        self.tree.perform_protector_end_access(self.bor_tag, self.alloc_info.alloc_id.get(), span)
+    pub fn protector_end(&mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
+        self.tree.perform_protector_end_access(
+            global_ctx,
+            self.bor_tag,
+            self.alloc_info.alloc_id.get(),
+            span,
+        )
     }
 
     /// Increments the reference count, returning `true` if the count went from
@@ -382,8 +393,14 @@ impl<'b> BorrowTracker<'b> {
         Ok(self.tree.decrement(self.bor_tag))
     }
 
-    pub fn access(&mut self, access_kind: AccessKind, span: Span) -> UBResult<()> {
+    pub fn access(
+        &mut self,
+        global_ctx: &GlobalCtx,
+        access_kind: AccessKind,
+        span: Span,
+    ) -> UBResult<()> {
         self.tree.perform_access(
+            global_ctx,
             self.bor_tag,
             self.range,
             access_kind,
@@ -394,20 +411,29 @@ impl<'b> BorrowTracker<'b> {
     }
 
     pub fn dealloc(mut self, global_ctx: &GlobalCtx, span: Span) -> UBResult<()> {
-        self.tree.take().dealloc(self.bor_tag, self.range, self.alloc_info.alloc_id.get(), span)?;
+        self.tree.take().dealloc(
+            global_ctx,
+            self.bor_tag,
+            self.range,
+            self.alloc_info.alloc_id.get(),
+            span,
+        )?;
         let range = unsafe { self.alloc_info.range() };
         global_ctx.remove_exposed_provenance(range, true);
         Ok(())
     }
 
     pub fn expose_tag(&mut self, global_ctx: &GlobalCtx) -> UBResult<()> {
+        if !global_ctx.flags.wildcard {
+            return Ok(());
+        }
         let tag = self.bor_tag;
         let range = unsafe { self.alloc_info.range() };
 
         // Ranges in the mapping must be non-empty, and a wildcard access can
         // never resolve to a zero-sized allocation anyway.
         if range.size > Size::ZERO {
-            let mut exposed = global_ctx.exposed_provenance_mut();
+            let mut exposed = global_ctx.exposed_provenance();
             if let AccessType::Empty(pos) = exposed.access_type(range) {
                 exposed.insert_at_pos(pos, range, self.alloc_info);
             }

--- a/bsan-rt/src/errors.rs
+++ b/bsan-rt/src/errors.rs
@@ -5,7 +5,7 @@ use core::cmp::max;
 use hashbrown::HashMap;
 
 use crate::helpers::Size;
-use crate::sanitizer_common::{SanitizerCommon, Symbol};
+use crate::sanitizer_common::{Bridge, Symbol};
 use crate::tree_borrows::diagnostics::TreeBorrowsUb;
 use crate::AllocId;
 
@@ -79,7 +79,7 @@ impl ErrorFormatContext {
             .drain(..)
             .map(|evt| {
                 if let Some(span) = evt.0 {
-                    let (sym, origin) = SanitizerCommon::symbolize_with_origin(span);
+                    let (sym, origin) = Bridge::symbolize_with_origin(span);
                     max_indentation = max_indentation.max(sym.line_length());
                     if let Some(origin) = &origin {
                         max_indentation = max_indentation.max(origin.line_length());
@@ -133,8 +133,8 @@ impl ErrorFormatContext {
                 let file = self
                     .file_cache
                     .entry(path.clone())
-                    .or_insert_with(|| SanitizerCommon::read_file(&path).unwrap_or_default());
-                if let Some(content_raw) = SanitizerCommon::get_source_line(file, line) {
+                    .or_insert_with(|| Bridge::read_file(&path).unwrap_or_default());
+                if let Some(content_raw) = Bridge::get_source_line(file, line) {
                     let content = content_raw.trim_start();
                     let trimmed_ws_diff = content_raw.len() - content.len();
                     let content = content.trim_end();

--- a/bsan-rt/src/global.rs
+++ b/bsan-rt/src/global.rs
@@ -2,62 +2,20 @@ use core::cell::UnsafeCell;
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use spin::{RwLock, RwLockWriteGuard};
 
-use crate::errors::{ErrorFormatContext, UBInfo};
+use crate::errors::UBInfo;
 use crate::helpers::FxHashMap;
 use crate::memory::Heap;
-use crate::sanitizer_common::Span;
+use crate::sanitizer_common::{Bridge, SharedSanitizerFlags};
 use crate::tree_borrows::data_structures::{AccessType, RangeObjectMap};
 use crate::tree_borrows::AllocStateImpl;
 use crate::*;
 
-pub static DISABLE_NODE_DEBUG_INFO: AtomicBool = AtomicBool::new(false);
+pub struct ExposedProvenance<'a>(RwLockWriteGuard<'a, RangeObjectMap<AllocInfoPtr>>);
 
-/// Only prune borrow trees with more than this many nodes; this initial value is only
-/// the pre-init default and is replaced by the flag's default (64) in `bsan_flags.inc`.
-pub static TREE_GC_MIN_NODES: AtomicUsize = AtomicUsize::new(0);
-
-/// Upper bound on how many children can be resulted from compaction of a single node.
-/// The pre-init default and is replaced by the flag's default (16) in `bsan_flags.inc`.
-pub static MAX_COMPACTED_CHILDREN: AtomicUsize = AtomicUsize::new(usize::MAX);
-
-/// Thread-local slot for a boxed `(UBInfo, Span)` set by `handle_error` and
-/// consumed by `__bsan_format_pending_ub` once the C++ side has captured the
-/// stack and located the first user-code frame.
-#[thread_local]
-static PENDING_ERROR: UnsafeCell<*mut (UBInfo, Span)> = UnsafeCell::new(core::ptr::null_mut());
-
-unsafe extern "C" {
-    fn __bsan_abort() -> !;
-    fn __bsan_disable_node_debug_info() -> bool;
-    fn __bsan_tree_gc_min_nodes() -> usize;
-    fn __bsan_max_compacted_children() -> usize;
-}
-
-/// Called from the `HANDLE_ERROR` C++ macro after the stack trace has been
-/// captured and the first user-code frame PC has been located.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn __bsan_format_pending_ub(user_frame_pc: usize) {
-    let ptr = unsafe { *PENDING_ERROR.get() };
-    if ptr.is_null() {
-        return;
-    }
-    unsafe { *PENDING_ERROR.get() = core::ptr::null_mut() };
-    let (ub_info, original_pc) = unsafe { *alloc::boxed::Box::from_raw(ptr) };
-    let (primary, origin) = crate::sanitizer_common::SanitizerCommon::resolve_error_location(
-        user_frame_pc,
-        original_pc,
-    );
-    let mut ctx = ErrorFormatContext::default();
-    crate::eprint!("error: {}", ctx.display_ub(ub_info, primary, origin));
-}
-
-pub struct ExposedProvenanceRef<'a>(RwLockReadGuard<'a, RangeObjectMap<AllocInfoPtr>>);
-
-impl<'a> Deref for ExposedProvenanceRef<'a> {
+impl<'a> Deref for ExposedProvenance<'a> {
     type Target = RangeObjectMap<AllocInfoPtr>;
 
     fn deref(&self) -> &Self::Target {
@@ -65,17 +23,7 @@ impl<'a> Deref for ExposedProvenanceRef<'a> {
     }
 }
 
-pub struct ExposedProvenanceRefMut<'a>(RwLockWriteGuard<'a, RangeObjectMap<AllocInfoPtr>>);
-
-impl<'a> Deref for ExposedProvenanceRefMut<'a> {
-    type Target = RangeObjectMap<AllocInfoPtr>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<'a> DerefMut for ExposedProvenanceRefMut<'a> {
+impl<'a> DerefMut for ExposedProvenance<'a> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
@@ -94,14 +42,16 @@ pub struct GlobalCtx {
     alloc_metadata_map: Heap<AllocInfo>,
     snapshots: RwLock<FxHashMap<AllocId, AllocStateImpl>>,
     exposed_provenance: RwLock<RangeObjectMap<AllocInfoPtr>>,
+    pub flags: SharedSanitizerFlags,
 }
 
 impl GlobalCtx {
-    fn new() -> Self {
+    pub(crate) fn new(flags: &SharedSanitizerFlags) -> Self {
         Self {
             alloc_metadata_map: Heap::new(),
             snapshots: RwLock::new(FxHashMap::default()),
             exposed_provenance: RwLock::new(RangeObjectMap::new()),
+            flags: flags.clone(),
         }
     }
 
@@ -113,16 +63,14 @@ impl GlobalCtx {
         unsafe { self.alloc_metadata_map.dealloc(ptr) }
     }
 
-    #[allow(unused)]
-    pub fn exposed_provenance<'a>(&'a self) -> ExposedProvenanceRef<'a> {
-        ExposedProvenanceRef(self.exposed_provenance.read())
-    }
-
-    pub fn exposed_provenance_mut<'a>(&'a self) -> ExposedProvenanceRefMut<'a> {
-        ExposedProvenanceRefMut(self.exposed_provenance.write())
+    pub fn exposed_provenance<'a>(&'a self) -> ExposedProvenance<'a> {
+        ExposedProvenance(self.exposed_provenance.write())
     }
 
     pub fn get_exposed_provenance(&self, range: AllocRange) -> Option<AllocInfoPtr> {
+        if !self.flags.wildcard {
+            return None;
+        }
         // A zero-sized lookup (e.g. a deallocation, where the size of the access
         // is determined by the allocation) still needs to resolve the allocation
         // containing its start address, so we widen it to a single byte.
@@ -139,7 +87,9 @@ impl GlobalCtx {
     }
 
     pub fn remove_exposed_provenance(&self, range: AllocRange, strict: bool) {
-        self.removing_exposed_provenance(range, strict, || {});
+        if self.flags.wildcard {
+            self.removing_exposed_provenance(range, strict, || {});
+        }
     }
     /// Removes a provenance value that has been exposed for the given range.
     /// If `strict`, then exposed provenance will only be removed if is matches
@@ -180,15 +130,7 @@ impl GlobalCtx {
     }
 
     pub fn handle_error(&self, ub_info: UBInfo, pc: Span) {
-        unsafe {
-            let old_ptr = *PENDING_ERROR.get();
-            if !old_ptr.is_null() {
-                drop(alloc::boxed::Box::from_raw(old_ptr));
-            }
-            let ptr = alloc::boxed::Box::into_raw(alloc::boxed::Box::new((ub_info, pc)));
-            *PENDING_ERROR.get() = ptr;
-            crate::sanitizer_common::__bsan_had_error = 1;
-        }
+        Bridge::prepare_error(ub_info, pc);
     }
 
     pub fn take_snapshot(&self, alloc_id: AllocId, tree: AllocStateImpl) {
@@ -263,12 +205,9 @@ static GLOBAL_CTX: GlobalCtxWrapper = GlobalCtxWrapper(UnsafeCell::new(MaybeUnin
 /// It is marked as `unsafe`, because it relies on the set of function pointers in
 /// `BsanHooks` to be valid.
 #[inline]
-pub unsafe fn init_global_ctx() {
+pub unsafe fn init_global_ctx(flags: NonNull<SharedSanitizerFlags>) {
     unsafe {
-        (*GLOBAL_CTX.0.get()).write(GlobalCtx::new());
-        DISABLE_NODE_DEBUG_INFO.store(__bsan_disable_node_debug_info(), Ordering::Relaxed);
-        TREE_GC_MIN_NODES.store(__bsan_tree_gc_min_nodes(), Ordering::Relaxed);
-        MAX_COMPACTED_CHILDREN.store(__bsan_max_compacted_children(), Ordering::Relaxed);
+        (*GLOBAL_CTX.0.get()).write(GlobalCtx::new(flags.as_ref()));
     }
 }
 

--- a/bsan-rt/src/lib.rs
+++ b/bsan-rt/src/lib.rs
@@ -31,7 +31,7 @@ mod errors;
 mod memory;
 
 use crate::helpers::{AllocRange, Size};
-use crate::sanitizer_common::Span;
+use crate::sanitizer_common::{SharedSanitizerFlags, Span};
 use crate::tree_borrows::perms::AccessKind;
 use crate::tree_borrows::tree::AllocStateImpl;
 use crate::tree_borrows::AllocState;
@@ -300,9 +300,9 @@ pub(crate) enum AllocInfoSummary {
 /// function having been executed. We assume the global invariant that
 /// no other API functions will be called prior to that point.
 #[unsafe(no_mangle)]
-unsafe extern "C-unwind" fn __bsan_internal_init() {
+unsafe extern "C-unwind" fn __bsan_internal_init(flags: NonNull<SharedSanitizerFlags>) {
     unsafe {
-        init_global_ctx();
+        init_global_ctx(flags);
     }
 }
 
@@ -376,12 +376,12 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
                 prov,
                 Size::from_addr(ptr),
                 Some(size),
-                |mut bt| bt.retag(retag_info, pc).map(Some),
+                |mut bt| bt.retag(ctx, retag_info, pc).map(Some),
             )
         }
     } else {
         BorrowTracker::for_access(ctx, prov, Size::from_addr(ptr), Some(size), |mut bt| {
-            bt.retag(retag_info, pc).map(Some)
+            bt.retag(ctx, retag_info, pc).map(Some)
         })
     }
     .map(|opt| opt.unwrap_or(prov))
@@ -395,9 +395,10 @@ unsafe extern "C-unwind" fn __bsan_retag_impl(
 
 #[unsafe(no_mangle)]
 extern "C" fn __bsan_protector_end_impl(bor_tag: BorTag, alloc_info: *mut AllocInfo, pc: Span) {
+    let ctx = unsafe { global_ctx() };
     let prov = Provenance { bor_tag, alloc_info };
     BorrowTracker::for_alloc_weak(prov, |mut bt| {
-        let _ = bt.protector_end(pc);
+        let _ = bt.protector_end(ctx, pc);
     });
 }
 
@@ -421,12 +422,12 @@ unsafe extern "C-unwind" fn __bsan_read_impl(
                 prov,
                 Size::from_addr(ptr),
                 Some(access_size),
-                |mut bt| bt.access(AccessKind::Read, pc),
+                |mut bt| bt.access(ctx, AccessKind::Read, pc),
             )
         }
     } else {
         BorrowTracker::for_access(ctx, prov, Size::from_addr(ptr), Some(access_size), |mut bt| {
-            bt.access(AccessKind::Read, pc)
+            bt.access(ctx, AccessKind::Read, pc)
         })
     }
     .unwrap_or_else(|err| ctx.handle_error(err, pc));
@@ -452,12 +453,12 @@ unsafe extern "C-unwind" fn __bsan_write_impl(
                 prov,
                 Size::from_addr(ptr),
                 Some(access_size),
-                |mut bt| bt.access(AccessKind::Write, pc),
+                |mut bt| bt.access(ctx, AccessKind::Write, pc),
             )
         }
     } else {
         BorrowTracker::for_access(ctx, prov, Size::from_addr(ptr), Some(access_size), |mut bt| {
-            bt.access(AccessKind::Write, pc)
+            bt.access(ctx, AccessKind::Write, pc)
         })
     }
     .unwrap_or_else(|err| ctx.handle_error(err, pc));
@@ -607,10 +608,11 @@ unsafe extern "C" fn __bsan_prune(
     bor_tags: *mut BorTag,
     len: usize,
 ) -> bool {
+    let global_ctx = unsafe { global_ctx() };
     let alloc: AllocInfoPtr = alloc_info.into();
     let dead_tags = unsafe { slice::from_raw_parts_mut(bor_tags, len) };
     match alloc.tree.lock().as_mut() {
-        Some(tree) => tree.remove_dead_tags(dead_tags),
+        Some(tree) => tree.remove_dead_tags(global_ctx, dead_tags),
         None => {
             // The tree is already deallocated, so we can zero out dead_tags
             dead_tags.fill(BorTag::omnivalid());

--- a/bsan-rt/src/memory/mod.rs
+++ b/bsan-rt/src/memory/mod.rs
@@ -6,12 +6,12 @@
 
 mod heap;
 use core::ffi::c_void;
-use core::mem::{self, MaybeUninit};
+use core::mem;
 use core::num::NonZero;
 use core::ptr::{self, NonNull};
 
 pub use heap::*;
-use libc::{pthread_attr_destroy, pthread_attr_init, pthread_attr_t, rlimit, _SC_PAGESIZE};
+use libc::_SC_PAGESIZE;
 
 use crate::{AllocInfo, BorTag};
 
@@ -21,47 +21,6 @@ pub const BSAN_MAP_FLAGS: i32 =
     libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_ANON | libc::MAP_NORESERVE;
 #[cfg(miri)]
 pub const BSAN_MAP_FLAGS: i32 = libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_ANON;
-
-#[derive(Debug, Copy, Clone)]
-pub struct StackSize(NonZero<usize>);
-
-#[allow(clippy::from_over_into)]
-impl Into<NonZero<usize>> for StackSize {
-    fn into(self) -> NonZero<usize> {
-        self.0
-    }
-}
-
-#[allow(unused)]
-impl StackSize {
-    pub fn from_rlimit() -> Self {
-        let mut limits = MaybeUninit::<rlimit>::uninit();
-
-        let exit_code = unsafe { libc::getrlimit(libc::RLIMIT_STACK, limits.as_mut_ptr()) };
-        assert!(exit_code == 0, "`getrlimit` with `RLIMIT_STACK failed: {exit_code}");
-
-        let size = unsafe { limits.assume_init() }.rlim_cur as usize;
-        unsafe { StackSize(NonZero::new_unchecked(size)) }
-    }
-
-    pub fn from_pthread() -> Self {
-        let mut attr = MaybeUninit::<pthread_attr_t>::uninit();
-
-        let attr_init = unsafe { pthread_attr_init(attr.as_mut_ptr()) };
-        assert!(attr_init == 0, "`pthread_attr_init` failed: {attr_init}");
-
-        let mut size = MaybeUninit::<libc::size_t>::uninit();
-        let size_init =
-            unsafe { libc::pthread_attr_getstacksize(attr.as_mut_ptr(), size.as_mut_ptr()) };
-        assert!(size_init == 0, "`pthread_attr_getstacksize` failed: {size_init}");
-
-        let attr_destroy = unsafe { pthread_attr_destroy(attr.as_mut_ptr()) };
-        assert!(attr_destroy == 0, "`pthread_attr_destroy` failed: {attr_destroy}");
-
-        let size = unsafe { NonZero::new_unchecked(size.assume_init()) };
-        StackSize(size)
-    }
-}
 
 static mut PAGE_SIZE_CACHED: Option<NonZero<usize>> = None;
 
@@ -161,17 +120,7 @@ pub unsafe fn munmap<T>(ptr: NonNull<T>, size_bytes: impl Into<NonZero<usize>>) 
 
 #[cfg(test)]
 mod tests {
-    use crate::memory::{next_greater_multiple_unchecked, StackSize};
-
-    #[test]
-    fn stack_size() {
-        StackSize::from_rlimit();
-        std::thread::spawn(move || {
-            StackSize::from_pthread();
-        })
-        .join()
-        .unwrap();
-    }
+    use crate::memory::next_greater_multiple_unchecked;
 
     #[test]
     fn rounding() {

--- a/bsan-rt/src/sanitizer_common.rs
+++ b/bsan-rt/src/sanitizer_common.rs
@@ -1,7 +1,45 @@
+use alloc::boxed::Box;
 use alloc::ffi::CString;
 use alloc::string::{String, ToString};
+use core::cell::UnsafeCell;
 use core::ffi::c_char;
 use core::{fmt, ptr, slice};
+
+use crate::errors::{ErrorFormatContext, UBInfo};
+
+/// Thread-local slot for a boxed `(UBInfo, Span)` set by `handle_error` and
+/// consumed by `__bsan_format_pending_ub` once the C++ side has captured the
+/// stack and located the first user-code frame.
+#[thread_local]
+pub(crate) static PENDING_ERROR: UnsafeCell<*mut (UBInfo, Span)> =
+    UnsafeCell::new(core::ptr::null_mut());
+
+/// Configuration options set by the user via `BSAN_OPTIONS`.
+///
+/// This mirrors a definition in the LLVM wrapper (`bsan_flags.h`).
+/// New options must be added to each definition, and initialized
+/// within `InitializeFlags` in C++.
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub(crate) struct SharedSanitizerFlags {
+    pub wildcard: bool,
+    pub node_debug_info: bool,
+    pub max_compacted_children: usize,
+    pub tree_gc_min_nodes: usize,
+}
+
+impl Default for SharedSanitizerFlags {
+    fn default() -> Self {
+        // These values should be kept in sync
+        // with those defined in `bsan_flags.inc`
+        Self {
+            wildcard: true,
+            node_debug_info: true,
+            max_compacted_children: 16,
+            tree_gc_min_nodes: 64,
+        }
+    }
+}
 
 /// The immediate caller PC of a runtime hook, captured at the retag/access
 /// site by the C++ interceptors. Symbolized lazily at display time as the
@@ -54,9 +92,21 @@ impl fmt::Display for Symbol {
     }
 }
 
-pub struct SanitizerCommon;
+pub struct Bridge;
 
-impl SanitizerCommon {
+impl Bridge {
+    pub fn prepare_error(ub_info: UBInfo, pc: Span) {
+        unsafe {
+            let old_ptr = *PENDING_ERROR.get();
+            if !old_ptr.is_null() {
+                drop(alloc::boxed::Box::from_raw(old_ptr));
+            }
+            let ptr = Box::into_raw(Box::new((ub_info, pc)));
+            *PENDING_ERROR.get() = ptr;
+            __bsan_had_error = 1;
+        }
+    }
+
     /// Symbolizes `pc` to a [`Symbol`], reporting whether it lies in an
     /// internal library path.
     fn symbolize_pc(pc: usize) -> (Symbol, bool) {
@@ -161,4 +211,21 @@ unsafe extern "C" {
 
     /// Free the buffer allocated by __bsan_read_file
     fn __bsan_free_buffer(buf: *mut c_char, size: usize);
+    fn __bsan_abort() -> !;
+}
+
+/// Called from the `HANDLE_ERROR` C++ macro after the stack trace has been
+/// captured and the first user-code frame PC has been located.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn __bsan_format_pending_ub(user_frame_pc: usize) {
+    let ptr = unsafe { *PENDING_ERROR.get() };
+    if ptr.is_null() {
+        return;
+    }
+    unsafe { *PENDING_ERROR.get() = core::ptr::null_mut() };
+    let (ub_info, original_pc) = unsafe { *alloc::boxed::Box::from_raw(ptr) };
+    let (primary, origin) =
+        crate::sanitizer_common::Bridge::resolve_error_location(user_frame_pc, original_pc);
+    let mut ctx = ErrorFormatContext::default();
+    crate::eprint!("error: {}", ctx.display_ub(ub_info, primary, origin));
 }

--- a/bsan-rt/src/tree_borrows/tree.rs
+++ b/bsan-rt/src/tree_borrows/tree.rs
@@ -15,7 +15,6 @@
 
 // use alloc::boxed::Box;
 use core::ops::Range;
-use core::sync::atomic::Ordering::Relaxed;
 use core::{cmp, fmt, mem};
 
 use smallvec::SmallVec;
@@ -31,7 +30,6 @@ use super::refcount::RefCount;
 use super::tree_visitor::{ChildrenVisitMode, ContinueTraversal, NodeAppArgs, TreeVisitor};
 use super::wildcard::{ExposedCache, WildcardAccessLevel};
 use crate::errors::UBResult;
-use crate::global::{MAX_COMPACTED_CHILDREN, TREE_GC_MIN_NODES};
 use crate::helpers::{AllocRange, Size};
 use crate::sanitizer_common::Span;
 use crate::tree_borrows::ProtectorKind;
@@ -247,6 +245,7 @@ impl LocationState {
     /// perm and wildcard_state to reflect the transition.
     fn perform_transition(
         &mut self,
+        global_ctx: &GlobalCtx,
         idx: UniIndex,
         nodes: &mut UniValMap<Node>,
         exposed_cache: &mut ExposedCache,
@@ -263,10 +262,13 @@ impl LocationState {
         let transition = self.perform_access(access_kind, relatedness, protected)?;
         if !transition.is_noop() {
             let node = nodes.get_mut(idx).unwrap();
-            // Record the event as part of the history.
-            node.debug_info
-                .history
-                .push(diagnostics.create_event(transition, relatedness.is_foreign()));
+
+            if global_ctx.flags.node_debug_info {
+                // Record the event as part of the history.
+                node.debug_info
+                    .history
+                    .push(diagnostics.create_event(transition, relatedness.is_foreign()));
+            }
 
             // We need to update the wildcard state, if the permission
             // of an exposed pointer changes.
@@ -534,7 +536,7 @@ impl EagerTree {
     /// Like [`Self::can_be_replaced_by_single_child`], but for a node with more than one
     /// child. This requires the stronger [`Permission::can_be_replaced_by_children`] check, and
     /// it must hold for every child at every location
-    fn can_be_replaced_by_children(&self, idx: UniIndex) -> bool {
+    fn can_be_replaced_by_children(&self, global_ctx: &GlobalCtx, idx: UniIndex) -> bool {
         let node = self.nodes.get(idx).unwrap();
         // A root nor `ReservedIM` parent is never replaced
         let Some(parent_idx) = node.parent else { return false };
@@ -544,7 +546,8 @@ impl EagerTree {
 
         // Check that the final compaction result would be within bounds
         let parent_width = self.nodes.get(parent_idx).unwrap().children.len();
-        if parent_width + node.children.len() - 1 > MAX_COMPACTED_CHILDREN.load(Relaxed) {
+
+        if parent_width + node.children.len() - 1 > global_ctx.flags.max_compacted_children {
             return false;
         }
 
@@ -610,7 +613,12 @@ impl EagerTree {
     /// `roots`, which [`LocationTree::perform_access`] and the wildcard consistency
     /// checks rely on. This retains at most one dead root per tree, and only until its
     /// subtree dies (or is compacted away), at which point it is removed as a leaf.
-    fn remove_useless_children(&mut self, dead_tags: &mut [BorTag], compact: bool) {
+    fn remove_useless_children(
+        &mut self,
+        global_ctx: &GlobalCtx,
+        dead_tags: &mut [BorTag],
+        compact: bool,
+    ) {
         // Iterating through dead_tags in reverse (descending tag order)
         for entry in dead_tags.iter_mut().rev() {
             let tag = *entry;
@@ -675,7 +683,7 @@ impl EagerTree {
                 }
                 // Node has more than one child. If every child can soundly replace it, compact it
                 // by reparenting all of its children onto its parent.
-                _ if compact && self.can_be_replaced_by_children(idx) => {
+                _ if compact && self.can_be_replaced_by_children(global_ctx, idx) => {
                     let parent_idx = parent.unwrap();
                     // Move `idx`'s children out so we can reparent them
                     let children = mem::take(&mut self.nodes.get_mut(idx).unwrap().children);
@@ -736,6 +744,7 @@ impl LocationTree {
     ///   of the accessed node.
     fn perform_access(
         &mut self,
+        global_ctx: &GlobalCtx,
         roots: impl Iterator<Item = UniIndex>,
         nodes: &mut UniValMap<Node>,
         access_source: Option<UniIndex>,
@@ -746,6 +755,7 @@ impl LocationTree {
     ) -> UBResult<()> {
         let accessed_root = if let Some(idx) = access_source {
             Some(self.perform_normal_access(
+                global_ctx,
                 idx,
                 nodes,
                 access_kind,
@@ -791,6 +801,7 @@ impl LocationTree {
             // As a consequence of this, since the root of the main tree is the smallest tag in the entire
             // allocation, if the access occurred in the main tree then other subtrees will only see foreign accesses.
             self.perform_wildcard_access(
+                global_ctx,
                 root,
                 access_source,
                 /*max_local_tag*/ accessed_root_tag,
@@ -811,6 +822,7 @@ impl LocationTree {
     ///   during the access. Used for protector end access.
     fn perform_normal_access(
         &mut self,
+        global_ctx: &GlobalCtx,
         access_source: UniIndex,
         nodes: &mut UniValMap<Node>,
         access_kind: AccessKind,
@@ -845,6 +857,7 @@ impl LocationTree {
             let protected = node.protector_kind.is_some();
             state
                 .perform_transition(
+                    global_ctx,
                     args.idx,
                     args.nodes,
                     &mut args.data.exposed_cache,
@@ -891,6 +904,7 @@ impl LocationTree {
     ///   at most `max_local_tag`.
     fn perform_wildcard_access(
         &mut self,
+        global_ctx: &GlobalCtx,
         root: UniIndex,
         access_source: Option<UniIndex>,
         max_local_tag: Option<BorTag>,
@@ -985,6 +999,7 @@ impl LocationTree {
 
                 // We know the exact relatedness, so we can actually do precise checks.
                 perm.perform_transition(
+                    global_ctx,
                     args.idx,
                     args.nodes,
                     &mut args.data.exposed_cache,
@@ -1042,6 +1057,7 @@ pub trait AllocState: Clone {
     ) -> UBResult<()>;
     fn perform_access(
         &mut self,
+        global_ctx: &GlobalCtx,
         tag: BorTag,
         access_range: AllocRange,
         access_kind: AccessKind,
@@ -1051,6 +1067,8 @@ pub trait AllocState: Clone {
     ) -> UBResult<()>;
     fn dealloc(
         &mut self,
+        global_ctx: &GlobalCtx,
+
         tag: BorTag,
         access_range: AllocRange,
         alloc_id: AllocId,
@@ -1058,13 +1076,14 @@ pub trait AllocState: Clone {
     ) -> UBResult<()>;
     fn perform_protector_end_access(
         &mut self,
+        global_ctx: &GlobalCtx,
         tag: BorTag,
         alloc_id: AllocId,
         span: Span,
     ) -> UBResult<()>;
     fn expose_tag(&mut self, tag: BorTag, protected: bool);
     #[allow(dead_code)]
-    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool;
+    fn remove_dead_tags(&mut self, global_ctx: &GlobalCtx, dead_tags: &mut [BorTag]) -> bool;
 }
 
 impl AllocState for LazyTree {
@@ -1104,6 +1123,8 @@ impl AllocState for LazyTree {
     }
     fn perform_access(
         &mut self,
+        global_ctx: &GlobalCtx,
+
         tag: BorTag,
         access_range: AllocRange,
         access_kind: AccessKind,
@@ -1113,13 +1134,20 @@ impl AllocState for LazyTree {
     ) -> UBResult<()> {
         match self {
             LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => {
-                tree.perform_access(tag, access_range, access_kind, access_cause, alloc_id, span)
-            }
+            LazyTree::Init(tree) => tree.perform_access(
+                global_ctx,
+                tag,
+                access_range,
+                access_kind,
+                access_cause,
+                alloc_id,
+                span,
+            ),
         }
     }
     fn dealloc(
         &mut self,
+        global_ctx: &GlobalCtx,
         tag: BorTag,
         access_range: AllocRange,
         alloc_id: AllocId,
@@ -1127,18 +1155,22 @@ impl AllocState for LazyTree {
     ) -> UBResult<()> {
         match self {
             LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.dealloc(tag, access_range, alloc_id, span),
+            LazyTree::Init(tree) => tree.dealloc(global_ctx, tag, access_range, alloc_id, span),
         }
     }
     fn perform_protector_end_access(
         &mut self,
+        global_ctx: &GlobalCtx,
+
         tag: BorTag,
         alloc_id: AllocId,
         span: Span,
     ) -> UBResult<()> {
         match self {
             LazyTree::Uninit { .. } => Ok(()),
-            LazyTree::Init(tree) => tree.perform_protector_end_access(tag, alloc_id, span),
+            LazyTree::Init(tree) => {
+                tree.perform_protector_end_access(global_ctx, tag, alloc_id, span)
+            }
         }
     }
     fn expose_tag(&mut self, tag: BorTag, protected: bool) {
@@ -1147,12 +1179,12 @@ impl AllocState for LazyTree {
             tree.expose_tag(tag, protected);
         }
     }
-    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
+    fn remove_dead_tags(&mut self, global_ctx: &GlobalCtx, dead_tags: &mut [BorTag]) -> bool {
         match self {
             LazyTree::Init(tree) => {
                 // Only *compaction* of dead interior nodes is skipped on small trees
-                let compact = tree.tag_mapping.len() > TREE_GC_MIN_NODES.load(Relaxed);
-                tree.remove_useless_children(dead_tags, compact);
+                let compact = tree.tag_mapping.len() > global_ctx.flags.tree_gc_min_nodes;
+                tree.remove_useless_children(global_ctx, dead_tags, compact);
                 tree.locations.merge_adjacent_thorough();
                 tree.roots.is_empty()
             }
@@ -1275,6 +1307,7 @@ impl AllocState for EagerTree {
     }
     fn perform_access(
         &mut self,
+        global_ctx: &GlobalCtx,
         tag: BorTag,
         access_range: AllocRange,
         access_kind: AccessKind,
@@ -1299,6 +1332,7 @@ impl AllocState for EagerTree {
                 transition_range: loc_range,
             };
             loc.perform_access(
+                global_ctx,
                 self.roots.iter().copied(),
                 &mut self.nodes,
                 source_idx,
@@ -1312,12 +1346,14 @@ impl AllocState for EagerTree {
     }
     fn dealloc(
         &mut self,
+        global_ctx: &GlobalCtx,
         tag: BorTag,
         access_range: AllocRange,
         alloc_id: AllocId,
         span: Span,
     ) -> UBResult<()> {
         self.perform_access(
+            global_ctx,
             tag,
             access_range,
             AccessKind::Write,
@@ -1381,6 +1417,7 @@ impl AllocState for EagerTree {
     }
     fn perform_protector_end_access(
         &mut self,
+        global_ctx: &GlobalCtx,
         tag: BorTag,
         alloc_id: AllocId,
         span: Span,
@@ -1411,6 +1448,7 @@ impl AllocState for EagerTree {
                     transition_range: loc_range,
                 };
                 loc.perform_access(
+                    global_ctx,
                     self.roots.iter().copied(),
                     &mut self.nodes,
                     Some(source_idx),
@@ -1459,10 +1497,10 @@ impl AllocState for EagerTree {
         }
     }
 
-    fn remove_dead_tags(&mut self, dead_tags: &mut [BorTag]) -> bool {
+    fn remove_dead_tags(&mut self, global_ctx: &GlobalCtx, dead_tags: &mut [BorTag]) -> bool {
         // Only *compaction* of dead interior nodes is skipped on small trees
-        let compact = self.tag_mapping.len() > TREE_GC_MIN_NODES.load(Relaxed);
-        self.remove_useless_children(dead_tags, compact);
+        let compact = self.tag_mapping.len() > global_ctx.flags.tree_gc_min_nodes;
+        self.remove_useless_children(global_ctx, dead_tags, compact);
         self.locations.merge_adjacent_thorough();
         self.roots.is_empty()
     }

--- a/bsan-rt/src/tree_borrows/tree/tests.rs
+++ b/bsan-rt/src/tree_borrows/tree/tests.rs
@@ -1,7 +1,6 @@
 // Ported from Miri (commit:ce9844e)
 //! Tests for the tree
 #![cfg(test)]
-
 use std::fmt;
 
 use super::super::exhaustive::{precondition, Exhaustive};
@@ -871,11 +870,12 @@ fn add_child_perm(tree: &mut EagerTree, parent: BorTag, child: BorTag, perm: Per
 
 #[test]
 fn dead_leaf_is_removed_and_zeroed() {
+    let ctx = GlobalCtx::new(&SharedSanitizerFlags::default());
     let mut tree = new_tree(t(10));
     add_child(&mut tree, t(10), t(11));
 
     let mut dead = [t(11)];
-    let empty = tree.remove_dead_tags(&mut dead);
+    let empty = tree.remove_dead_tags(&ctx, &mut dead);
 
     assert!(!empty, "the root is still in the tree");
     assert_eq!(dead, [BorTag::omnivalid()]);
@@ -885,6 +885,13 @@ fn dead_leaf_is_removed_and_zeroed() {
 
 #[test]
 fn dead_node_with_multiple_children_is_compacted() {
+    // Ensure that we can compact any size of tree
+    let flags = SharedSanitizerFlags {
+        max_compacted_children: usize::MAX,
+        tree_gc_min_nodes: 0,
+        ..Default::default()
+    };
+    let ctx = GlobalCtx::new(&flags);
     // A dead interior node whose children can all soundly replace it (here Frozen parent,
     // Frozen children) is compacted: its children are reparented onto the grandparent and the
     // node is pruned immediately, even though it has more than one child.
@@ -896,7 +903,7 @@ fn dead_node_with_multiple_children_is_compacted() {
     tree.increment(t(13));
 
     let mut dead = [t(11)];
-    let empty = tree.remove_dead_tags(&mut dead);
+    let empty = tree.remove_dead_tags(&ctx, &mut dead);
 
     assert!(!empty);
     // The dead node was removed; its slot is zeroed so the caller drops it.
@@ -910,6 +917,7 @@ fn dead_node_with_multiple_children_is_compacted() {
 
 #[test]
 fn dead_node_with_incompatible_children_is_retained() {
+    let ctx = GlobalCtx::new(&SharedSanitizerFlags::default());
     // When some child cannot replace the dead node (here Frozen parent, `ReservedFrz` children),
     // compaction is unsound, so the node is retained for a future pass.
     let mut tree = new_tree(t(10));
@@ -920,7 +928,7 @@ fn dead_node_with_incompatible_children_is_retained() {
     tree.increment(t(13));
 
     let mut dead = [t(11)];
-    let empty = tree.remove_dead_tags(&mut dead);
+    let empty = tree.remove_dead_tags(&ctx, &mut dead);
 
     assert!(!empty);
     // The dead node cannot be pruned yet. Its slot must stay nonzero so the caller keeps it
@@ -932,6 +940,7 @@ fn dead_node_with_incompatible_children_is_retained() {
 
 #[test]
 fn retained_tag_is_pruned_once_children_die() {
+    let ctx = GlobalCtx::new(&SharedSanitizerFlags::default());
     let mut tree = new_tree(t(10));
     add_child(&mut tree, t(10), t(11));
     // `ReservedFrz` children block compaction of the Frozen parent, so it is retained rather
@@ -943,7 +952,7 @@ fn retained_tag_is_pruned_once_children_die() {
 
     // First GC pass: the dead parent is blocked by its two live, non-replacing children.
     let mut dead = [t(11)];
-    assert!(!tree.remove_dead_tags(&mut dead));
+    assert!(!tree.remove_dead_tags(&ctx, &mut dead));
     assert_eq!(dead, [t(11)]);
 
     // The children die, re-entering a ZCT. The next pass removes them as leaves, and the
@@ -952,7 +961,7 @@ fn retained_tag_is_pruned_once_children_die() {
     tree.decrement(t(12));
     tree.decrement(t(13));
     let mut dead = [t(11), t(12), t(13)];
-    let empty = tree.remove_dead_tags(&mut dead);
+    let empty = tree.remove_dead_tags(&ctx, &mut dead);
 
     assert!(!empty, "the root is still in the tree");
     assert_eq!(dead, [BorTag::omnivalid(); 3]);
@@ -967,6 +976,8 @@ fn root_tags(tree: &EagerTree) -> Vec<BorTag> {
 
 #[test]
 fn dead_root_with_children_is_retained() {
+    let ctx = GlobalCtx::new(&SharedSanitizerFlags::default());
+
     // A dead root is never replaced by its child, since promoting the child into `roots`
     // could break its ascending-tag order. Here the main root's only child (tag 30) has a
     // larger tag than the wildcard subtree root (tag 20), so the pre-guard promotion would
@@ -978,7 +989,7 @@ fn dead_root_with_children_is_retained() {
     tree.increment(t(30));
 
     let mut dead = [t(10)];
-    let empty = tree.remove_dead_tags(&mut dead);
+    let empty = tree.remove_dead_tags(&ctx, &mut dead);
 
     assert!(!empty);
     // The root cannot be pruned while it has a child; it must stay pending.
@@ -989,6 +1000,7 @@ fn dead_root_with_children_is_retained() {
 
 #[test]
 fn dead_root_is_pruned_as_leaf_once_subtree_dies() {
+    let ctx: GlobalCtx = GlobalCtx::new(&SharedSanitizerFlags::default());
     let mut tree = new_tree(t(10));
     add_child(&mut tree, BorTag::wildcard(), t(20));
     add_child(&mut tree, t(10), t(30));
@@ -997,7 +1009,7 @@ fn dead_root_is_pruned_as_leaf_once_subtree_dies() {
 
     // First pass: the dead root is retained while its child is alive.
     let mut dead = [t(10)];
-    assert!(!tree.remove_dead_tags(&mut dead));
+    assert!(!tree.remove_dead_tags(&ctx, &mut dead));
     assert_eq!(dead, [t(10)]);
     assert_eq!(root_tags(&tree), [t(10), t(20)]);
 
@@ -1007,7 +1019,7 @@ fn dead_root_is_pruned_as_leaf_once_subtree_dies() {
     tree.decrement(t(20));
     tree.decrement(t(30));
     let mut dead = [t(10), t(20), t(30)];
-    let empty = tree.remove_dead_tags(&mut dead);
+    let empty = tree.remove_dead_tags(&ctx, &mut dead);
 
     assert!(empty, "every root was removed as a leaf");
     assert_eq!(dead, [BorTag::omnivalid(); 3]);

--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -53,17 +53,20 @@ MIRI_CONFIGS = [MIRI]
 
 # BorrowSanitizer configurations.
 BSAN_CONFIGS = [
-    # Full checking, skip parsing terminal info.
+    # Full checking.
     {
         "name": "full",
         "cmd": ["cargo", "bsan", "test", "--lib"],
-        "env": {"RUSTFLAGS": "--cfg=miri", "TERM": None},
-    },
-    # Full checking, parse terminal info.
-    {
-        "name": "full-terminfo",
-        "cmd": ["cargo", "bsan", "test", "--lib"],
         "env": {"RUSTFLAGS": "--cfg=miri"},
+    },
+    # Full, but with wildcard provenance disabled.
+    {
+        "name": "full-no-wildcard",
+        "cmd": ["cargo", "bsan", "test", "--lib"],
+        "env": {
+            "RUSTFLAGS": "--cfg=miri", 
+            "BSAN_OPTIONS": "wildcard=0"
+        },
     },
     # No-op checking. Instrumentation is inserted, but
     # all memory access checks, retags, and reference count
@@ -71,7 +74,7 @@ BSAN_CONFIGS = [
     {
         "name": "no-op",
         "cmd": ["cargo", "bsan", "test", "--nop", "--lib"],
-        "env": {"RUSTFLAGS": "--cfg=miri", "TERM": None},
+        "env": {"RUSTFLAGS": "--cfg=miri"},
     }
 ]
 
@@ -404,7 +407,6 @@ def process_config(
             raw_results.append(row_start + (config["name"], mean))
 
         baselines = {NATIVE["name"]: per_test_means.pop(NATIVE["name"])}
-
         # execute Miri and add each configuration as a baseline for comparison
         for miri_config in MIRI_CONFIGS:
             miri_mean = run_miri_test(src_dir, t, miri_config, scratch)

--- a/bsan-script/src/commands.rs
+++ b/bsan-script/src/commands.rs
@@ -96,7 +96,6 @@ impl Command {
         cmd!(env.sh, "rm -rf {cargo_test_path}").run()?;
         cmd!(env.sh, "python3 tests/test-cargo-bsan/run_test.py").run()?;
         Self::stats(env)?;
-
         Ok(())
     }
 
@@ -108,7 +107,6 @@ impl Command {
             Self::fmt(env, true)?;
             components.iter().try_for_each(|c| c.clippy(env, args))?;
             components.iter().try_for_each(|c| c.test(env, args))?;
-            //components.iter().try_for_each(|c| c.miri(env, args))?;
             Self::ui(env, false, false, allow_unsafe_deps)
         })
     }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -128,7 +128,13 @@ fn run_tests(
     config.program.envs.push(("BSAN_TEMP".into(), Some(tmpdir.to_owned().into())));
     // If a test ICEs, we want to see a backtrace.
     config.program.envs.push(("RUST_BACKTRACE".into(), Some("1".into())));
-    config.program.envs.push(("BSAN_OPTIONS".into(), Some("stacktrace_max_len=3".into())));
+
+    let default_options =
+        [("stacktrace_max_len", "3"), ("wildcard", "1"), ("node_debug_info", "1")]
+            .map(|(key, val)| format!("{key}={val}"))
+            .join(",");
+
+    config.program.envs.push(("BSAN_OPTIONS".into(), Some(default_options.into())));
     config
         .program
         .envs


### PR DESCRIPTION
This adds two new values to `BSAN_OPTIONS`.

* `node_debug_info=1` - When enabled, we will track the history of the state machine for every node. This is on by default.

* `wildcard=1` - When enabled, we will expose provenance values. This is on by default.

 It also makes it easier to add new options. After defining a new flag within `bsan_flags.inc`, you need to add it as a field within a struct:
 ```C++
 extern "C" struct SharedSanitizerFlags {
  ...
  bool wildcard;
};
```
This struct is shared across the FFI boundary, so this needs to happen twice: once on the Rust side, and once on the C++ side. Field declarations must be in the same order.

Finally, you'll add a line to `InitializeFlags` like so:
```C++
COPY_FLAG(wildcard);
```

In Rust, the `GlobalCtx` object has a copy of these shared flags.