### PR TITLE
Enable debug assertions

### DIFF
--- a/bsan-script/etc/bench.py
+++ b/bsan-script/etc/bench.py
@@ -27,7 +27,7 @@ WARMUP = 1
 NATIVE = {
     "name": "native",
     "cmd": ["cargo", "test", "--lib"],
-    "env": {"RUSTFLAGS": "--cfg=bsan --cfg=miri", "TERM": None},
+    "env": {"RUSTFLAGS": "--cfg=bsan --cfg=miri"},
 }
 
 # Flags shared by every Miri configuration. These disable most forms of
@@ -44,7 +44,6 @@ MIRI = {
     "name": "miri-tb",
     "env": {
         "MIRIFLAGS": f"-Zmiri-tree-borrows {MIRI_COMMON_FLAGS}",
-        "RUSTFLAGS": "-Cdebug-assertions=off",
     },
 }
 

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -296,8 +296,8 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
             // to set it twice.
             cmd.arg("--sysroot").arg(expect_env("BSAN_SYSROOT"));
         }
-        // During setup, patch the panic runtime for `libpanic_abort`
-        // (mirroring what bootstrap usually does).
+        // During setup, configure libtest as if we were Miri. It has Miri-specific
+        // configuration options.
         if phase == RustcPhase::Setup
             && get_arg_flag_value("--crate-name").as_deref() == Some("test")
         {

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -55,7 +55,7 @@ pub const BSAN_DEFAULT_RUSTFLAGS: &[&str] = &[
     "-Zinline-llvm=no",
     "-Cembed-bitcode=yes",
     "-Cdebuginfo=2",
-    "-Cdebug-assertions=off",
+    "-Zmir-enable-passes=-CheckAlignment",
 ];
 
 pub const BSAN_DEFAULT_CFLAGS: &[&str] =
@@ -298,6 +298,11 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
         }
         // During setup, patch the panic runtime for `libpanic_abort`
         // (mirroring what bootstrap usually does).
+        if phase == RustcPhase::Setup
+            && get_arg_flag_value("--crate-name").as_deref() == Some("test")
+        {
+            cmd.arg("-C").arg("cfg=abort");
+        }
         if phase == RustcPhase::Setup
             && get_arg_flag_value("--crate-name").as_deref() == Some("panic_abort")
         {

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -55,7 +55,7 @@ pub const BSAN_DEFAULT_RUSTFLAGS: &[&str] = &[
     "-Zinline-llvm=no",
     "-Cembed-bitcode=yes",
     "-Cdebuginfo=2",
-    "-Zmir-enable-passes=-CheckAlignment",
+    "-Zmir-enable-passes=-CheckAlignment,-CheckNull,-CheckEnums",
 ];
 
 pub const BSAN_DEFAULT_CFLAGS: &[&str] =
@@ -301,7 +301,7 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
         if phase == RustcPhase::Setup
             && get_arg_flag_value("--crate-name").as_deref() == Some("test")
         {
-            cmd.arg("-C").arg("cfg=abort");
+            cmd.arg("--cfg=miri");
         }
         if phase == RustcPhase::Setup
             && get_arg_flag_value("--crate-name").as_deref() == Some("panic_abort")

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -296,13 +296,6 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
             // to set it twice.
             cmd.arg("--sysroot").arg(expect_env("BSAN_SYSROOT"));
         }
-        // During setup, configure libtest as if we were Miri. It has Miri-specific
-        // configuration options.
-        if phase == RustcPhase::Setup
-            && get_arg_flag_value("--crate-name").as_deref() == Some("test")
-        {
-            cmd.arg("--cfg=miri");
-        }
         if phase == RustcPhase::Setup
             && get_arg_flag_value("--crate-name").as_deref() == Some("panic_abort")
         {

--- a/cargo-bsan/src/phases.rs
+++ b/cargo-bsan/src/phases.rs
@@ -93,15 +93,6 @@ pub fn phase_cargo_bsan(mut args: impl Iterator<Item = String>) {
         ),
     };
 
-    // This is sound in a single-threaded environment.
-    // Miri skips parting terminfo via a conditional
-    // compilation directive. We do not have equivalent
-    // upstream status, so instead, we unset this variable,
-    // which has the same effect.
-    unsafe {
-        env::remove_var("TERM");
-    }
-
     let env = EnvConfig::from_args();
 
     // Determine the involved architectures.
@@ -295,6 +286,13 @@ pub fn phase_rustc(args: impl Iterator<Item = String>, phase: RustcPhase) {
             // Rustdoc already receives the sysroot via its dedicated phase, so we do not want
             // to set it twice.
             cmd.arg("--sysroot").arg(expect_env("BSAN_SYSROOT"));
+        }
+        // During setup, configure libtest as if we were Miri. It has Miri-specific
+        // configuration options.
+        if phase == RustcPhase::Setup
+            && get_arg_flag_value("--crate-name").as_deref() == Some("test")
+        {
+            cmd.arg("--cfg=miri");
         }
         if phase == RustcPhase::Setup
             && get_arg_flag_value("--crate-name").as_deref() == Some("panic_abort")


### PR DESCRIPTION
By default, we should enable debug assertions, and only disable those that interfere with wildcard provenance. We can also disable parsing terminal info via passing `--cfg=miri` when parsing libtest, since all of the Miri directives in libtest relate to this at the moment.