### PR TITLE
Build clang for MacOS

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,6 @@
 # Updates the current nightly version of Rust, creating a
 # pull request for manual validation. This will also build 
-# and distribute a compatible version of clang, as needed.
+# and distribute a compatible version of clang.
 name: nightly 
 on:
   workflow_dispatch:
@@ -32,6 +32,9 @@ jobs:
       # such that libLLVM is built differently, but it uses the same source,
       # then we want those changes, too.
       tag: ${{ steps.nightly.outputs.tag }}
+      # The list of targets that need to be built. If a target is missing
+      # from an existing release, then it will still be built.
+      matrix: ${{ steps.nightly.outputs.matrix }}
       should_build: ${{ steps.nightly.outputs.should_build }}
     steps:
       - name: Fetch nightly release info
@@ -46,8 +49,28 @@ jobs:
           llvm_sha=$(gh api "repos/rust-lang/rust/contents/src/llvm-project?ref=$rust_sha" --jq .sha)
           rust_version=$(gh api "repos/rust-lang/rust/contents/src/version?ref=$rust_sha" --jq .content | base64 -d | tr -d '[:space:]')
           tag="clang-${llvm_sha:0:7}-$rust_version"
+
+          # The set of supported targets.
+          targets='[
+            {"target": "x86_64-unknown-linux-gnu",  "os": "ubuntu-latest"},
+            {"target": "aarch64-unknown-linux-gnu", "os": "ubuntu-24.04-arm"},
+            {"target": "aarch64-apple-darwin",      "os": "macos-latest"}
+          ]'
+
+          # Obtain a newline separated list of every release asset. 
+          # If the release does not exist, then the list will be empty.
+          assets=$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" \
+            --json assets --jq '.assets[].name' 2>/dev/null || true)
+
+          # Select every element of the targets list where the given target does 
+          # not correspond to an existing release asset.
+          matrix=$(jq -c --arg tag "$tag" --arg assets "$assets" '
+            ($assets | split("\n")) as $have
+            | map(select(.target as $t | ($have | index("\($tag)-\($t).tar.xz")) | not))
+          ' <<<"$targets")
+
           should_build=false
-          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          if [ "$(jq length <<<"$matrix")" -gt 0 ]; then
             should_build=true
           fi
           {
@@ -56,6 +79,7 @@ jobs:
             echo "llvm_sha=$llvm_sha"
             echo "nightly_date=$nightly_date"
             echo "tag=$tag"
+            echo "matrix=$matrix"
             echo "should_build=$should_build"
             echo "rust_version=$rust_version"
           } >> "$GITHUB_OUTPUT"
@@ -67,13 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
-          - target: aarch64-apple-darwin
-            os: macos-latest
+        config: ${{ fromJSON(needs.init.outputs.matrix) }}
     runs-on: ${{ matrix.config.os }}
     defaults:
       run:
@@ -82,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
             sparse-checkout: bsan-script/etc/build-clang.sh
-            sparse-checkout-cone-mode: false  
+            sparse-checkout-cone-mode: false
       - name: Build
         run: |
           # We need a version of `clang` that matches nightly Rust toolchain
@@ -126,23 +144,36 @@ jobs:
             echo "No build artifacts found!"
             exit 1
           fi
+          tag="${{ needs.init.outputs.tag }}"
           llvm_sha="${{ needs.init.outputs.llvm_sha }}"
           llvm_link="[\`${llvm_sha:0:7}\`]($GITHUB_SERVER_URL/rust-lang/llvm-project/commit/$llvm_sha)"
-          gh release create "${{ needs.init.outputs.tag }}" \
-            --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "Clang (${llvm_sha:0:7})" \
-            --notes "A build of Clang that shares its LLVM version with nightly Rust ($llvm_link)." \
-            --prerelease \
-            "${files[@]}"
 
-
+          # if the release already exists, then all we need to do is upload the assets,
+          # which are already confirmed to be missing.
+          # otherwise, create a new release. 
+          if gh release view "$tag" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release upload "$tag" \
+              --repo "${{ github.repository }}" \
+              --clobber \
+              "${files[@]}"
+          else
+            gh release create "$tag" \
+              --repo "${{ github.repository }}" \
+              --target "${{ github.sha }}" \
+              --title "Clang (${llvm_sha:0:7})" \
+              --notes "A build of Clang that shares its LLVM version with nightly Rust ($llvm_link)." \
+              --prerelease \
+              "${files[@]}"
+          fi
   update:
     name: Open PR
     needs: [init, build, release]
     # Run this step if we did not need to build clang,
     # or if we did, and both the build and release
-    # steps succeeded
+    # steps succeeded. In this step, we check to see
+    # if the committed nightly version is different from
+    # the latest upstream nightly version, and skip creating
+    # a PR if nothing needs to be updated. 
     if: >-
       ${{ !cancelled()
         && ((needs.init.outputs.should_build == 'false')
@@ -162,6 +193,7 @@ jobs:
       - name: Open PR
         run: |
           set -euo pipefail
+          # if nothing changed, then exit without creating a PR.
           if git diff --quiet; then
             exit 0
           fi

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,21 +72,17 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            os: macos-latest
     runs-on: ${{ matrix.config.os }}
     defaults:
       run:
         shell: bash
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y cmake ninja-build lld
-          
       - uses: actions/checkout@v4
         with:
             sparse-checkout: bsan-script/etc/build-clang.sh
-            sparse-checkout-cone-mode: false
-            
+            sparse-checkout-cone-mode: false  
       - name: Build
         run: |
           # We need a version of `clang` that matches nightly Rust toolchain

--- a/bsan-script/etc/build-clang.sh
+++ b/bsan-script/etc/build-clang.sh
@@ -1,76 +1,85 @@
-#!/bin/bash
-# This script builds clang from source by reusing build artifacts
-# from `rust-dev`.
+#!/usr/bin/env bash
 set -euo pipefail
 
+# This script builds a version of clang that is compatible with a particular
+# nightly version of Rust, using the prebuilt LLVM artifacts provided by
+# Rust's CI pipeline (e.g. download-ci-llvm).
 if [[ $# -ne 4 ]]; then
-    echo "usage: $0 <llvm-sha> <rust-sha> <target> <output>"
+    echo "usage: $0 <llvm-sha> <rust-sha> <target> <output>" >&2
     exit 1
 fi
 
-check_dependencies() {
-    local missing=()
-    for cmd in "$@"; do
-        command -v "$cmd" &> /dev/null || missing+=("$cmd")
-    done
-    if [ ${#missing[@]} -gt 0 ]; then
-        echo "Missing dependencies: ${missing[*]}" >&2
-        return 1
-    fi
-    return 0
-}
-
-check_dependencies git cmake ninja lld curl || exit 1
-
 LLVM_SHA=$1
 RUSTC_SHA=$2
-# The target architecture that we are building for.
 TARGET=$3
-
-# We place an archive with the build output into the current directory.
 OUTPUT_DIR="$PWD"
-# we produce the file $OUTPUT.tar.xz
+
+# We produce an archive with the specified output name, 
+# followed by the toolchain's target.
 OUTPUT="$4-$TARGET"
 
-# Rust's LLVM fork.
-LLVM_ORIGIN="https://github.com/rust-lang/llvm-project.git"
-
-# The endpoint where CI artifacts are hosted for nightly builds.
-RUST_DEV_ENDPOINT="https://ci-artifacts.rust-lang.org/rustc-builds/$RUSTC_SHA"
-
-# Rust distributes a `rust-dev` archive that contains build artifacts which can
-# be reused to speed-up building the compiler from source (download-ci-llvm). The 
-# artifact contains a copy of libLLVM for the current nightly.
-RUST_DEV_ARTIFACT="rust-dev-nightly-$TARGET"
-RUST_DEV_URL="$RUST_DEV_ENDPOINT/$RUST_DEV_ARTIFACT.tar.xz"
-
-# Create a temporary directory where we build everything.
-TMP_DIR=$(mktemp -d)
+TMP_DIR="${TMP_DIR:-$(mktemp -d)}"
+mkdir -p "$TMP_DIR"
 cd "$TMP_DIR"
 
 git init -q
-git remote add origin $LLVM_ORIGIN
+git remote add origin https://github.com/rust-lang/llvm-project.git
 git sparse-checkout init --cone
 git sparse-checkout set cmake llvm clang third-party libc
 git fetch -q --depth=1 --filter=tree:0 origin "$LLVM_SHA"
 git checkout -q FETCH_HEAD
- 
-echo "Downloading rust-dev artifacts..."
+
+# The rust-dev component is what gets downloaded when you
+# build Rust from source using ./x.py under the default
+# bootstrap configuration. It contains a prebuilt libLLVM,
+# along with llvm tool binaries.
 curl --proto '=https' --tlsv1.2 -sSfL --retry 3 \
-    "$RUST_DEV_URL" -o rust-dev.tar.xz
+    "https://ci-artifacts.rust-lang.org/rustc-builds/$RUSTC_SHA/rust-dev-nightly-$TARGET.tar.xz" \
+    -o rust-dev.tar.xz
 tar -xf rust-dev.tar.xz --strip-components=1
 
-# Rust's libLLVM is labelled "libLLVM.so.<MAJOR>.<MINOR>-rust-<VERSION>-nightly"
-LIB_LLVM=$(find "$PWD"/rust-dev/lib/libLLVM.so.*-rust-* | head -1)
-LIB_LLVM_NAME=$(basename "$LIB_LLVM")
-LLVM_VERSION_SUFFIX="-${LIB_LLVM_NAME#*-}"
+LLVM_CONFIG="$TMP_DIR/rust-dev/bin/llvm-config"
+LLVM_VERSION=$("$LLVM_CONFIG" --version)
+LLVM_CMAKE_DIR=$("$LLVM_CONFIG" --cmakedir)
+LLVM_TBLGEN=$("$LLVM_CONFIG" --bindir)/llvm-tblgen
 
-# We reinitialize rust-dev as a build directory for LLVM,
-# keeping the same suffix that Rust uses.
-cmake -S llvm -B "rust-dev" -G Ninja \
+# Rust adds a custom suffix to libLLVM for linux toolchains,
+# indicating the Rust semver and channel of the toolchain.
+# For example: `libLLVM-23-rust-1.99.0-nightly`.
+# When we build clang, we need to point it toward a version
+# of libLLVM that has the same name, which we can obtain from `llvm-config`.
+# The version reported by `llvm-config` will be `23-rust-1.99.0-nightly`,
+# so we need to extract everything after the first dash. On Darwin, Rust does
+# not apply a suffix, but it's still reported by `llvm-config`, so we do not
+# need to skip the parsing here. 
+case "$LLVM_VERSION" in
+    *-*) LLVM_VERSION_SUFFIX="-${LLVM_VERSION#*-}" ;;
+    *)
+        echo "no rust suffix in llvm version: $LLVM_VERSION" >&2
+        exit 1
+        ;;
+esac
+
+# We will place the `clang` binaries within the toolchain's 
+# root `bin` directory, so we need to adjust their rpath to 
+# look for libLLVM in the adjacent `lib` directory.
+case "$TARGET" in
+    *-apple-darwin) RPATH='@loader_path/../lib' ;;
+    *)              RPATH='$ORIGIN/../lib' ;;
+esac
+
+# What we downloaded in `rust-dev` is a partial copy of 
+# LLVM's build artifacts. We need the generated headers and
+# CMake files, too. So, we point CMake at the unzipped directory
+# and build LLVM to produce only what we're missing. Note that we
+# still provide the suffix on Darwin, but we also set
+# `-DLLVM_VERSIONED_DYLIB_NAME_ON_DARWIN` to avoid applying it,
+# matching what Rust does.
+cmake -S llvm -B rust-dev -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
     -DLLVM_LINK_LLVM_DYLIB=ON \
     -DLLVM_VERSION_SUFFIX="$LLVM_VERSION_SUFFIX" \
+    -DLLVM_VERSIONED_DYLIB_NAME_ON_DARWIN=OFF \
     -DLLVM_TARGETS_TO_BUILD=host \
     -DLLVM_ENABLE_ASSERTIONS=OFF \
     -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF \
@@ -79,17 +88,20 @@ cmake -S llvm -B "rust-dev" -G Ninja \
     -DLLVM_INCLUDE_BENCHMARKS=OFF \
     -DLLVM_INCLUDE_EXAMPLES=OFF
 
-# Clang needs all of these generated headers, which are not shipped
-# with rust-dev by default. 
+# We also need tblgen-ed headers. This list is unavoidable at
+# the moment; If we set `-DLLVM_ENABLE_PROJECTS=clang`, this would
+# automatically build these dependencies, but it will also build
+# all of LLVM from source, which we want to avoid. 
 ninja -C rust-dev intrinsics_gen omp_gen acc_gen analysis_gen \
     target_parser_gen vt_gen
 
-# Build clang
 cmake -S clang -B clang-build -G Ninja \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_INSTALL_PREFIX="$PWD/dist/$OUTPUT" \
-    -DLLVM_DIR="$PWD/rust-dev/lib/cmake/llvm" \
-    -DLLVM_TABLEGEN_EXE="$PWD/rust-dev/bin/llvm-tblgen" \
+    -DCMAKE_INSTALL_PREFIX="$TMP_DIR/dist/$OUTPUT" \
+    -DCMAKE_INSTALL_RPATH="$RPATH" \
+    -DCMAKE_INSTALL_NAME_DIR="@rpath" \
+    -DLLVM_DIR="$LLVM_CMAKE_DIR" \
+    -DLLVM_TABLEGEN_EXE="$LLVM_TBLGEN" \
     -DLLVM_ENABLE_ASSERTIONS=OFF \
     -DLLVM_ENABLE_RTTI=OFF \
     -DLLVM_ENABLE_PLUGINS=ON \
@@ -97,8 +109,10 @@ cmake -S clang -B clang-build -G Ninja \
     -DLLVM_INCLUDE_TESTS=OFF \
     -DCLANG_INCLUDE_TESTS=OFF
 
-cmake --build clang-build --target clang clang-format libclang
 cmake --build clang-build --target install-clang install-clang-cpp \
     install-clang-format install-clang-resource-headers install-libclang
 
-tar -cJf "$OUTPUT_DIR/$OUTPUT.tar.xz" -C dist "$OUTPUT"
+# Setting `COPYFILE_DISABLE` prevents MacOS-specific attribute data 
+# from being included within the generated archive as files with 
+# the ._* extention
+COPYFILE_DISABLE=1 tar -cJf "$OUTPUT_DIR/$OUTPUT.tar.xz" -C dist "$OUTPUT"


### PR DESCRIPTION
This PR is the first step toward supporting MacOS. It adjusts our build scripts for nightly clang to support building for Mac, where shared libraries use the `.dylib` extension. 

* When building clang, we will now use `llvm-config` to resolve Rust's custom libLLVM suffix instead of attempting to parse it from the name of the libLLVM artifact.

* Our GitHub actions workflow will now build artifacts that are missing from the latest existing release, making it easier to add new targets. 

This PR was created with AI assistance, but edited, audited, and documented by me.