### PR TITLE
Use internal allocator for `BorTagSet` during GC passes.

### DIFF
--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -81,7 +81,6 @@ void GlobalContext::SnapshotCallback(const SuspendedThreadsList &, void *arg) {
 }
 
 void GlobalContext::CollectGarbage(Snapshot &snap) {
-
   ConcreteProvenanceSet still_pending;
   pending_.drain([&](AllocInfo *info, BorTagSet &tags) {
     // If `__bsan_prune` returns true, then the allocation's tree is empty;

--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -62,7 +62,11 @@ void GlobalContext::MergeZeroCounts(Snapshot *snap, ZeroCountTable &zct) {
 }
 
 void GlobalContext::SnapshotCallback(const SuspendedThreadsList &, void *arg) {
-  // The `arg` here is a pointer to a `SnapShot` object.
+  Snapshot *snap = static_cast<Snapshot *>(arg);
+  // We need access to the internal allocator so that we can add
+  // live provenance values to the set within the snapshot. Unlocking
+  // it here prevents us from unlocking it again once the closure returns.
+  snap->scope->UnlockInternalAllocator();
   ThreadManager &threads = global_ctx()->Threads();
   // For each thread, add all live provenance values to the snapshot.
   threads.ForEachThread(CollectProvenance, arg);
@@ -73,7 +77,7 @@ void GlobalContext::SnapshotCallback(const SuspendedThreadsList &, void *arg) {
   threads.ForEachThread(MergeZeroCountsCallback, arg);
   // We also need to visit the global ZCT, which contains garbage from threads
   // that have exited since the last collection run.
-  MergeZeroCounts(static_cast<Snapshot *>(arg), threads.global_zct);
+  MergeZeroCounts(snap, threads.global_zct);
 }
 
 void GlobalContext::CollectGarbage(Snapshot &snap) {
@@ -82,7 +86,7 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
   pending_.drain([&](AllocInfo *info, BorTagSet &tags) {
     // If `__bsan_prune` returns true, then the allocation's tree is empty;
     // every single tag was pruned.
-    if (__bsan_prune(info, tags.data(), tags.size())) {
+    if (__bsan_prune(info, tags.Data(), tags.Size())) {
       // Insert the allocation into the quarantine.
       // It might already be present. If so, its generation is
       // updated. It is crucial for this to be a hashmap. Otherwise,
@@ -92,8 +96,8 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
       // The Rust core zeroes out every tag that no longer needs tracking.
       // The remaining nonzero tags are dead nodes that could not be pruned
       // yet; collect them for a future GC pass.
-      const BorTag *retained = tags.data();
-      for (uptr i = 0; i < tags.size(); ++i) {
+      const BorTag *retained = tags.Data();
+      for (uptr i = 0; i < tags.Size(); ++i) {
         if (retained[i] != 0) {
           still_pending.insert({retained[i], info});
         }
@@ -129,6 +133,7 @@ void GlobalContext::RequestGC() {
       Snapshot state(&live, gen);
       {
         ScopedStopTheWorldLock stopped;
+        state.scope = &stopped;
         StopTheWorld(SnapshotCallback, &state);
       }
       CollectGarbage(state);

--- a/bsan-rt/llvm-wrapper/bsan_global.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_global.cpp
@@ -85,7 +85,7 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
   pending_.drain([&](AllocInfo *info, BorTagSet &tags) {
     // If `__bsan_prune` returns true, then the allocation's tree is empty;
     // every single tag was pruned.
-    if (__bsan_prune(info, tags.Data(), tags.Size())) {
+    if (__bsan_prune(info, tags.data(), tags.size())) {
       // Insert the allocation into the quarantine.
       // It might already be present. If so, its generation is
       // updated. It is crucial for this to be a hashmap. Otherwise,
@@ -95,8 +95,8 @@ void GlobalContext::CollectGarbage(Snapshot &snap) {
       // The Rust core zeroes out every tag that no longer needs tracking.
       // The remaining nonzero tags are dead nodes that could not be pruned
       // yet; collect them for a future GC pass.
-      const BorTag *retained = tags.Data();
-      for (uptr i = 0; i < tags.Size(); ++i) {
+      const BorTag *retained = tags.data();
+      for (uptr i = 0; i < tags.size(); ++i) {
         if (retained[i] != 0) {
           still_pending.insert({retained[i], info});
         }

--- a/bsan-rt/llvm-wrapper/bsan_global.h
+++ b/bsan-rt/llvm-wrapper/bsan_global.h
@@ -8,6 +8,8 @@
 
 namespace __bsan {
 
+struct ScopedStopTheWorldLock;
+
 struct Snapshot {
 public:
   Snapshot(ConcreteProvenanceSet *live, uptr gen)
@@ -19,6 +21,12 @@ public:
   uptr gen;
   // The minimum generation recorded by any live thread.
   uptr min_drained;
+  // The scope holding the lock for global state. We need
+  // access to this within the closure that executes when
+  // the world is stopped, so that we can selectively
+  // unlock the internal allocator. We only want to unlock
+  // this once, so we need to update the state of the scope.
+  ScopedStopTheWorldLock *scope = nullptr;
 };
 
 // Global state associated with the runtime.
@@ -110,14 +118,24 @@ struct ScopedStopTheWorldLock {
     InternalAllocatorLock();
   }
 
-  ~ScopedStopTheWorldLock() {
+  void UnlockInternalAllocator() {
     InternalAllocatorUnlock();
+    internal_is_locked_ = false;
+  }
+
+  ~ScopedStopTheWorldLock() {
+    if (internal_is_locked_) {
+      InternalAllocatorUnlock();
+    }
     UnlockAllocator();
     global_ctx()->Threads().UnlockThreads();
   }
 
   ScopedStopTheWorldLock &operator=(const ScopedStopTheWorldLock &) = delete;
   ScopedStopTheWorldLock(const ScopedStopTheWorldLock &) = delete;
+
+private:
+  bool internal_is_locked_ = true;
 };
 
 } // namespace __bsan

--- a/bsan-rt/llvm-wrapper/bsan_set.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_set.cpp
@@ -3,13 +3,13 @@
 
 namespace __bsan {
 
-uptr BorTagSet::lowerBound(BorTag Tag) const {
+uptr BorTagSet::LowerBound(BorTag Tag) const {
   // Binary search over the elements of the array
   uptr lo = 0;
-  uptr hi = tags_.size();
+  uptr hi = Size();
   while (lo < hi) {
     uptr mid = lo + (hi - lo) / 2;
-    if (tags_[mid] < Tag) {
+    if ((*this)[mid] < Tag) {
       lo = mid + 1;
     } else {
       hi = mid;
@@ -18,49 +18,64 @@ uptr BorTagSet::lowerBound(BorTag Tag) const {
   return lo;
 }
 
-bool BorTagSet::contains(BorTag tag) const {
-  uptr i = lowerBound(tag);
-  return i < tags_.size() && tags_[i] == tag;
+bool BorTagSet::Contains(BorTag tag) const {
+  uptr i = LowerBound(tag);
+  return i < Size() && (*this)[i] == tag;
 }
 
-void BorTagSet::insert(BorTag tag) {
-  uptr i = lowerBound(tag);
-  if (i < tags_.size() && tags_[i] == tag) {
-    return; // Already present.
+void BorTagSet::Insert(BorTag tag) {
+  uptr i = LowerBound(tag);
+
+  if (i < Size() && (*this)[i] == tag)
+    return;
+
+  EnsureCapacity(Size() + 1);
+
+  // Move up every tag after the index,
+  // leaving an empty slot for the new tag.
+  for (uptr j = Size() - 1; j > i; --j) {
+    (*this)[j] = (*this)[j - 1];
   }
-  tags_.push_back(tag);
-  for (uptr j = tags_.size() - 1; j > i; --j) {
-    tags_[j] = tags_[j - 1];
-  }
-  tags_[i] = tag;
+  (*this)[i] = tag;
 }
 
-void BorTagSet::erase(BorTag tag) {
-  uptr i = lowerBound(tag);
-  if (i >= tags_.size() || tags_[i] != tag) {
+void BorTagSet::Erase(BorTag tag) {
+  uptr i = LowerBound(tag);
+  if (i >= Size() || (*this)[i] != tag) {
     return;
   }
-  // Shift the tail down in place, then drop the last slot. Never shrinks the
-  // mapping, so this takes no allocator lock and is safe while the world is
-  // stopped.
-  for (uptr j = i; j + 1 < tags_.size(); ++j) {
-    tags_[j] = tags_[j + 1];
+  for (uptr j = i; j + 1 < Size(); ++j) {
+    (*this)[j] = (*this)[j + 1];
   }
-  tags_.pop_back();
+  end_--;
 }
 
-void BorTagSet::destroy() {
-  if (tags_.data()) {
-    tags_.Destroy();
-    // Reset to a valid empty state so the set is safe to reuse (e.g. if its
-    // map bucket is repopulated) and so a second Destroy is a no-op.
-    tags_.Initialize(0);
+void BorTagSet::EnsureCapacity(uptr req_size) {
+  uptr old_capacity = last_ - begin_;
+  uptr old_size = Size();
+  if (req_size > old_capacity) {
+    uptr capacity = old_capacity * 2;
+    if (capacity == 0)
+      capacity = 16;
+    if (capacity < req_size)
+      capacity = req_size;
+
+    BorTag *p = (BorTag *)InternalAlloc(capacity * sizeof(BorTag));
+
+    if (capacity) {
+      internal_memcpy(p, begin_, old_size * sizeof(BorTag));
+      InternalFree(begin_);
+    }
+
+    begin_ = p;
+    last_ = begin_ + capacity;
   }
+  end_ = begin_ + req_size;
 }
 
 void ConcreteProvenanceSet::insert(Provenance prov) {
   if (prov.info != nullptr) {
-    set_[prov.info].insert(prov.tag);
+    set_[prov.info].Insert(prov.tag);
   }
 }
 
@@ -72,27 +87,27 @@ void ConcreteProvenanceSet::remove(Provenance prov) {
   // shifts in place and never frees, so this takes no allocator lock and is
   // safe to run while the world is stopped.
   if (auto *tags = find(prov.info)) {
-    tags->erase(prov.tag);
+    tags->Erase(prov.tag);
   }
 }
 
 void ConcreteProvenanceSet::clear() {
   set_.forEach([](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
-    KV.second.clear();
+    KV.second.Clear();
     return true;
   });
 }
 
 bool ConcreteProvenanceSet::contains(Provenance prov) {
   if (auto *tags = find(prov.info)) {
-    return tags->contains(prov.tag);
+    return tags->Contains(prov.tag);
   }
   return false;
 }
 
 ConcreteProvenanceSet::~ConcreteProvenanceSet() {
   set_.forEach([](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
-    KV.second.destroy();
+    KV.second.Reset();
     return true;
   });
 }

--- a/bsan-rt/llvm-wrapper/bsan_set.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_set.cpp
@@ -6,7 +6,7 @@ namespace __bsan {
 uptr BorTagSet::LowerBound(BorTag Tag) const {
   // Binary search over the elements of the array
   uptr lo = 0;
-  uptr hi = Size();
+  uptr hi = size();
   while (lo < hi) {
     uptr mid = lo + (hi - lo) / 2;
     if ((*this)[mid] < Tag) {
@@ -18,33 +18,33 @@ uptr BorTagSet::LowerBound(BorTag Tag) const {
   return lo;
 }
 
-bool BorTagSet::Contains(BorTag tag) const {
+bool BorTagSet::contains(BorTag tag) const {
   uptr i = LowerBound(tag);
-  return i < Size() && (*this)[i] == tag;
+  return i < size() && (*this)[i] == tag;
 }
 
-void BorTagSet::Insert(BorTag tag) {
+void BorTagSet::insert(BorTag tag) {
   uptr i = LowerBound(tag);
 
-  if (i < Size() && (*this)[i] == tag)
+  if (i < size() && (*this)[i] == tag)
     return;
 
-  EnsureCapacity(Size() + 1);
+  EnsureCapacity(size() + 1);
 
   // Move up every tag after the index,
   // leaving an empty slot for the new tag.
-  for (uptr j = Size() - 1; j > i; --j) {
+  for (uptr j = size() - 1; j > i; --j) {
     (*this)[j] = (*this)[j - 1];
   }
   (*this)[i] = tag;
 }
 
-void BorTagSet::Erase(BorTag tag) {
+void BorTagSet::erase(BorTag tag) {
   uptr i = LowerBound(tag);
-  if (i >= Size() || (*this)[i] != tag) {
+  if (i >= size() || (*this)[i] != tag) {
     return;
   }
-  for (uptr j = i; j + 1 < Size(); ++j) {
+  for (uptr j = i; j + 1 < size(); ++j) {
     (*this)[j] = (*this)[j + 1];
   }
   end_--;
@@ -52,7 +52,7 @@ void BorTagSet::Erase(BorTag tag) {
 
 void BorTagSet::EnsureCapacity(uptr req_size) {
   uptr old_capacity = last_ - begin_;
-  uptr old_size = Size();
+  uptr old_size = size();
   if (req_size > old_capacity) {
     uptr capacity = old_capacity * 2;
     if (capacity == 0)
@@ -77,7 +77,7 @@ void BorTagSet::EnsureCapacity(uptr req_size) {
 
 void ConcreteProvenanceSet::insert(Provenance prov) {
   if (prov.info != nullptr) {
-    set_[prov.info].Insert(prov.tag);
+    set_[prov.info].insert(prov.tag);
   }
 }
 
@@ -85,31 +85,31 @@ void ConcreteProvenanceSet::remove(Provenance prov) {
   if (prov.info == nullptr) {
     return;
   }
-  // Only erase the tag; leave the (possibly now-empty) tag set in place. Erase
+  // Only erase the tag; leave the (possibly now-empty) tag set in place. erase
   // shifts in place and never frees, so this takes no allocator lock and is
   // safe to run while the world is stopped.
   if (auto *tags = find(prov.info)) {
-    tags->Erase(prov.tag);
+    tags->erase(prov.tag);
   }
 }
 
 void ConcreteProvenanceSet::clear() {
   set_.forEach([](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
-    KV.second.Clear();
+    KV.second.clear();
     return true;
   });
 }
 
 bool ConcreteProvenanceSet::contains(Provenance prov) {
   if (auto *tags = find(prov.info)) {
-    return tags->Contains(prov.tag);
+    return tags->contains(prov.tag);
   }
   return false;
 }
 
 ConcreteProvenanceSet::~ConcreteProvenanceSet() {
   set_.forEach([](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
-    KV.second.Reset();
+    KV.second.reset();
     return true;
   });
 }

--- a/bsan-rt/llvm-wrapper/bsan_set.cpp
+++ b/bsan-rt/llvm-wrapper/bsan_set.cpp
@@ -62,7 +62,9 @@ void BorTagSet::EnsureCapacity(uptr req_size) {
 
     BorTag *p = (BorTag *)InternalAlloc(capacity * sizeof(BorTag));
 
-    if (capacity) {
+    // We only need to free and copy over if the set
+    // already contains elements.
+    if (old_capacity && capacity) {
       internal_memcpy(p, begin_, old_size * sizeof(BorTag));
       InternalFree(begin_);
     }

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -8,14 +8,10 @@
 // `InternalMmapVector` underneath).
 
 #include "bsan.h"
-#include "sanitizer_common/sanitizer_array_ref.h"
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_dense_map.h"
-#include "sanitizer_common/sanitizer_vector.h"
 
-using __sanitizer::ArrayRef;
 using __sanitizer::DenseMap;
-using __sanitizer::InternalMmapVectorNoCtor;
 
 namespace __bsan {
 
@@ -27,46 +23,67 @@ namespace __bsan {
 // but it would make the API more cumbersome.
 class BorTagSet {
 public:
-  void insert(BorTag Tag);
-  void erase(BorTag Tag);
-  bool contains(BorTag Tag) const;
+  BorTagSet() : begin_(), end_(), last_() {}
+
+  const BorTag *Data() const { return begin_; }
+  // Mutable access to the underlying array.
+  BorTag *Data() { return begin_; }
+  uptr Size() const { return (end_ - begin_); }
+
+  void Insert(BorTag Tag);
+  void Erase(BorTag Tag);
+  bool Contains(BorTag Tag) const;
+
+  // Frees the underlying allocation.
+  void Reset() {
+    if (begin_)
+      InternalFree(begin_);
+    begin_ = 0;
+    end_ = 0;
+    last_ = 0;
+  }
 
   // Removes all elements of the list without freeing
   // the underlying allocation.
-  void clear() { tags_.clear(); }
+  void Clear() { end_ = begin_; }
 
-  // Removes all elements of the list and frees the
-  // underlying allocation. This is idempotent.
-  void destroy();
+  BorTag &operator[](uptr i) {
+    DCHECK_LT(i, end_ - begin_);
+    return begin_[i];
+  }
 
-  const BorTag *data() const { return tags_.data(); }
-  // Mutable access to the underlying array.
-  BorTag *data() { return tags_.data(); }
-  uptr size() const { return tags_.size(); }
+  const BorTag &operator[](uptr i) const {
+    DCHECK_LT(i, end_ - begin_);
+    return begin_[i];
+  }
 
   template <typename Fn> void forEach(Fn fn) const {
-    for (uptr i = 0; i < tags_.size(); ++i) {
-      fn(tags_[i]);
+    for (uptr i = 0; i < this->Size(); ++i) {
+      fn((*this)[i]);
     }
   }
 
   // Keep only the tags that satisfy the given predicate.
   template <typename Fn> void retainIf(Fn keep) {
     uptr w = 0;
-    for (uptr r = 0; r < tags_.size(); ++r) {
-      BorTag tag = tags_[r];
+    for (uptr r = 0; r < this->Size(); ++r) {
+      BorTag tag = (*this)[r];
       if (keep(tag)) {
-        tags_[w++] = tag;
+        (*this)[w++] = tag;
       }
     }
-    tags_.resize(w);
+    end_ = begin_ + w;
   }
 
 private:
+  BorTag *begin_;
+  BorTag *end_;
+  BorTag *last_;
+
   // Returns the index where this tag exists, or needs
   // to be inserted.
-  uptr lowerBound(BorTag Tag) const;
-  InternalMmapVectorNoCtor<BorTag> tags_{};
+  uptr LowerBound(BorTag Tag) const;
+  void EnsureCapacity(uptr size);
 };
 
 // A set of concrete provenance values (e.g. not wildcard, omnivalid, or null).
@@ -90,7 +107,7 @@ public:
   // given callback for each allocation.
   void takeFrom(ConcreteProvenanceSet &other) {
     other.drain([&](AllocInfo *info, BorTagSet &tags) {
-      tags.forEach([&](BorTag tag) { set_[info].insert(tag); });
+      tags.forEach([&](BorTag tag) { set_[info].Insert(tag); });
     });
   }
 
@@ -99,7 +116,7 @@ public:
   template <typename Fn> void drain(Fn visit) {
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       visit(KV.first, KV.second);
-      KV.second.destroy();
+      KV.second.Reset();
       return true;
     });
     set_.clear();
@@ -111,8 +128,8 @@ public:
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       AllocInfo *info = KV.first;
       KV.second.retainIf([&](BorTag tag) { return retain(info, tag); });
-      if (KV.second.size() == 0) {
-        KV.second.destroy();
+      if (KV.second.Size() == 0) {
+        KV.second.Reset();
         ToErase.push_back(info);
       }
       return true;

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -25,17 +25,17 @@ class BorTagSet {
 public:
   BorTagSet() : begin_(), end_(), last_() {}
 
-  const BorTag *Data() const { return begin_; }
+  const BorTag *data() const { return begin_; }
   // Mutable access to the underlying array.
-  BorTag *Data() { return begin_; }
-  uptr Size() const { return (end_ - begin_); }
+  BorTag *data() { return begin_; }
+  uptr size() const { return (end_ - begin_); }
 
-  void Insert(BorTag Tag);
-  void Erase(BorTag Tag);
-  bool Contains(BorTag Tag) const;
+  void insert(BorTag Tag);
+  void erase(BorTag Tag);
+  bool contains(BorTag Tag) const;
 
   // Frees the underlying allocation.
-  void Reset() {
+  void reset() {
     if (begin_)
       InternalFree(begin_);
     begin_ = 0;
@@ -45,7 +45,7 @@ public:
 
   // Removes all elements of the list without freeing
   // the underlying allocation.
-  void Clear() { end_ = begin_; }
+  void clear() { end_ = begin_; }
 
   BorTag &operator[](uptr i) {
     DCHECK_LT(i, end_ - begin_);
@@ -58,7 +58,7 @@ public:
   }
 
   template <typename Fn> void forEach(Fn fn) const {
-    for (uptr i = 0; i < this->Size(); ++i) {
+    for (uptr i = 0; i < this->size(); ++i) {
       fn((*this)[i]);
     }
   }
@@ -66,7 +66,7 @@ public:
   // Keep only the tags that satisfy the given predicate.
   template <typename Fn> void retainIf(Fn keep) {
     uptr w = 0;
-    for (uptr r = 0; r < this->Size(); ++r) {
+    for (uptr r = 0; r < this->size(); ++r) {
       BorTag tag = (*this)[r];
       if (keep(tag)) {
         (*this)[w++] = tag;
@@ -107,7 +107,7 @@ public:
   // given callback for each allocation.
   void takeFrom(ConcreteProvenanceSet &other) {
     other.drain([&](AllocInfo *info, BorTagSet &tags) {
-      tags.forEach([&](BorTag tag) { set_[info].Insert(tag); });
+      tags.forEach([&](BorTag tag) { set_[info].insert(tag); });
     });
   }
 
@@ -116,7 +116,7 @@ public:
   template <typename Fn> void drain(Fn visit) {
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       visit(KV.first, KV.second);
-      KV.second.Reset();
+      KV.second.reset();
       return true;
     });
     set_.clear();
@@ -128,8 +128,8 @@ public:
     set_.forEach([&](DenseMap<AllocInfo *, BorTagSet>::value_type &KV) {
       AllocInfo *info = KV.first;
       KV.second.retainIf([&](BorTag tag) { return retain(info, tag); });
-      if (KV.second.Size() == 0) {
-        KV.second.Reset();
+      if (KV.second.size() == 0) {
+        KV.second.reset();
         ToErase.push_back(info);
       }
       return true;

--- a/bsan-rt/llvm-wrapper/bsan_set.h
+++ b/bsan-rt/llvm-wrapper/bsan_set.h
@@ -1,12 +1,6 @@
 #ifndef BSAN_GC_H
 #define BSAN_GC_H
 
-// We use a variety of custom data structures
-// for BorrowSanitizer's garbage collector. Each
-// relies directly on `InternalMmapVector`, or
-// uses a proxy (e.g. `DenseMap`, which is an
-// `InternalMmapVector` underneath).
-
 #include "bsan.h"
 #include "sanitizer_common/sanitizer_common.h"
 #include "sanitizer_common/sanitizer_dense_map.h"


### PR DESCRIPTION
This PR reimplements `BorTagSet` as a minimal version of the pre-existing `Vector` in `sanitizer_common`, but with a copy constructor, so that it can be used in the range of a `DenseMap`. This is significantly faster than before, where `BorTagSet` was a wrapper around `InternalMmapVector`. Each set required an `mmap`/`munmap` pair, which is incredibly expensive, considering that most sets contain only one node (singleton trees). 