### PR TITLE
Fixed potential double-free in quarantine.

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -77,33 +77,17 @@ void GlobalContext::SnapshotCallback(const SuspendedThreadsList &, void *arg) {
 }
 
 void GlobalContext::CollectGarbage(Snapshot &snap) {
-  InternalMmapVector<RetiredAlloc> filtered;
-  // Eject all retired allocation metadata objects
-  // that are confirmed to be unreachable as of the
-  // current minimum generation.
-  for (uptr i = 0; i < quarantine_.size(); ++i) {
-    RetiredAlloc retired = quarantine_[i];
-    if (retired.retire_gen <= snap.min_drained) {
-      __bsan_eject(retired.info);
-    } else {
-      // If we can't eject this object yet, then
-      // make sure it stays in quarantine.
-      filtered.push_back(retired);
-    }
-  }
-  quarantine_.swap(filtered);
 
-  // A pending set of unpruned tags
   ConcreteProvenanceSet still_pending;
   pending_.drain([&](AllocInfo *info, BorTagSet &tags) {
     // If `__bsan_prune` returns true, then the allocation's tree is empty;
     // every single tag was pruned.
     if (__bsan_prune(info, tags.data(), tags.size())) {
-      if (snap.min_drained == snap.gen) {
-        __bsan_eject(info);
-      } else {
-        quarantine_.push_back({info, snap.gen});
-      }
+      // Insert the allocation into the quarantine.
+      // It might already be present. If so, its generation is
+      // updated. It is crucial for this to be a hashmap. Otherwise,
+      // we will end up double-freeing allocation metadata.
+      quarantine_[info] = snap.gen;
     } else {
       // The Rust core zeroes out every tag that no longer needs tracking.
       // The remaining nonzero tags are dead nodes that could not be pruned
@@ -117,6 +101,17 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
     }
   });
   pending_.swap(still_pending);
+
+  DenseMap<AllocInfo *, uptr> quarantined;
+  quarantine_.forEach([&](const DenseMap<AllocInfo *, uptr>::value_type &KV) {
+    if (KV.second <= snap.min_drained) {
+      __bsan_eject(KV.first);
+    } else {
+      quarantined.try_emplace(KV.first, KV.second);
+    }
+    return true;
+  });
+  quarantine_.swap(quarantined);
 }
 
 void GlobalContext::RequestGC() {

--- a/bsan-rt/llvm-wrapper/bsan_global.h
+++ b/bsan-rt/llvm-wrapper/bsan_global.h
@@ -21,17 +21,6 @@ public:
   uptr min_drained;
 };
 
-// An allocation that is unreachable and
-// has had all of its nodes pruned, but that
-// cannot be ejected yet, because it might still
-// be stored within a thread's zero count table.
-struct RetiredAlloc {
-  // A non-null pointer to the allocation.
-  AllocInfo *info;
-  // The generation when it was retired.
-  uptr retire_gen;
-};
-
 // Global state associated with the runtime.
 struct GlobalContext {
 public:
@@ -93,8 +82,11 @@ private:
   // has restarted.
   void CollectGarbage(Snapshot &snap);
 
-  // A list of retired allocations that have yet to be ejected.
-  InternalMmapVectorNoCtor<RetiredAlloc> quarantine_{};
+  // Allocations that are unreachable and have had all of their nodes pruned,
+  // but that cannot be ejected yet, because they might still be stored within a
+  // thread's zero count table. Maps each allocation to the generation when it
+  // was retired.
+  DenseMap<AllocInfo *, uptr> quarantine_{};
 
   // Guards `at_exit_stack_`.
   Mutex at_exit_lock_;


### PR DESCRIPTION
When we try to collect an allocation metadata object, we might need to put it in "quarantine" if one or more threads are paused in the middle of a critical section. We store it in a list alongside the generational counter for the GC run when it was collected. Then, we wait to free the object until every thread has been visited since that generation.

We used a vector for the quarantine, which ignores the fact that the same allocation might be collected more than once if it is shared across multiple threads. For example, an allocation could be placed into some thread `t1`'s ZCT and quarantined at generation `g`. Then, another thread `t2` could send it into quarantine at generation `g + 1`. At some generation `g + n`, when both `t1` and `t2` have been visited, we will empty the quarantine, double-freeing the allocation. 

This PR fixes the problem by switching to a `DenseMap` representation. An allocation can only be quarantined once.